### PR TITLE
Jacoco 라이브러리 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
+.idea/
 
 # AWS User-specific
 .idea/**/aws.xml
@@ -217,3 +218,6 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,windows,intellij+all,java,gradle,git
+
+# Custom ignores
+DduDuStyle.xml

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.0'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'jacoco'
 }
 
 group = 'com.devcourse'
@@ -9,6 +10,10 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = '17'
+}
+
+jacoco {
+    toolVersion = '0.8.11'
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -51,4 +51,54 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    reports {
+        html.required = true
+        xml.required = true
+        csv.required = false
+
+        html.outputLocation = layout.buildDirectory.dir('jacocoReports/html')
+        xml.outputLocation = layout.buildDirectory.file('jacocoReports/jacoco.xml')
+    }
+
+    finalizedBy jacocoTestCoverageVerification
+}
+
+jacocoTestCoverageVerification {
+    classDirectories.setFrom(
+            files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: ["**/*Application*"])
+            })
+    )
+
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            excludes = ['com/ddudu/DduduApplication.java']
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.90
+            }
+
+            limit {
+                counter = 'LINE'
+                value = 'TOTALCOUNT'
+                maximum = 200
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,15 +22,24 @@ repositories {
 }
 
 dependencies {
+    // SpringBoot
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // MySql
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Flyway
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/com/ddudu/DduduApplication.java
+++ b/src/main/java/com/ddudu/DduduApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class DduduApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(DduduApplication.class, args);
-    }
+  public static void main(String[] args) {
+    SpringApplication.run(DduduApplication.class, args);
+  }
 
 }


### PR DESCRIPTION
## 관련 이슈
Resolves #3

## 구현 내용
- Jacoco 플러그인 추가
- Jacoco 관련 Gradle task 설정
   - jacocoTestReport (테스트 결과를 html, xml 리포트로 생성)
   - jacocoTestCoverageVerification (테스트 결과가 설정한 커버리지 기준을 만족하는지 확인)

### 커버리지 기준
1. 라인 커버리지를 최소한 80% 만족
2. 브랜치 커버리지를 최소한 90% 만족
3. 한 클래스 내에 실행 가능한 라인수를 최대 200라인으로 제한

## 코멘트
- 테스트 리포트는 build/jacocoReports 폴더 아래에서 확인할 수 있습니다.
- DduduApplication.class는 커버리지 검사에서 제외했습니다. (테스트 결과 리포트에서는 확인 가능)
- gitignore와 bulid.gradle 의존성 그룹화하는 부분은 따로 PR을 올릴껄 그랬네요..! 죄송합니다..
 