### PR TITLE
feat: api 요청 시 필요 없는 필터 무시

### DIFF
--- a/src/main/java/com/ddudu/config/WebSecurityConfig.java
+++ b/src/main/java/com/ddudu/config/WebSecurityConfig.java
@@ -1,0 +1,32 @@
+package com.ddudu.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+  @Bean
+  public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
+    return http
+        .securityMatchers(matcher -> matcher
+            .requestMatchers("/api/**"))
+        .sessionManagement(session -> session
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .requestCache(RequestCacheConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .rememberMe(AbstractHttpConfigurer::disable)
+        .logout(AbstractHttpConfigurer::disable)
+        .httpBasic(AbstractHttpConfigurer::disable)
+        .csrf(AbstractHttpConfigurer::disable)
+        .build();
+  }
+
+}


### PR DESCRIPTION
## 관련 이슈
Resolves #17 

## 구현 내용
* api가 Spring Security에 걸리지 않기 위해 필요없는 필터들을 무시했습니다!
  * `formLogin, rememberMe, logout, httpBasic, csrf`는 세션 기반 기능들이기 때문에 꺼놨습니다
  * `requestCache` 또한 http 요청을 캐싱할 일이 없다고 생각해 꺼놨는데, 나중에 필요한 일이 생긴다면 그 때 지우겠습니다!