### PR TITLE
jacoco 커버리지 기준 완화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,10 @@ jacocoTestCoverageVerification {
 private excludedClassFilesForReport(classDirectories) {
     classDirectories.setFrom(
             files(classDirectories.files.collect {
-                fileTree(dir: it, exclude: ["**/*Application*"])
+                fileTree(dir: it, exclude: [
+                        "**/*Application*",
+                        "**/*Config*"
+                ])
             })
     )
 }

--- a/build.gradle
+++ b/build.gradle
@@ -65,15 +65,13 @@ jacocoTestReport {
         xml.outputLocation = layout.buildDirectory.file('jacocoReports/jacoco.xml')
     }
 
+    excludedClassFilesForReport(classDirectories)
+
     finalizedBy jacocoTestCoverageVerification
 }
 
 jacocoTestCoverageVerification {
-    classDirectories.setFrom(
-            files(classDirectories.files.collect {
-                fileTree(dir: it, exclude: ["**/*Application*"])
-            })
-    )
+    excludedClassFilesForReport(classDirectories)
 
     violationRules {
         rule {
@@ -99,4 +97,12 @@ jacocoTestCoverageVerification {
             }
         }
     }
+}
+
+private excludedClassFilesForReport(classDirectories) {
+    classDirectories.setFrom(
+            files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: ["**/*Application*"])
+            })
+    )
 }

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
-                minimum = 0.80
+                minimum = 0.60
             }
 
             limit {

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
## 관련이슈
Resolves: #20 

## 구현내용
jacoco로 인해 개발이 늦어지는 것 같아, 임시로 커버리지 통과 기준을 낮추려 합니다!
- 라인 커버리지 기준 80% -> 60%로 변경
- 롬복에서 생성해주는 메서드(ex. getter) jacoco에서 제외
- \**/*Config\* 클래스 jacoco에서 제외
- 커버리지 검사에서 제외되는 클래스를 리포트에서도 제외