### PR TITLE
목표 생성 기능 구현

### DIFF
--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -50,7 +50,6 @@ public class GoalController {
   public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidEx(
       MethodArgumentNotValidException e
   ) {
-
     String errorMessage = e.getBindingResult()
         .getFieldErrors()
         .stream()

--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -2,6 +2,7 @@ package com.ddudu.goal.controller;
 
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
+import com.ddudu.goal.dto.response.ErrorResponse;
 import com.ddudu.goal.service.GoalService;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -35,9 +36,12 @@ public class GoalController {
         .body(response);
   }
 
-  @ExceptionHandler(Exception.class)
-  public void handleException(Exception ex) {
-    ex.printStackTrace();
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ErrorResponse> handleBadRequest(IllegalArgumentException e) {
+    ErrorResponse response = new ErrorResponse(e.getMessage());
+
+    return ResponseEntity.badRequest()
+        .body(response);
   }
 
 }

--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -1,0 +1,43 @@
+package com.ddudu.goal.controller;
+
+import com.ddudu.goal.dto.requset.CreateGoalRequest;
+import com.ddudu.goal.dto.response.CreateGoalResponse;
+import com.ddudu.goal.service.GoalService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/goals")
+@RequiredArgsConstructor
+@Slf4j
+public class GoalController {
+
+  private final GoalService goalService;
+
+  @PostMapping
+  public ResponseEntity<CreateGoalResponse> create(
+      @RequestBody
+      @Valid
+      CreateGoalRequest request
+  ) {
+    CreateGoalResponse response = goalService.create(request);
+    URI uri = URI.create("/api/goals/" + response.id());
+
+    return ResponseEntity.created(uri)
+        .body(response);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public void handleException(Exception ex) {
+    ex.printStackTrace();
+  }
+
+}

--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -8,7 +8,9 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,8 +39,26 @@ public class GoalController {
   }
 
   @ExceptionHandler(IllegalArgumentException.class)
-  public ResponseEntity<ErrorResponse> handleBadRequest(IllegalArgumentException e) {
+  public ResponseEntity<ErrorResponse> handleIllegalArgumentEx(IllegalArgumentException e) {
     ErrorResponse response = new ErrorResponse(e.getMessage());
+
+    return ResponseEntity.badRequest()
+        .body(response);
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidEx(
+      MethodArgumentNotValidException e
+  ) {
+
+    String errorMessage = e.getBindingResult()
+        .getFieldErrors()
+        .stream()
+        .map(DefaultMessageSourceResolvable::getDefaultMessage)
+        .toList()
+        .toString();
+
+    ErrorResponse response = new ErrorResponse(errorMessage);
 
     return ResponseEntity.badRequest()
         .body(response);

--- a/src/main/java/com/ddudu/goal/domain/Color.java
+++ b/src/main/java/com/ddudu/goal/domain/Color.java
@@ -16,7 +16,6 @@ public class Color {
   private static final int HEX_COLOR_CODE_LENGTH = 6;
   private static final Pattern HEX_COLOR_CODE_PATTERN = Pattern.compile(
       "^[0-9A-Fa-f]{" + HEX_COLOR_CODE_LENGTH + "}$");
-
   private static final String DEFAULT_COLOR_CODE = "191919";
 
   private String code;

--- a/src/main/java/com/ddudu/goal/domain/Color.java
+++ b/src/main/java/com/ddudu/goal/domain/Color.java
@@ -1,0 +1,43 @@
+package com.ddudu.goal.domain;
+
+import static io.micrometer.common.util.StringUtils.isBlank;
+
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Color {
+
+  private static final int HEX_COLOR_CODE_LENGTH = 6;
+  private static final Pattern HEX_COLOR_CODE_PATTERN = Pattern.compile(
+      "^[0-9A-Fa-f]{" + HEX_COLOR_CODE_LENGTH + "}$");
+
+  private static final String DEFAULT_COLOR_CODE = "191919";
+
+  private String code;
+
+  public Color(String code) {
+    validate(code);
+    this.code = isBlank(code) ? DEFAULT_COLOR_CODE : code;
+  }
+
+  private void validate(String code) {
+    if (isBlank(code)) {
+      return;
+    }
+
+    boolean matches = HEX_COLOR_CODE_PATTERN.matcher(code)
+        .matches();
+
+    if (!matches) {
+      throw new IllegalArgumentException("올바르지 않은 색상 코드입니다. 색상 코드는 "
+          + HEX_COLOR_CODE_LENGTH + "자리 16진수입니다.");
+    }
+  }
+
+}

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -20,8 +20,8 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "goal")
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Goal {
 
   private static final GoalStatus DEFAULT_STATUS = GoalStatus.IN_PROGRESS;

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -14,10 +14,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "goal")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Goal {
 

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -1,10 +1,11 @@
 package com.ddudu.goal.domain;
 
 import static io.micrometer.common.util.StringUtils.isBlank;
-import static io.micrometer.common.util.StringUtils.isNotBlank;
 import static java.util.Objects.isNull;
 
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -24,14 +25,10 @@ import lombok.NoArgsConstructor;
 public class Goal {
 
   private static final GoalStatus DEFAULT_STATUS = GoalStatus.IN_PROGRESS;
-  private static final String DEFAULT_COLOR = "191919";
   private static final PrivacyType DEFAULT_PRIVACY_TYPE = PrivacyType.PRIVATE;
   private static final Boolean DEFAULT_IS_DELETED = false;
 
   private static final int MAX_NAME_LENGTH = 50;
-
-  private static final int HEX_COLOR_CODE_LENGTH = 6;
-  private static final String HEX_COLOR_PATTERN = "^[0-9A-Fa-f]{" + HEX_COLOR_CODE_LENGTH + "}$";
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,8 +42,12 @@ public class Goal {
   @Enumerated(EnumType.STRING)
   private GoalStatus status = DEFAULT_STATUS;
 
-  @Column(name = "color", nullable = false, columnDefinition = "CHAR", length = 6)
-  private String color;
+  @Embedded
+  @AttributeOverride(
+      name = "code",
+      column = @Column(name = "color", nullable = false, columnDefinition = "CHAR", length = 6)
+  )
+  private Color color;
 
   @Column(name = "privacy", nullable = false, columnDefinition = "VARCHAR", length = 20)
   @Enumerated(EnumType.STRING)
@@ -58,11 +59,14 @@ public class Goal {
   @Builder
   public Goal(String name, String color, PrivacyType privacyType) {
     validateName(name);
-    validateColor(color);
 
     this.name = name;
-    this.color = isBlank(color) ? DEFAULT_COLOR : color;
+    this.color = new Color(color);
     this.privacyType = isNull(privacyType) ? DEFAULT_PRIVACY_TYPE : privacyType;
+  }
+
+  public String getColor() {
+    return color.getCode();
   }
 
   private void validateName(String name) {
@@ -72,13 +76,6 @@ public class Goal {
 
     if (name.length() > MAX_NAME_LENGTH) {
       throw new IllegalArgumentException("목표명은 최대 " + MAX_NAME_LENGTH + "자 입니다.");
-    }
-  }
-
-  private void validateColor(String color) {
-    if (isNotBlank(color) && !color.matches(HEX_COLOR_PATTERN)) {
-      throw new IllegalArgumentException("올바르지 않은 색상 코드입니다. 색상 코드는 "
-          + HEX_COLOR_CODE_LENGTH + "자리 16진수입니다.");
     }
   }
 

--- a/src/main/java/com/ddudu/goal/dto/requset/CreateGoalRequest.java
+++ b/src/main/java/com/ddudu/goal/dto/requset/CreateGoalRequest.java
@@ -3,9 +3,7 @@ package com.ddudu.goal.dto.requset;
 import com.ddudu.goal.domain.PrivacyType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
 
-@Builder
 public record CreateGoalRequest(
     @NotBlank(message = "목표가 입력되지 않았습니다.")
     @Size(max = 50, message = "목표는 최대 50자 입니다.")

--- a/src/main/java/com/ddudu/goal/dto/requset/CreateGoalRequest.java
+++ b/src/main/java/com/ddudu/goal/dto/requset/CreateGoalRequest.java
@@ -1,0 +1,18 @@
+package com.ddudu.goal.dto.requset;
+
+import com.ddudu.goal.domain.PrivacyType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+public record CreateGoalRequest(
+    @NotBlank(message = "목표가 입력되지 않았습니다.")
+    @Size(max = 50, message = "목표는 최대 50자 입니다.")
+    String name,
+    @Size(max = 6, message = "색상 코드는 6자리 16진수입니다.")
+    String color,
+    PrivacyType privacyType
+) {
+
+}

--- a/src/main/java/com/ddudu/goal/dto/response/CreateGoalResponse.java
+++ b/src/main/java/com/ddudu/goal/dto/response/CreateGoalResponse.java
@@ -1,7 +1,9 @@
 package com.ddudu.goal.dto.response;
 
 import com.ddudu.goal.domain.Goal;
+import lombok.Builder;
 
+@Builder
 public record CreateGoalResponse(
     Long id,
     String name,
@@ -9,7 +11,11 @@ public record CreateGoalResponse(
 ) {
 
   public static CreateGoalResponse from(Goal goal) {
-    return new CreateGoalResponse(goal.getId(), goal.getName(), goal.getColor());
+    return CreateGoalResponse.builder()
+        .id(goal.getId())
+        .name(goal.getName())
+        .color(goal.getColor())
+        .build();
   }
 
 }

--- a/src/main/java/com/ddudu/goal/dto/response/CreateGoalResponse.java
+++ b/src/main/java/com/ddudu/goal/dto/response/CreateGoalResponse.java
@@ -1,0 +1,15 @@
+package com.ddudu.goal.dto.response;
+
+import com.ddudu.goal.domain.Goal;
+
+public record CreateGoalResponse(
+    Long id,
+    String name,
+    String color
+) {
+
+  public static CreateGoalResponse from(Goal goal) {
+    return new CreateGoalResponse(goal.getId(), goal.getName(), goal.getColor());
+  }
+
+}

--- a/src/main/java/com/ddudu/goal/dto/response/ErrorResponse.java
+++ b/src/main/java/com/ddudu/goal/dto/response/ErrorResponse.java
@@ -1,0 +1,7 @@
+package com.ddudu.goal.dto.response;
+
+public record ErrorResponse(
+    String message
+) {
+
+}

--- a/src/main/java/com/ddudu/goal/repository/GoalRepository.java
+++ b/src/main/java/com/ddudu/goal/repository/GoalRepository.java
@@ -2,9 +2,7 @@ package com.ddudu.goal.repository;
 
 import com.ddudu.goal.domain.Goal;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface GoalRepository extends JpaRepository<Goal, Long> {
 
 }

--- a/src/main/java/com/ddudu/goal/repository/GoalRepository.java
+++ b/src/main/java/com/ddudu/goal/repository/GoalRepository.java
@@ -1,0 +1,10 @@
+package com.ddudu.goal.repository;
+
+import com.ddudu.goal.domain.Goal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GoalRepository extends JpaRepository<Goal, Long> {
+
+}

--- a/src/main/java/com/ddudu/goal/service/GoalService.java
+++ b/src/main/java/com/ddudu/goal/service/GoalService.java
@@ -1,7 +1,9 @@
 package com.ddudu.goal.service;
 
+import com.ddudu.goal.domain.Goal;
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
+import com.ddudu.goal.repository.GoalRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,11 +16,17 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class GoalService {
 
+  private final GoalRepository goalRepository;
+
   @Transactional
   public CreateGoalResponse create(@Valid CreateGoalRequest request) {
-    // TODO: 목표 생성 및 응답 값 반환
+    Goal goal = Goal.builder()
+        .name(request.name())
+        .color(request.color())
+        .privacyType(request.privacyType())
+        .build();
 
-    return null;
+    return CreateGoalResponse.from(goalRepository.save(goal));
   }
 
 }

--- a/src/main/java/com/ddudu/goal/service/GoalService.java
+++ b/src/main/java/com/ddudu/goal/service/GoalService.java
@@ -1,0 +1,24 @@
+package com.ddudu.goal.service;
+
+import com.ddudu.goal.dto.requset.CreateGoalRequest;
+import com.ddudu.goal.dto.response.CreateGoalResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Validated
+public class GoalService {
+
+  @Transactional
+  public CreateGoalResponse create(@Valid CreateGoalRequest request) {
+    // TODO: 목표 생성 및 응답 값 반환
+
+    return null;
+  }
+
+}

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -158,7 +158,6 @@ class GoalControllerTest {
       return List.of(longString);
     }
 
-
   }
 
 }

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -119,7 +119,7 @@ class GoalControllerTest {
     }
 
     @ParameterizedTest(name = "6자를 초과하는 색상 : {0}")
-    @MethodSource("provideLongString")
+    @ValueSource(strings = {"7letter"})
     void 색상은_6자를_넘을_수_없다(String longColor) throws Exception {
       // given
       CreateGoalRequest request = new CreateGoalRequest(validName, longColor, PrivacyType.PUBLIC);

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -1,0 +1,68 @@
+package com.ddudu.goal.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ddudu.config.WebSecurityConfig;
+import com.ddudu.goal.dto.requset.CreateGoalRequest;
+import com.ddudu.goal.dto.response.CreateGoalResponse;
+import com.ddudu.goal.service.GoalService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = GoalController.class)
+@Import(WebSecurityConfig.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class GoalControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private GoalService goalService;
+
+  @Nested
+  class 목표_생성_API_테스트 {
+
+    @Test
+    void 목표를_생성할_수_있다() throws Exception {
+      // given
+      CreateGoalRequest request = CreateGoalRequest.builder()
+          .name("dev course")
+          .color(null)
+          .privacyType(null)
+          .build();
+
+      CreateGoalResponse response = new CreateGoalResponse(1L, "dev course", "191919");
+
+      given(goalService.create(any(CreateGoalRequest.class)))
+          .willReturn(response);
+
+      // when then
+      mockMvc.perform(
+              post("/api/goals")
+                  .content(objectMapper.writeValueAsString(request))
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.id").value("1"));
+    }
+
+  }
+
+}

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -80,7 +80,7 @@ class GoalControllerTest {
 
     @ParameterizedTest(name = "유효하지 않은 목표 : {0}")
     @NullAndEmptySource
-    void 목표가_입력되지_않거나_빈_문자열일_수_없다(String invalidName) throws Exception {
+    void 목표가_null_이거나_빈_문자열인_경우_Bad_Request_응답을_반환한다(String invalidName) throws Exception {
       // given
       CreateGoalRequest request = new CreateGoalRequest(
           invalidName, validColor, PrivacyType.PUBLIC);
@@ -102,7 +102,7 @@ class GoalControllerTest {
 
     @ParameterizedTest(name = "50자를 초과하는 목표 : {0}")
     @MethodSource("provide51Letters")
-    void 목표는_50자를_넘을_수_없다(String longName) throws Exception {
+    void 목표가_50자를_초과하면_Bad_Request_응답을_반환한다(String longName) throws Exception {
       // given
       CreateGoalRequest request = new CreateGoalRequest(longName, validColor, PrivacyType.PUBLIC);
 
@@ -123,7 +123,7 @@ class GoalControllerTest {
 
     @ParameterizedTest(name = "6자를 초과하는 색상 : {0}")
     @ValueSource(strings = {"7letter"})
-    void 색상은_6자를_넘을_수_없다(String longColor) throws Exception {
+    void 색상이_6자를_넘으면_Bad_Request_응답을_반환한다(String longColor) throws Exception {
       // given
       CreateGoalRequest request = new CreateGoalRequest(validName, longColor, PrivacyType.PUBLIC);
 

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -1,20 +1,27 @@
 package com.ddudu.goal.controller;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.ddudu.config.WebSecurityConfig;
+import com.ddudu.goal.domain.PrivacyType;
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
 import com.ddudu.goal.service.GoalService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -39,16 +46,24 @@ class GoalControllerTest {
   @Nested
   class 목표_생성_API_테스트 {
 
+    private String validName;
+    private String validColor;
+
+    목표_생성_API_테스트() {
+      validName = "dev course";
+      validColor = "F7A29D";
+    }
+
     @Test
-    void 목표를_생성할_수_있다() throws Exception {
+    void 목표_색상_보기_설정과_함께_목표를_생성할_수_있다() throws Exception {
       // given
       CreateGoalRequest request = CreateGoalRequest.builder()
-          .name("dev course")
-          .color(null)
-          .privacyType(null)
+          .name(validName)
+          .color(validColor)
+          .privacyType(PrivacyType.PUBLIC)
           .build();
 
-      CreateGoalResponse response = new CreateGoalResponse(1L, "dev course", "191919");
+      CreateGoalResponse response = new CreateGoalResponse(1L, validName, validColor);
 
       given(goalService.create(any(CreateGoalRequest.class)))
           .willReturn(response);
@@ -60,8 +75,89 @@ class GoalControllerTest {
                   .contentType(MediaType.APPLICATION_JSON)
           )
           .andExpect(status().isCreated())
-          .andExpect(jsonPath("$.id").value("1"));
+          .andExpect(header().exists("location"))
+          .andExpect(jsonPath("$.id").value(response.id()))
+          .andExpect(jsonPath("$.name").value(response.name()))
+          .andExpect(jsonPath("$.color").value(response.color()));
     }
+
+    @ParameterizedTest(name = "유효하지 않은 목표 : {0}")
+    @NullAndEmptySource
+    void 목표가_입력되지_않거나_빈_문자열일_수_없다(String invalidName) throws Exception {
+      // given
+      CreateGoalRequest request = CreateGoalRequest.builder()
+          .name(invalidName)
+          .color(validColor)
+          .privacyType(PrivacyType.PUBLIC)
+          .build();
+
+      given(goalService.create(any(CreateGoalRequest.class)))
+          .willReturn(new CreateGoalResponse(1L, validName, validColor));
+
+      // when then
+      mockMvc.perform(
+              post("/api/goals")
+                  .content(objectMapper.writeValueAsString(request))
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message")
+              .value(containsString("목표가 입력되지 않았습니다.")));
+    }
+
+    @ParameterizedTest(name = "50자를 초과하는 목표 : {0}")
+    @MethodSource("provideLongString")
+    void 목표는_50자를_넘을_수_없다(String longName) throws Exception {
+      // given
+      CreateGoalRequest request = CreateGoalRequest.builder()
+          .name(longName)
+          .color(validColor)
+          .privacyType(PrivacyType.PUBLIC)
+          .build();
+
+      given(goalService.create(any(CreateGoalRequest.class)))
+          .willReturn(new CreateGoalResponse(1L, validName, validColor));
+
+      // when then
+      mockMvc.perform(
+              post("/api/goals")
+                  .content(objectMapper.writeValueAsString(request))
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message")
+              .value(containsString("목표는 최대 50자 입니다.")));
+    }
+
+    @ParameterizedTest(name = "6자를 초과하는 색상 : {0}")
+    @MethodSource("provideLongString")
+    void 색상은_6자를_넘을_수_없다(String longColor) throws Exception {
+      // given
+      CreateGoalRequest request = CreateGoalRequest.builder()
+          .color(longColor)
+          .name(validName)
+          .privacyType(PrivacyType.PUBLIC)
+          .build();
+
+      given(goalService.create(any(CreateGoalRequest.class)))
+          .willReturn(new CreateGoalResponse(1L, validName, validColor));
+
+      // when then
+      mockMvc.perform(
+              post("/api/goals")
+                  .content(objectMapper.writeValueAsString(request))
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message")
+              .value(containsString("색상 코드는 6자리 16진수입니다.")));
+    }
+
+    private static List<String> provideLongString() {
+      String longString = "a".repeat(100);
+      return List.of(longString);
+    }
+
 
   }
 

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -101,7 +101,7 @@ class GoalControllerTest {
     }
 
     @ParameterizedTest(name = "50자를 초과하는 목표 : {0}")
-    @MethodSource("provideLongString")
+    @MethodSource("provide51Letters")
     void 목표는_50자를_넘을_수_없다(String longName) throws Exception {
       // given
       CreateGoalRequest request = new CreateGoalRequest(longName, validColor, PrivacyType.PUBLIC);
@@ -142,8 +142,8 @@ class GoalControllerTest {
               .value(containsString("색상 코드는 6자리 16진수입니다.")));
     }
 
-    private static List<String> provideLongString() {
-      String longString = "a".repeat(100);
+    private static List<String> provide51Letters() {
+      String longString = "a".repeat(51);
       return List.of(longString);
     }
 

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -85,7 +86,8 @@ class GoalControllerTest {
           invalidName, validColor, PrivacyType.PUBLIC);
 
       given(goalService.create(any(CreateGoalRequest.class)))
-          .willReturn(new CreateGoalResponse(1L, validName, validColor));
+          .willReturn(CreateGoalResponse.builder()
+              .build());
 
       // when then
       mockMvc.perform(
@@ -105,7 +107,8 @@ class GoalControllerTest {
       CreateGoalRequest request = new CreateGoalRequest(longName, validColor, PrivacyType.PUBLIC);
 
       given(goalService.create(any(CreateGoalRequest.class)))
-          .willReturn(new CreateGoalResponse(1L, validName, validColor));
+          .willReturn(CreateGoalResponse.builder()
+              .build());
 
       // when then
       mockMvc.perform(
@@ -125,7 +128,8 @@ class GoalControllerTest {
       CreateGoalRequest request = new CreateGoalRequest(validName, longColor, PrivacyType.PUBLIC);
 
       given(goalService.create(any(CreateGoalRequest.class)))
-          .willReturn(new CreateGoalResponse(1L, validName, validColor));
+          .willReturn(CreateGoalResponse.builder()
+              .build());
 
       // when then
       mockMvc.perform(

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -56,7 +56,7 @@ class GoalControllerTest {
     }
 
     @Test
-    void 목표_색상_보기_설정과_함께_목표를_생성할_수_있다() throws Exception {
+    void 목표를_생성할_수_있다() throws Exception {
       // given
       CreateGoalRequest request = new CreateGoalRequest(validName, validColor, PrivacyType.PUBLIC);
 
@@ -140,6 +140,27 @@ class GoalControllerTest {
           .andExpect(status().isBadRequest())
           .andExpect(jsonPath("$.message")
               .value(containsString("색상 코드는 6자리 16진수입니다.")));
+    }
+
+    @Test
+    void 색상이_16진수_포맷이_아닌_경우_Bad_Rquest_응답을_반환한다() throws Exception {
+      // given
+      String invalidColor = "Z123!";
+      CreateGoalRequest request = new CreateGoalRequest(
+          validName, invalidColor, PrivacyType.PUBLIC);
+
+      given(goalService.create(any(CreateGoalRequest.class)))
+          .willThrow(new IllegalArgumentException("올바르지 않은 색상 코드입니다. 색상 코드는 6자리 16진수입니다."));
+
+      // when then
+      mockMvc.perform(
+              post("/api/goals")
+                  .content(objectMapper.writeValueAsString(request))
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message")
+              .value(containsString("올바르지 않은 색상 코드입니다. 색상 코드는 6자리 16진수입니다.")));
     }
 
     private static List<String> provide51Letters() {

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -57,11 +57,7 @@ class GoalControllerTest {
     @Test
     void 목표_색상_보기_설정과_함께_목표를_생성할_수_있다() throws Exception {
       // given
-      CreateGoalRequest request = CreateGoalRequest.builder()
-          .name(validName)
-          .color(validColor)
-          .privacyType(PrivacyType.PUBLIC)
-          .build();
+      CreateGoalRequest request = new CreateGoalRequest(validName, validColor, PrivacyType.PUBLIC);
 
       CreateGoalResponse response = new CreateGoalResponse(1L, validName, validColor);
 
@@ -85,11 +81,8 @@ class GoalControllerTest {
     @NullAndEmptySource
     void 목표가_입력되지_않거나_빈_문자열일_수_없다(String invalidName) throws Exception {
       // given
-      CreateGoalRequest request = CreateGoalRequest.builder()
-          .name(invalidName)
-          .color(validColor)
-          .privacyType(PrivacyType.PUBLIC)
-          .build();
+      CreateGoalRequest request = new CreateGoalRequest(
+          invalidName, validColor, PrivacyType.PUBLIC);
 
       given(goalService.create(any(CreateGoalRequest.class)))
           .willReturn(new CreateGoalResponse(1L, validName, validColor));
@@ -109,11 +102,7 @@ class GoalControllerTest {
     @MethodSource("provideLongString")
     void 목표는_50자를_넘을_수_없다(String longName) throws Exception {
       // given
-      CreateGoalRequest request = CreateGoalRequest.builder()
-          .name(longName)
-          .color(validColor)
-          .privacyType(PrivacyType.PUBLIC)
-          .build();
+      CreateGoalRequest request = new CreateGoalRequest(longName, validColor, PrivacyType.PUBLIC);
 
       given(goalService.create(any(CreateGoalRequest.class)))
           .willReturn(new CreateGoalResponse(1L, validName, validColor));
@@ -133,11 +122,7 @@ class GoalControllerTest {
     @MethodSource("provideLongString")
     void 색상은_6자를_넘을_수_없다(String longColor) throws Exception {
       // given
-      CreateGoalRequest request = CreateGoalRequest.builder()
-          .color(longColor)
-          .name(validName)
-          .privacyType(PrivacyType.PUBLIC)
-          .build();
+      CreateGoalRequest request = new CreateGoalRequest(validName, longColor, PrivacyType.PUBLIC);
 
       given(goalService.create(any(CreateGoalRequest.class)))
           .willReturn(new CreateGoalResponse(1L, validName, validColor));

--- a/src/test/java/com/ddudu/goal/domain/GoalTest.java
+++ b/src/test/java/com/ddudu/goal/domain/GoalTest.java
@@ -67,7 +67,7 @@ class GoalTest {
     }
 
     @ParameterizedTest(name = "{index}. {0}은 50자를 초과한다.")
-    @MethodSource("provideLongString")
+    @MethodSource("provide51Letters")
     void 목표명은_50자를_초과할_수_없다(String longName) {
       // when then
       assertThatThrownBy(() -> Goal.builder()
@@ -108,8 +108,8 @@ class GoalTest {
 
     }
 
-    private static List<String> provideLongString() {
-      String longString = "a".repeat(100);
+    private static List<String> provide51Letters() {
+      String longString = "a".repeat(51);
       return List.of(longString);
     }
 

--- a/src/test/java/com/ddudu/goal/domain/GoalTest.java
+++ b/src/test/java/com/ddudu/goal/domain/GoalTest.java
@@ -4,7 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -12,15 +13,14 @@ import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 class GoalTest {
 
   @Nested
-  @DisplayName("목표 생성 테스트")
-  class ConstructorTest {
+  class 목표_생성_테스트 {
 
     @Test
-    @DisplayName("목표를 생성할 수 있다.")
-    void create() {
+    void 목표를_생성할_수_있다() {
       // given
       String name = "dev course";
 
@@ -36,8 +36,7 @@ class GoalTest {
     }
 
     @Test
-    @DisplayName("색상 코드, 보기 설정과 함께 목표를 생성할 수 있다.")
-    void createWithColorAndPrivacyType() {
+    void 색상_코드_보기_설정과_함께_목표를_생성할_수_있다() {
       // given
       String name = "dev course";
       String color = "999999";
@@ -57,9 +56,8 @@ class GoalTest {
     }
 
     @ParameterizedTest
-    @DisplayName("목표명은 필수값이며 빈 문자열일 수 없다.")
     @NullAndEmptySource
-    void createWithoutName(String invalidName) {
+    void 목표명은_필수값이며_빈_문자열일_수_없다(String invalidName) {
       // when then
       assertThatThrownBy(() -> Goal.builder()
           .name(invalidName)
@@ -69,9 +67,8 @@ class GoalTest {
     }
 
     @ParameterizedTest(name = "{index}. {0}은 50자를 초과한다.")
-    @DisplayName("목표 생성 시 목표명은 50자를 초과할 수 없다.")
     @MethodSource("provideLongString")
-    void createWithLongName(String longName) {
+    void 목표명은_50자를_초과할_수_없다(String longName) {
       // when then
       assertThatThrownBy(() -> Goal.builder()
           .name(longName)
@@ -81,9 +78,8 @@ class GoalTest {
     }
 
     @ParameterizedTest
-    @DisplayName("목표 생성 시 색상 코드가 빈 문자열이면 기본값으로 저장된다.")
     @EmptySource
-    void createWithBlankColor(String emptyColor) {
+    void 색상_코드가_빈_문자열이면_기본값으로_저장된다(String emptyColor) {
       // when
       Goal goal = Goal.builder()
           .name("dev course")
@@ -96,8 +92,7 @@ class GoalTest {
     }
 
     @Test
-    @DisplayName("목표 생성 시 색상 코드는 6자리 16진수 포맷을 따라야 한다.")
-    void createWithInvalidColor() {
+    void 색상_코드는_6자리_16진수_포맷을_따라야_한다() {
       // given
       String invalidColor = "19191!";
 

--- a/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
@@ -92,11 +92,8 @@ class GoalServiceTest {
       // given
       String defaultColor = "191919";
 
-      CreateGoalRequest request = CreateGoalRequest.builder()
-          .name(validName)
-          .color(invalidColor)
-          .privacyType(PrivacyType.PUBLIC)
-          .build();
+      CreateGoalRequest request = new CreateGoalRequest(
+          validName, invalidColor, PrivacyType.PUBLIC);
 
       // when
       CreateGoalResponse expected = goalService.create(request);
@@ -111,10 +108,7 @@ class GoalServiceTest {
     @Test
     void 보기_설정을_설정하지_않으면_PRIVATE이_적용된다() {
       // given
-      CreateGoalRequest request = CreateGoalRequest.builder()
-          .name(validName)
-          .color(validColor)
-          .build();
+      CreateGoalRequest request = new CreateGoalRequest(validName, validColor, null);
 
       // when
       CreateGoalResponse expected = goalService.create(request);

--- a/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
@@ -3,6 +3,7 @@ package com.ddudu.goal.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ddudu.goal.domain.Goal;
+import com.ddudu.goal.domain.GoalStatus;
 import com.ddudu.goal.domain.PrivacyType;
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,14 +33,18 @@ class GoalServiceTest {
   @Nested
   class 목표_생성_테스트 {
 
+    private String validName;
+    private String validColor;
+
+    목표_생성_테스트() {
+      validName = "dev course";
+      validColor = "F7A29D";
+    }
+
     @Test
     void 목표를_생성할_수_있다() {
       // given
-      String name = "dev course";
-      String color = "191919";
-      PrivacyType privacyType = PrivacyType.PUBLIC;
-
-      CreateGoalRequest request = new CreateGoalRequest(name, color, privacyType);
+      CreateGoalRequest request = new CreateGoalRequest(validName, validColor, PrivacyType.PUBLIC);
 
       // when
       CreateGoalResponse expected = goalService.create(request);
@@ -46,7 +53,77 @@ class GoalServiceTest {
       Optional<Goal> actual = goalRepository.findById(expected.id());
       assertThat(actual).isNotEmpty();
       assertThat(actual.get()).extracting("name", "color")
-          .containsExactly(name, color);
+          .containsExactly(validName, validColor);
+    }
+
+    @Test
+    void 목표_생성_시_ID가_자동_생성된다() {
+      // given
+      CreateGoalRequest request = new CreateGoalRequest(validName, validColor, PrivacyType.PUBLIC);
+
+      // when
+      CreateGoalResponse expected = goalService.create(request);
+
+      // then
+      Optional<Goal> actual = goalRepository.findById(expected.id());
+      assertThat(actual).isNotEmpty();
+      assertThat(actual.get()
+          .getId()).isNotNull();
+    }
+
+    @Test
+    void 목표_생성_시_IN_PROGRESS_상태가_된다() {
+      // given
+      CreateGoalRequest request = new CreateGoalRequest(validName, validColor, PrivacyType.PUBLIC);
+
+      // when
+      CreateGoalResponse expected = goalService.create(request);
+
+      // then
+      Optional<Goal> actual = goalRepository.findById(expected.id());
+      assertThat(actual).isNotEmpty();
+      assertThat(actual.get()
+          .getStatus()).isEqualTo(GoalStatus.IN_PROGRESS);
+    }
+
+    @ParameterizedTest(name = "유효하지 않은 색상 : {0}")
+    @NullAndEmptySource
+    void 색상을_설정하지_않거나_빈_문자열이면_기본값이_적용된다(String invalidColor) {
+      // given
+      String defaultColor = "191919";
+
+      CreateGoalRequest request = CreateGoalRequest.builder()
+          .name(validName)
+          .color(invalidColor)
+          .privacyType(PrivacyType.PUBLIC)
+          .build();
+
+      // when
+      CreateGoalResponse expected = goalService.create(request);
+
+      // then
+      Optional<Goal> actual = goalRepository.findById(expected.id());
+      assertThat(actual).isNotEmpty();
+      assertThat(actual.get()
+          .getColor()).isEqualTo(defaultColor);
+    }
+
+    @Test
+    void 보기_설정을_설정하지_않으면_PRIVATE이_적용된다() {
+      // given
+      CreateGoalRequest request = CreateGoalRequest.builder()
+          .name(validName)
+          .color(validColor)
+          .build();
+
+      // when
+      CreateGoalResponse expected = goalService.create(request);
+
+      // then
+      Optional<Goal> actual = goalRepository.findById(expected.id());
+      assertThat(actual).isNotEmpty();
+      assertThat(actual.get()
+          .getPrivacyType()).isEqualTo(PrivacyType.PRIVATE);
     }
 
   }

--- a/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
@@ -1,0 +1,54 @@
+package com.ddudu.goal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddudu.goal.domain.Goal;
+import com.ddudu.goal.domain.PrivacyType;
+import com.ddudu.goal.dto.requset.CreateGoalRequest;
+import com.ddudu.goal.dto.response.CreateGoalResponse;
+import com.ddudu.goal.repository.GoalRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class GoalServiceTest {
+
+  @Autowired
+  GoalService goalService;
+
+  @Autowired
+  GoalRepository goalRepository;
+
+  @Nested
+  class 목표_생성_테스트 {
+
+    @Test
+    void 목표를_생성할_수_있다() {
+      // given
+      String name = "dev course";
+      String color = "191919";
+      PrivacyType privacyType = PrivacyType.PUBLIC;
+
+      CreateGoalRequest request = new CreateGoalRequest(name, color, privacyType);
+
+      // when
+      CreateGoalResponse expected = goalService.create(request);
+
+      // then
+      Optional<Goal> actual = goalRepository.findById(expected.id());
+      assertThat(actual).isNotEmpty();
+      assertThat(actual.get()).extracting("name", "color")
+          .containsExactly(name, color);
+    }
+
+  }
+
+}


### PR DESCRIPTION
## 🎫관련 이슈
Resolves #19

## 🎊구현 내용
- [API 명세서](https://www.notion.so/backend-devcourse/005f1b84323d47cda1005197ddf112d4?pvs=4)

- [x] Color VO로 변경
- [x] 목표 생성 컨트롤러 작성 (+예외처리)
- [x] 목표 생성 서비스 작성
- [x] 목표 생성 테스트 코드 작성

- user와 연관관계, `createdAt`, `updatedAt`은 추후 추가하겠습니다:)
- 생성만 했는데, 코드가 꽤 기네요ㅠㅜ (테스트 코드는 길지만, 내용이 비슷해서 빠르게 보실 수 있을 것 같습니당..)