### PR TITLE
목표 수정 기능 구현

### DIFF
--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -6,8 +6,11 @@ import com.ddudu.goal.dto.response.CreateGoalResponse;
 import com.ddudu.goal.dto.response.ErrorResponse;
 import com.ddudu.goal.dto.response.GoalResponse;
 import com.ddudu.goal.service.GoalService;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -78,6 +81,20 @@ public class GoalController {
 
     return ResponseEntity.badRequest()
         .body(response);
+  }
+
+  @ExceptionHandler(InvalidFormatException.class)
+  public ResponseEntity<ErrorResponse> handleInvalidFormatEx(
+      InvalidFormatException e
+  ) {
+    Class<?> targetType = e.getTargetType();
+    String enumTypeName = targetType.getSimpleName();
+    String validValues = Arrays.stream(targetType.getEnumConstants())
+        .map(enumConstant -> ((Enum<?>) enumConstant).name())
+        .collect(Collectors.joining(", "));
+
+    return ResponseEntity.badRequest()
+        .body(new ErrorResponse(enumTypeName + "는 [" + validValues + "] 중 하나여야 합니다."));
   }
 
 }

--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -14,9 +14,9 @@ import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,7 +42,7 @@ public class GoalController {
         .body(response);
   }
 
-  @PatchMapping("/{id}")
+  @PutMapping("/{id}")
   public ResponseEntity<GoalResponse> update(
       @PathVariable
       Long id,

--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -1,8 +1,10 @@
 package com.ddudu.goal.controller;
 
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
+import com.ddudu.goal.dto.requset.UpdateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
 import com.ddudu.goal.dto.response.ErrorResponse;
+import com.ddudu.goal.dto.response.GoalResponse;
 import com.ddudu.goal.service.GoalService;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -12,6 +14,8 @@ import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,6 +40,19 @@ public class GoalController {
 
     return ResponseEntity.created(uri)
         .body(response);
+  }
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<GoalResponse> update(
+      @PathVariable
+      Long id,
+      @RequestBody
+      @Valid
+      UpdateGoalRequest request
+  ) {
+    GoalResponse response = goalService.update(id, request);
+
+    return ResponseEntity.ok(response);
   }
 
   @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -69,22 +69,15 @@ public class Goal {
     return color.getCode();
   }
 
-  public void setName(String name) {
+  public void applyGoalUpdates(
+      String name, GoalStatus status, String color, PrivacyType privacyType
+  ) {
     validateName(name);
 
     this.name = name;
-  }
-
-  public void setStatus(GoalStatus status) {
     this.status = status;
-  }
-
-  public void setColor(Color color) {
-    this.color = color;
-  }
-
-  public void setPrivacyType(PrivacyType privacyType) {
-    this.privacyType = privacyType;
+    this.color = new Color(color);
+    this.privacyType = isNull(privacyType) ? DEFAULT_PRIVACY_TYPE : privacyType;
   }
 
   private void validateName(String name) {

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -69,6 +69,24 @@ public class Goal {
     return color.getCode();
   }
 
+  public void setName(String name) {
+    validateName(name);
+
+    this.name = name;
+  }
+
+  public void setStatus(GoalStatus status) {
+    this.status = status;
+  }
+
+  public void setColor(Color color) {
+    this.color = color;
+  }
+
+  public void setPrivacyType(PrivacyType privacyType) {
+    this.privacyType = privacyType;
+  }
+
   private void validateName(String name) {
     if (isBlank(name)) {
       throw new IllegalArgumentException("목표명은 필수값입니다.");

--- a/src/main/java/com/ddudu/goal/dto/requset/UpdateGoalRequest.java
+++ b/src/main/java/com/ddudu/goal/dto/requset/UpdateGoalRequest.java
@@ -1,0 +1,22 @@
+package com.ddudu.goal.dto.requset;
+
+import com.ddudu.goal.domain.GoalStatus;
+import com.ddudu.goal.domain.PrivacyType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateGoalRequest(
+    @NotBlank(message = "목표가 입력되지 않았습니다.")
+    @Size(max = 50, message = "목표는 최대 50자 입니다.")
+    String name,
+    @NotNull(message = "목표 상태가 입력되지 않았습니다.")
+    GoalStatus status,
+    @NotBlank(message = "색상이 입력되지 않았습니다.")
+    @Size(max = 6, message = "색상 코드는 6자리 16진수입니다.")
+    String color,
+    @NotNull(message = "공개 설정이 입력되지 않았습니다.")
+    PrivacyType privacyType
+) {
+
+}

--- a/src/main/java/com/ddudu/goal/dto/response/GoalResponse.java
+++ b/src/main/java/com/ddudu/goal/dto/response/GoalResponse.java
@@ -1,26 +1,26 @@
 package com.ddudu.goal.dto.response;
 
 import com.ddudu.goal.domain.Goal;
+import com.ddudu.goal.domain.GoalStatus;
+import com.ddudu.goal.domain.PrivacyType;
 import lombok.Builder;
 
 @Builder
 public record GoalResponse(
     Long id,
     String name,
-    String status,
+    GoalStatus status,
     String color,
-    String privacyType
+    PrivacyType privacyType
 ) {
 
   public static GoalResponse from(Goal goal) {
     return GoalResponse.builder()
         .id(goal.getId())
         .name(goal.getName())
-        .status(goal.getStatus()
-            .name())
+        .status(goal.getStatus())
         .color(goal.getColor())
-        .privacyType(goal.getPrivacyType()
-            .name())
+        .privacyType(goal.getPrivacyType())
         .build();
   }
 

--- a/src/main/java/com/ddudu/goal/dto/response/GoalResponse.java
+++ b/src/main/java/com/ddudu/goal/dto/response/GoalResponse.java
@@ -1,0 +1,28 @@
+package com.ddudu.goal.dto.response;
+
+import com.ddudu.goal.domain.Goal;
+import lombok.Builder;
+
+@Builder
+public record GoalResponse(
+    Long id,
+    String name,
+    String status,
+    String color,
+    String privacyType
+) {
+
+  public static GoalResponse from(Goal goal) {
+    return GoalResponse.builder()
+        .id(goal.getId())
+        .name(goal.getName())
+        .status(goal.getStatus()
+            .name())
+        .color(goal.getColor())
+        .privacyType(goal.getPrivacyType()
+            .name())
+        .build();
+  }
+
+}
+

--- a/src/main/java/com/ddudu/goal/service/GoalService.java
+++ b/src/main/java/com/ddudu/goal/service/GoalService.java
@@ -1,6 +1,5 @@
 package com.ddudu.goal.service;
 
-import com.ddudu.goal.domain.Color;
 import com.ddudu.goal.domain.Goal;
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.requset.UpdateGoalRequest;
@@ -38,10 +37,8 @@ public class GoalService {
     Goal goal = goalRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 목표가 존재하지 않습니다."));
 
-    goal.setName(request.name());
-    goal.setStatus(request.status());
-    goal.setColor(new Color(request.color()));
-    goal.setPrivacyType(request.privacyType());
+    goal.applyGoalUpdates(
+        request.name(), request.status(), request.color(), request.privacyType());
 
     return GoalResponse.from(goal);
   }

--- a/src/main/java/com/ddudu/goal/service/GoalService.java
+++ b/src/main/java/com/ddudu/goal/service/GoalService.java
@@ -1,9 +1,13 @@
 package com.ddudu.goal.service;
 
+import com.ddudu.goal.domain.Color;
 import com.ddudu.goal.domain.Goal;
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
+import com.ddudu.goal.dto.requset.UpdateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
+import com.ddudu.goal.dto.response.GoalResponse;
 import com.ddudu.goal.repository.GoalRepository;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,6 +31,19 @@ public class GoalService {
         .build();
 
     return CreateGoalResponse.from(goalRepository.save(goal));
+  }
+
+  @Transactional
+  public GoalResponse update(Long id, @Valid UpdateGoalRequest request) {
+    Goal goal = goalRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 목표가 존재하지 않습니다."));
+
+    goal.setName(request.name());
+    goal.setStatus(request.status());
+    goal.setColor(new Color(request.color()));
+    goal.setPrivacyType(request.privacyType());
+
+    return GoalResponse.from(goal);
   }
 
 }

--- a/src/main/resources/db/data/afterMigrate.sql
+++ b/src/main/resources/db/data/afterMigrate.sql
@@ -10,3 +10,9 @@ INSERT INTO users(id, optional_username, email, password, nickname) VALUES (7,'d
 INSERT INTO users(id, optional_username, email, password, nickname) VALUES (8,'injaesong', 'injaesong0@gmail.com', '$2a$10$39InvdkmJm3.4xIy4kGCyuoohtLK5rGF09HEKpBFu2fgqfCzYLPiG', '송인재');
 INSERT INTO users(id, optional_username, email, password, nickname) VALUES (9,'devcrazy', 'crazy@example.com', '$2a$10$5ZXbGs1etnGkrath/enkB.TdMj8U//jdmH3GXSRj3F3ACHi5LABHC', '개발 미친 사람');
 INSERT INTO users(id, optional_username, email, password, nickname) VALUES (10,'dingmon', 'coding@mon.co.kr', '$2a$10$k3/gS0YD9tAr69nRZRBjQOmf.MiqXa29hdCSa.Kg0i5U4/gISOsDG', '코딩몬');
+
+-- GOAL
+INSERT INTO goal(id, name, color, privacy) VALUES (1, 'dev course', '71D6E4', 'PUBLIC');
+INSERT INTO goal(id, name, color, privacy) VALUES (2, 'study', 'F2D055', 'PUBLIC');
+INSERT INTO goal(id, name, color, privacy) VALUES (3, 'event', 'F2B2C8', 'PRIVATE');
+INSERT INTO goal(id, name, color, privacy) VALUES (4, 'etc', 'C9D66A', 'PUBLIC');

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -4,14 +4,18 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.ddudu.config.WebSecurityConfig;
+import com.ddudu.goal.domain.GoalStatus;
 import com.ddudu.goal.domain.PrivacyType;
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
+import com.ddudu.goal.dto.requset.UpdateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
+import com.ddudu.goal.dto.response.GoalResponse;
 import com.ddudu.goal.service.GoalService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
@@ -44,16 +48,16 @@ class GoalControllerTest {
   @MockBean
   private GoalService goalService;
 
+  private String validName;
+  private String validColor;
+
+  GoalControllerTest() {
+    validName = "dev course";
+    validColor = "F7A29D";
+  }
+
   @Nested
   class 목표_생성_API_테스트 {
-
-    private String validName;
-    private String validColor;
-
-    목표_생성_API_테스트() {
-      validName = "dev course";
-      validColor = "F7A29D";
-    }
 
     @Test
     void 목표를_생성할_수_있다() throws Exception {
@@ -166,6 +170,37 @@ class GoalControllerTest {
     private static List<String> provide51Letters() {
       String longString = "a".repeat(51);
       return List.of(longString);
+    }
+
+  }
+
+  @Nested
+  class 목표_수정_API_테스트 {
+
+    @Test
+    void Put_목표_수정을_성공한다() throws Exception {
+      // given
+      UpdateGoalRequest request = new UpdateGoalRequest(
+          validName, GoalStatus.IN_PROGRESS, validColor, PrivacyType.PUBLIC);
+
+      GoalResponse response = new GoalResponse(
+          1L, validName, GoalStatus.IN_PROGRESS.name(), validColor, PrivacyType.PUBLIC.name());
+
+      given(goalService.update(any(Long.class), any(UpdateGoalRequest.class)))
+          .willReturn(response);
+
+      // when then
+      mockMvc.perform(
+              put("/api/goals/{id}", 1L)
+                  .content(objectMapper.writeValueAsString(request))
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.id").value(response.id()))
+          .andExpect(jsonPath("$.name").value(response.name()))
+          .andExpect(jsonPath("$.status").value(response.status()))
+          .andExpect(jsonPath("$.color").value(response.color()))
+          .andExpect(jsonPath("$.privacyType").value(response.privacyType()));
     }
 
   }

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -184,7 +184,7 @@ class GoalControllerTest {
           validName, GoalStatus.IN_PROGRESS, validColor, PrivacyType.PUBLIC);
 
       GoalResponse response = new GoalResponse(
-          1L, validName, GoalStatus.IN_PROGRESS.name(), validColor, PrivacyType.PUBLIC.name());
+          1L, validName, GoalStatus.IN_PROGRESS, validColor, PrivacyType.PUBLIC);
 
       given(goalService.update(any(Long.class), any(UpdateGoalRequest.class)))
           .willReturn(response);
@@ -198,9 +198,11 @@ class GoalControllerTest {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.id").value(response.id()))
           .andExpect(jsonPath("$.name").value(response.name()))
-          .andExpect(jsonPath("$.status").value(response.status()))
+          .andExpect(jsonPath("$.status").value(response.status()
+              .name()))
           .andExpect(jsonPath("$.color").value(response.color()))
-          .andExpect(jsonPath("$.privacyType").value(response.privacyType()));
+          .andExpect(jsonPath("$.privacyType").value(response.privacyType()
+              .name()));
     }
 
   }

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -205,6 +205,64 @@ class GoalControllerTest {
               .name()));
     }
 
+    @Test
+    void Put_유효하지_않은_목표_상태가_입력된_경우_Bad_Request_응답을_반환한다() throws Exception {
+      // given
+      String invalidRequestJson = """
+          {
+              "name": "dev course",
+              "status": "INVALID TYPE",
+              "color": "191919",
+              "privacyType": "PUBLIC"
+          }
+          """;
+
+      GoalResponse response = GoalResponse.builder()
+          .build();
+
+      given(goalService.update(any(Long.class), any(UpdateGoalRequest.class)))
+          .willReturn(response);
+
+      // when then
+      mockMvc.perform(
+              put("/api/goals/{id}", 1L)
+                  .content(invalidRequestJson)
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message")
+              .value(containsString("GoalStatus는 [IN_PROGRESS, DONE] 중 하나여야 합니다.")));
+    }
+
+    @Test
+    void Put_유효하지_않은_공개_설정이_입력된_경우_Bad_Request_응답을_반환한다() throws Exception {
+      // given
+      String invalidRequestJson = """
+          {
+              "name": "dev course",
+              "status": "IN_PROGRESS",
+              "color": "191919",
+              "privacyType": "INVALID TYPE"
+          }
+          """;
+
+      GoalResponse response = GoalResponse.builder()
+          .build();
+
+      given(goalService.update(any(Long.class), any(UpdateGoalRequest.class)))
+          .willReturn(response);
+
+      // when then
+      mockMvc.perform(
+              put("/api/goals/{id}", 1L)
+                  .content(invalidRequestJson)
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message")
+              .value(containsString("PrivacyType는 [PRIVATE, FOLLOWER, PUBLIC] 중 하나여야 합니다.")));
+    }
+
   }
 
 }

--- a/src/test/java/com/ddudu/goal/domain/GoalTest.java
+++ b/src/test/java/com/ddudu/goal/domain/GoalTest.java
@@ -115,4 +115,40 @@ class GoalTest {
 
   }
 
+  @Nested
+  class 목표_수정_테스트 {
+
+    목표_수정_테스트() {
+      validName = "dav course";
+      validColor = "191919";
+    }
+
+    @Test
+    void 목표명_색상_상태_공개_설정을_수정_할_수_있다() {
+      // given
+      Goal goal = createGoal();
+      String changedName = "데브 코스";
+      String changedColor = "999999";
+      GoalStatus changedStatus = GoalStatus.DONE;
+      PrivacyType changedPrivacyType = PrivacyType.PUBLIC;
+
+      // when
+      goal.applyGoalUpdates(changedName, changedStatus, changedColor, changedPrivacyType);
+
+      // then
+      assertThat(goal.getName()).isEqualTo(changedName);
+      assertThat(goal).extracting("name", "status", "color", "privacyType")
+          .containsExactly(changedName, changedStatus, changedColor, changedPrivacyType);
+    }
+
+    private Goal createGoal() {
+      return Goal.builder()
+          .name(validName)
+          .color(validColor)
+          .privacyType(PrivacyType.PRIVATE)
+          .build();
+    }
+
+  }
+
 }

--- a/src/test/java/com/ddudu/goal/domain/GoalTest.java
+++ b/src/test/java/com/ddudu/goal/domain/GoalTest.java
@@ -139,7 +139,6 @@ class GoalTest {
       goal.applyGoalUpdates(changedName, changedStatus, changedColor, changedPrivacyType);
 
       // then
-      assertThat(goal.getName()).isEqualTo(changedName);
       assertThat(goal).extracting("name", "status", "color", "privacyType")
           .containsExactly(changedName, changedStatus, changedColor, changedPrivacyType);
     }

--- a/src/test/java/com/ddudu/goal/domain/GoalTest.java
+++ b/src/test/java/com/ddudu/goal/domain/GoalTest.java
@@ -118,6 +118,9 @@ class GoalTest {
   @Nested
   class 목표_수정_테스트 {
 
+    private String validName;
+    private String validColor;
+
     목표_수정_테스트() {
       validName = "dav course";
       validColor = "191919";

--- a/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
@@ -6,6 +6,7 @@ import com.ddudu.goal.domain.Goal;
 import com.ddudu.goal.domain.GoalStatus;
 import com.ddudu.goal.domain.PrivacyType;
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
+import com.ddudu.goal.dto.requset.UpdateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
 import com.ddudu.goal.repository.GoalRepository;
 import java.util.Optional;
@@ -30,16 +31,16 @@ class GoalServiceTest {
   @Autowired
   GoalRepository goalRepository;
 
+  private String validName;
+  private String validColor;
+
+  GoalServiceTest() {
+    validName = "dev course";
+    validColor = "F7A29D";
+  }
+
   @Nested
   class 목표_생성_테스트 {
-
-    private String validName;
-    private String validColor;
-
-    목표_생성_테스트() {
-      validName = "dev course";
-      validColor = "F7A29D";
-    }
 
     @Test
     void 목표를_생성할_수_있다() {
@@ -118,6 +119,44 @@ class GoalServiceTest {
       assertThat(actual).isNotEmpty();
       assertThat(actual.get()
           .getPrivacyType()).isEqualTo(PrivacyType.PRIVATE);
+    }
+
+  }
+
+  @Nested
+  class 목표_수정_테스트 {
+
+    @Test
+    void 목표를_수정_할_수_있다() {
+      // given
+      Goal goal = createGoal();
+
+      String changedName = "데브 코스";
+      String changedColor = "999999";
+      GoalStatus changedStatus = GoalStatus.DONE;
+      PrivacyType changedPrivacyType = PrivacyType.PUBLIC;
+
+      UpdateGoalRequest request = new UpdateGoalRequest(
+          changedName, changedStatus, changedColor, changedPrivacyType);
+
+      // when
+      goalService.update(goal.getId(), request);
+
+      // then
+      Goal actual = goalRepository.findById(goal.getId())
+          .get();
+      assertThat(actual).extracting("name", "status", "color", "privacyType")
+          .containsExactly(changedName, changedStatus, changedColor, changedPrivacyType);
+    }
+
+    private Goal createGoal() {
+      Goal goal = Goal.builder()
+          .name(validName)
+          .color(validColor)
+          .privacyType(PrivacyType.PRIVATE)
+          .build();
+
+      return goalRepository.save(goal);
     }
 
   }


### PR DESCRIPTION
## 🎫관련 이슈
Resolves #41

## 🎊구현 내용
- 목표 수정 요청, 응답 DTO 생성
- 목표 수정 컨트롤러 작성 (PUT /api/goals/{id})
- Goal 엔티티에 applyGoalUpdates() 메서드 생성
- 목표 수정 서비스 구현
- 테스트 코드 작성
