### PR TITLE
목표 조회(단일, 전체) 기능 구현

### DIFF
--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -7,7 +7,7 @@ import com.ddudu.goal.dto.requset.UpdateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
 import com.ddudu.goal.dto.response.ErrorResponse;
 import com.ddudu.goal.dto.response.GoalResponse;
-import com.ddudu.goal.dto.response.GoalSummaryDTO;
+import com.ddudu.goal.dto.response.GoalSummaryResponse;
 import com.ddudu.goal.service.GoalService;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import jakarta.persistence.EntityNotFoundException;
@@ -77,11 +77,11 @@ public class GoalController {
   }
 
   @GetMapping
-  public ResponseEntity<List<GoalSummaryDTO>> getGoals(
+  public ResponseEntity<List<GoalSummaryResponse>> getGoals(
       @RequestParam
       Long userId
   ) {
-    List<GoalSummaryDTO> response = goalService.getGoals(userId);
+    List<GoalSummaryResponse> response = goalService.getGoals(userId);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -67,21 +67,21 @@ public class GoalController {
   }
 
   @GetMapping("/{id}")
-  public ResponseEntity<GoalResponse> getGoal(
+  public ResponseEntity<GoalResponse> getById(
       @PathVariable
       Long id
   ) {
-    GoalResponse response = goalService.getGoal(id);
+    GoalResponse response = goalService.getById(id);
 
     return ResponseEntity.ok(response);
   }
 
   @GetMapping
-  public ResponseEntity<List<GoalSummaryResponse>> getGoals(
+  public ResponseEntity<List<GoalSummaryResponse>> getAllById(
       @RequestParam
       Long userId
   ) {
-    List<GoalSummaryResponse> response = goalService.getGoals(userId);
+    List<GoalSummaryResponse> response = goalService.getAllById(userId);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -36,11 +36,12 @@ public class GoalController {
 
   @PostMapping
   public ResponseEntity<CreateGoalResponse> create(
+      Long userId,
       @RequestBody
       @Valid
       CreateGoalRequest request
   ) {
-    CreateGoalResponse response = goalService.create(request);
+    CreateGoalResponse response = goalService.create(userId, request);
     URI uri = URI.create("/api/goals/" + response.id());
 
     return ResponseEntity.created(uri)

--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -1,9 +1,13 @@
 package com.ddudu.goal.controller;
 
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
 import com.ddudu.goal.dto.response.ErrorResponse;
+import com.ddudu.goal.dto.response.GoalResponse;
 import com.ddudu.goal.service.GoalService;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +16,8 @@ import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,6 +44,16 @@ public class GoalController {
         .body(response);
   }
 
+  @GetMapping("/{id}")
+  public ResponseEntity<GoalResponse> getGoal(
+      @PathVariable
+      Long id
+  ) {
+    GoalResponse response = goalService.getGoal(id);
+
+    return ResponseEntity.ok(response);
+  }
+
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<ErrorResponse> handleIllegalArgumentEx(IllegalArgumentException e) {
     ErrorResponse response = new ErrorResponse(e.getMessage());
@@ -60,6 +76,14 @@ public class GoalController {
     ErrorResponse response = new ErrorResponse(errorMessage);
 
     return ResponseEntity.badRequest()
+        .body(response);
+  }
+
+  @ExceptionHandler(EntityNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleEntityNotFoundEx(EntityNotFoundException e) {
+    ErrorResponse response = new ErrorResponse(e.getMessage());
+
+    return ResponseEntity.status(NOT_FOUND)
         .body(response);
   }
 

--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -6,10 +6,12 @@ import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
 import com.ddudu.goal.dto.response.ErrorResponse;
 import com.ddudu.goal.dto.response.GoalResponse;
+import com.ddudu.goal.dto.response.GoalSummaryDTO;
 import com.ddudu.goal.service.GoalService;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -50,6 +53,16 @@ public class GoalController {
       Long id
   ) {
     GoalResponse response = goalService.getGoal(id);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping
+  public ResponseEntity<List<GoalSummaryDTO>> getGoals(
+      @RequestParam
+      Long userId
+  ) {
+    List<GoalSummaryDTO> response = goalService.getGoals(userId);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -3,15 +3,19 @@ package com.ddudu.goal.domain;
 import static io.micrometer.common.util.StringUtils.isBlank;
 import static java.util.Objects.isNull;
 
+import com.ddudu.user.domain.User;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -37,6 +41,10 @@ public class Goal {
 
   @Column(name = "name", nullable = false, length = 50)
   private String name;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
 
   @Column(name = "status", nullable = false, columnDefinition = "VARCHAR", length = 20)
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -4,10 +4,12 @@ import static io.micrometer.common.util.StringUtils.isBlank;
 import static java.util.Objects.isNull;
 
 import com.ddudu.user.domain.User;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
@@ -17,13 +19,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "goal")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Goal {
@@ -60,6 +67,16 @@ public class Goal {
   @Column(name = "privacy", nullable = false, columnDefinition = "VARCHAR", length = 20)
   @Enumerated(EnumType.STRING)
   private PrivacyType privacyType;
+
+  @Column(name = "created_at", nullable = false, columnDefinition = "TIMESTAMP")
+  @CreatedDate
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false, columnDefinition = "TIMESTAMP")
+  @LastModifiedDate
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  private LocalDateTime updatedAt;
 
   @Column(name = "is_deleted", nullable = false)
   private boolean isDeleted = DEFAULT_IS_DELETED;

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -20,6 +20,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -82,16 +83,22 @@ public class Goal {
   private boolean isDeleted = DEFAULT_IS_DELETED;
 
   @Builder
-  public Goal(String name, String color, PrivacyType privacyType) {
-    validateName(name);
+  public Goal(String name, User user, String color, PrivacyType privacyType) {
+    validate(name, user);
 
     this.name = name;
+    this.user = user;
     this.color = new Color(color);
     this.privacyType = isNull(privacyType) ? DEFAULT_PRIVACY_TYPE : privacyType;
   }
 
   public String getColor() {
     return color.getCode();
+  }
+
+  private void validate(String name, User user) {
+    validateName(name);
+    validateUser(user);
   }
 
   private void validateName(String name) {
@@ -103,5 +110,12 @@ public class Goal {
       throw new IllegalArgumentException("목표명은 최대 " + MAX_NAME_LENGTH + "자 입니다.");
     }
   }
+
+  private void validateUser(User user) {
+    if (Objects.isNull(user)) {
+      throw new IllegalArgumentException("사용자는 필수값입니다.");
+    }
+  }
+
 
 }

--- a/src/main/java/com/ddudu/goal/dto/response/GoalResponse.java
+++ b/src/main/java/com/ddudu/goal/dto/response/GoalResponse.java
@@ -1,0 +1,27 @@
+package com.ddudu.goal.dto.response;
+
+import com.ddudu.goal.domain.Goal;
+import lombok.Builder;
+
+@Builder
+public record GoalResponse(
+    Long id,
+    String name,
+    String status,
+    String color,
+    String privacyType
+) {
+
+  public static GoalResponse from(Goal goal) {
+    return GoalResponse.builder()
+        .id(goal.getId())
+        .name(goal.getName())
+        .status(goal.getStatus()
+            .name())
+        .color(goal.getColor())
+        .privacyType(goal.getPrivacyType()
+            .name())
+        .build();
+  }
+
+}

--- a/src/main/java/com/ddudu/goal/dto/response/GoalSummaryDTO.java
+++ b/src/main/java/com/ddudu/goal/dto/response/GoalSummaryDTO.java
@@ -1,0 +1,24 @@
+package com.ddudu.goal.dto.response;
+
+import com.ddudu.goal.domain.Goal;
+import lombok.Builder;
+
+@Builder
+public record GoalSummaryDTO(
+    Long id,
+    String name,
+    String status,
+    String color
+) {
+
+  public static GoalSummaryDTO from(Goal goal) {
+    return GoalSummaryDTO.builder()
+        .id(goal.getId())
+        .name(goal.getName())
+        .status(goal.getStatus()
+            .name())
+        .color(goal.getColor())
+        .build();
+  }
+
+}

--- a/src/main/java/com/ddudu/goal/dto/response/GoalSummaryResponse.java
+++ b/src/main/java/com/ddudu/goal/dto/response/GoalSummaryResponse.java
@@ -4,15 +4,15 @@ import com.ddudu.goal.domain.Goal;
 import lombok.Builder;
 
 @Builder
-public record GoalSummaryDTO(
+public record GoalSummaryResponse(
     Long id,
     String name,
     String status,
     String color
 ) {
 
-  public static GoalSummaryDTO from(Goal goal) {
-    return GoalSummaryDTO.builder()
+  public static GoalSummaryResponse from(Goal goal) {
+    return GoalSummaryResponse.builder()
         .id(goal.getId())
         .name(goal.getName())
         .status(goal.getStatus()

--- a/src/main/java/com/ddudu/goal/repository/GoalRepository.java
+++ b/src/main/java/com/ddudu/goal/repository/GoalRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface GoalRepository extends JpaRepository<Goal, Long> {
 
-  @Query("SELECT g FROM Goal g ORDER BY g.status DESC, g.createdAt ASC")
+  @Query("SELECT g FROM Goal g WHERE g.user=:user ORDER BY g.status DESC, g.createdAt ASC")
   List<Goal> findAllByUser(User user);
 
 }

--- a/src/main/java/com/ddudu/goal/repository/GoalRepository.java
+++ b/src/main/java/com/ddudu/goal/repository/GoalRepository.java
@@ -1,8 +1,14 @@
 package com.ddudu.goal.repository;
 
 import com.ddudu.goal.domain.Goal;
+import com.ddudu.user.domain.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GoalRepository extends JpaRepository<Goal, Long> {
+
+  @Query("SELECT g FROM Goal g ORDER BY g.status DESC, g.createdAt ASC")
+  List<Goal> findAllByUser(User user);
 
 }

--- a/src/main/java/com/ddudu/goal/service/GoalService.java
+++ b/src/main/java/com/ddudu/goal/service/GoalService.java
@@ -4,9 +4,13 @@ import com.ddudu.goal.domain.Goal;
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
 import com.ddudu.goal.dto.response.GoalResponse;
+import com.ddudu.goal.dto.response.GoalSummaryDTO;
 import com.ddudu.goal.repository.GoalRepository;
+import com.ddudu.user.domain.User;
+import com.ddudu.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +23,7 @@ import org.springframework.validation.annotation.Validated;
 public class GoalService {
 
   private final GoalRepository goalRepository;
+  private final UserRepository userRepository;
 
   @Transactional
   public CreateGoalResponse create(@Valid CreateGoalRequest request) {
@@ -36,6 +41,17 @@ public class GoalService {
         .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 목표가 존재하지 않습니다."));
 
     return GoalResponse.from(goal);
+  }
+
+  public List<GoalSummaryDTO> getGoals(Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."));
+
+    List<Goal> goals = goalRepository.findAllByUser(user);
+
+    return goals.stream()
+        .map(GoalSummaryDTO::from)
+        .toList();
   }
 
 }

--- a/src/main/java/com/ddudu/goal/service/GoalService.java
+++ b/src/main/java/com/ddudu/goal/service/GoalService.java
@@ -3,7 +3,9 @@ package com.ddudu.goal.service;
 import com.ddudu.goal.domain.Goal;
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
+import com.ddudu.goal.dto.response.GoalResponse;
 import com.ddudu.goal.repository.GoalRepository;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,6 +29,13 @@ public class GoalService {
         .build();
 
     return CreateGoalResponse.from(goalRepository.save(goal));
+  }
+
+  public GoalResponse getGoal(Long id) {
+    Goal goal = goalRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 목표가 존재하지 않습니다."));
+
+    return GoalResponse.from(goal);
   }
 
 }

--- a/src/main/java/com/ddudu/goal/service/GoalService.java
+++ b/src/main/java/com/ddudu/goal/service/GoalService.java
@@ -5,7 +5,7 @@ import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.requset.UpdateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
 import com.ddudu.goal.dto.response.GoalResponse;
-import com.ddudu.goal.dto.response.GoalSummaryDTO;
+import com.ddudu.goal.dto.response.GoalSummaryResponse;
 import com.ddudu.goal.repository.GoalRepository;
 import com.ddudu.user.domain.User;
 import com.ddudu.user.repository.UserRepository;
@@ -63,14 +63,14 @@ public class GoalService {
     return GoalResponse.from(goal);
   }
 
-  public List<GoalSummaryDTO> getGoals(Long userId) {
+  public List<GoalSummaryResponse> getGoals(Long userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."));
 
     List<Goal> goals = goalRepository.findAllByUser(user);
 
     return goals.stream()
-        .map(GoalSummaryDTO::from)
+        .map(GoalSummaryResponse::from)
         .toList();
   }
 

--- a/src/main/java/com/ddudu/goal/service/GoalService.java
+++ b/src/main/java/com/ddudu/goal/service/GoalService.java
@@ -56,14 +56,14 @@ public class GoalService {
     return GoalResponse.from(goal);
   }
 
-  public GoalResponse getGoal(Long id) {
+  public GoalResponse getById(Long id) {
     Goal goal = goalRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 목표가 존재하지 않습니다."));
 
     return GoalResponse.from(goal);
   }
 
-  public List<GoalSummaryResponse> getGoals(Long userId) {
+  public List<GoalSummaryResponse> getAllById(Long userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."));
 

--- a/src/main/java/com/ddudu/goal/service/GoalService.java
+++ b/src/main/java/com/ddudu/goal/service/GoalService.java
@@ -26,9 +26,17 @@ public class GoalService {
   private final UserRepository userRepository;
 
   @Transactional
-  public CreateGoalResponse create(@Valid CreateGoalRequest request) {
+  public CreateGoalResponse create(
+      Long userId,
+      @Valid
+      CreateGoalRequest request
+  ) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."));
+
     Goal goal = Goal.builder()
         .name(request.name())
+        .user(user)
         .color(request.color())
         .privacyType(request.privacyType())
         .build();

--- a/src/main/resources/db/data/afterMigrate.sql
+++ b/src/main/resources/db/data/afterMigrate.sql
@@ -1,5 +1,7 @@
 -- USER
+SET foreign_key_checks = 0;
 TRUNCATE TABLE users;
+SET foreign_key_checks = 1;
 INSERT INTO users(id, email, password, nickname) VALUES (1, 'nicolette.mills@hotmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Kenya Dewit');
 INSERT INTO users(id, email, password, nickname) VALUES (2, 'brian.mayer@hotmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Jack Pott');
 INSERT INTO users(id, email, password, nickname) VALUES (3, 'shayne.bogisich@gmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Lou Pole');
@@ -10,3 +12,13 @@ INSERT INTO users(id, optional_username, email, password, nickname) VALUES (7,'d
 INSERT INTO users(id, optional_username, email, password, nickname) VALUES (8,'injaesong', 'injaesong0@gmail.com', '$2a$10$39InvdkmJm3.4xIy4kGCyuoohtLK5rGF09HEKpBFu2fgqfCzYLPiG', '송인재');
 INSERT INTO users(id, optional_username, email, password, nickname) VALUES (9,'devcrazy', 'crazy@example.com', '$2a$10$5ZXbGs1etnGkrath/enkB.TdMj8U//jdmH3GXSRj3F3ACHi5LABHC', '개발 미친 사람');
 INSERT INTO users(id, optional_username, email, password, nickname) VALUES (10,'dingmon', 'coding@mon.co.kr', '$2a$10$k3/gS0YD9tAr69nRZRBjQOmf.MiqXa29hdCSa.Kg0i5U4/gISOsDG', '코딩몬');
+
+-- GOAL
+SET foreign_key_checks = 0;
+TRUNCATE TABLE goal;
+SET foreign_key_checks = 1;
+INSERT INTO goal(id, user_id, name, color, privacy) VALUES (1, 8, 'dev course', '75D7E4', 'PUBLIC');
+INSERT INTO goal(id, user_id, name, color, privacy) VALUES (2, 8, 'study', 'F3D056', 'PUBLIC');
+INSERT INTO goal(id, user_id, name, color, privacy) VALUES (3, 8, 'event', 'F1B5CA', 'PRIVATE');
+INSERT INTO goal(id, user_id, name, color, privacy) VALUES (4, 8, 'etc', 'C7D567', 'PUBLIC');
+INSERT INTO goal(id, user_id, name, privacy, status) VALUES (5, 8, 'college', 'PUBLIC', 'DONE');

--- a/src/main/resources/db/migration/V1__schema.sql
+++ b/src/main/resources/db/migration/V1__schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS users
 CREATE TABLE IF NOT EXISTS goal
 (
     id         BIGINT      AUTO_INCREMENT,
+    user_id    BIGINT      NOT NULL,
     name       VARCHAR(50) NOT NULL,
     color      CHAR(6)     NOT NULL DEFAULT '191919',
     privacy    VARCHAR(20) NOT NULL DEFAULT 'PRIVATE',
@@ -27,6 +28,7 @@ CREATE TABLE IF NOT EXISTS goal
     updated_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     is_deleted TINYINT(1)  NOT NULL DEFAULT 0,
     CONSTRAINT pk_goal_id PRIMARY KEY (id),
+    CONSTRAINT fk_user_id FOREIGN KEY (user_id) REFERENCES users (id),
     CONSTRAINT ck_color CHECK ( CHAR_LENGTH(color) = 6 )
 );
 

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -228,7 +228,7 @@ class GoalControllerTest {
         // given
         GoalResponse response = createGoalResponse();
 
-        given(goalService.getGoal(any(Long.class))).willReturn(response);
+        given(goalService.getById(any(Long.class))).willReturn(response);
 
         // when then
         mockMvc.perform(
@@ -307,7 +307,7 @@ class GoalControllerTest {
       void ID가_유효하지_않으면_Not_Found_응답을_반환한다() throws Exception {
         // given
         Long invalidId = -1L;
-        given(goalService.getGoal(any(Long.class)))
+        given(goalService.getById(any(Long.class)))
             .willThrow(new EntityNotFoundException("해당 아이디를 가진 목표가 존재하지 않습니다."));
 
         // when then
@@ -341,7 +341,7 @@ class GoalControllerTest {
         List<GoalSummaryResponse> response = createGoalSummaryDTO();
         GoalSummaryResponse firstElement = response.get(0);
 
-        given(goalService.getGoals(any(Long.class))).willReturn(response);
+        given(goalService.getAllById(any(Long.class))).willReturn(response);
 
         // when then
         mockMvc.perform(
@@ -361,7 +361,7 @@ class GoalControllerTest {
       void Get_사용자가_존재하지_않은_경우_404_Not_Found_응답을_반환한다() throws Exception {
         // given
         String invalidUserId = "-1";
-        given(goalService.getGoals(any(Long.class))).willThrow(
+        given(goalService.getAllById(any(Long.class))).willThrow(
             new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."));
 
         // when then

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -1,136 +1,392 @@
 package com.ddudu.goal.controller;
 
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.ddudu.config.WebSecurityConfig;
+import com.ddudu.goal.domain.GoalStatus;
+import com.ddudu.goal.domain.PrivacyType;
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.requset.UpdateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
-import com.ddudu.goal.dto.response.ErrorResponse;
 import com.ddudu.goal.dto.response.GoalResponse;
 import com.ddudu.goal.dto.response.GoalSummaryDTO;
 import com.ddudu.goal.service.GoalService;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.validation.Valid;
-import java.net.URI;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.support.DefaultMessageSourceResolvable;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import net.datafaker.Faker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 
-@RestController
-@RequestMapping("/api/goals")
-@RequiredArgsConstructor
-@Slf4j
-public class GoalController {
+@WebMvcTest(controllers = GoalController.class)
+@Import(WebSecurityConfig.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class GoalControllerTest {
 
-  private final GoalService goalService;
+  static final Faker faker = new Faker();
 
-  @PostMapping
-  public ResponseEntity<CreateGoalResponse> create(
-      Long userId,
-      @RequestBody
-      @Valid
-      CreateGoalRequest request
-  ) {
-    CreateGoalResponse response = goalService.create(userId, request);
-    URI uri = URI.create("/api/goals/" + response.id());
+  @Autowired
+  private MockMvc mockMvc;
 
-    return ResponseEntity.created(uri)
-        .body(response);
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private GoalService goalService;
+
+  String validName;
+  String validColor;
+
+  @BeforeEach
+  void setUp() {
+    validName = faker.lorem()
+        .word();
+    validColor = faker.color()
+        .hex()
+        .substring(1);
   }
 
-  @PutMapping("/{id}")
-  public ResponseEntity<GoalResponse> update(
-      @PathVariable
-      Long id,
-      @RequestBody
-      @Valid
-      UpdateGoalRequest request
-  ) {
-    GoalResponse response = goalService.update(id, request);
+  @Nested
+  class 목표_생성_API_테스트 {
 
-    return ResponseEntity.ok(response);
+    @Test
+    void 목표를_생성할_수_있다() throws Exception {
+      // given
+      CreateGoalRequest request = new CreateGoalRequest(validName, validColor, PrivacyType.PUBLIC);
+      CreateGoalResponse response = new CreateGoalResponse(1L, validName, validColor);
+
+      given(goalService.create(any(Long.class), any(CreateGoalRequest.class)))
+          .willReturn(response);
+
+      // when then
+      mockMvc.perform(
+              post("/api/goals")
+                  .param("userId", "1")
+                  .content(objectMapper.writeValueAsString(request))
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isCreated())
+          .andExpect(header().exists("location"))
+          .andExpect(jsonPath("$.id").value(response.id()))
+          .andExpect(jsonPath("$.name").value(response.name()))
+          .andExpect(jsonPath("$.color").value(response.color()));
+    }
+
+    @ParameterizedTest(name = "유효하지 않은 목표 : {0}")
+    @NullAndEmptySource
+    void 목표가_null_이거나_빈_문자열인_경우_Bad_Request_응답을_반환한다(String invalidName) throws Exception {
+      // given
+      CreateGoalRequest request = new CreateGoalRequest(
+          invalidName, validColor, PrivacyType.PUBLIC);
+
+      given(goalService.create(any(Long.class), any(CreateGoalRequest.class)))
+          .willReturn(CreateGoalResponse.builder()
+              .build());
+
+      // when then
+      mockMvc.perform(
+              post("/api/goals")
+                  .param("userId", "1")
+                  .content(objectMapper.writeValueAsString(request))
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message")
+              .value(containsString("목표가 입력되지 않았습니다.")));
+    }
+
+    @ParameterizedTest(name = "50자를 초과하는 목표 : {0}")
+    @MethodSource("provide51Letters")
+    void 목표가_50자를_초과하면_Bad_Request_응답을_반환한다(String longName) throws Exception {
+      // given
+      CreateGoalRequest request = new CreateGoalRequest(longName, validColor, PrivacyType.PUBLIC);
+
+      given(goalService.create(any(Long.class), any(CreateGoalRequest.class)))
+          .willReturn(CreateGoalResponse.builder()
+              .build());
+
+      // when then
+      mockMvc.perform(
+              post("/api/goals")
+                  .param("userId", "1")
+                  .content(objectMapper.writeValueAsString(request))
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message")
+              .value(containsString("목표는 최대 50자 입니다.")));
+    }
+
+    @ParameterizedTest(name = "6자를 초과하는 색상 : {0}")
+    @ValueSource(strings = {"7letter"})
+    void 색상이_6자를_넘으면_Bad_Request_응답을_반환한다(String longColor) throws Exception {
+      // given
+      CreateGoalRequest request = new CreateGoalRequest(validName, longColor, PrivacyType.PUBLIC);
+
+      given(goalService.create(any(Long.class), any(CreateGoalRequest.class)))
+          .willReturn(CreateGoalResponse.builder()
+              .build());
+
+      // when then
+      mockMvc.perform(
+              post("/api/goals")
+                  .param("userId", "1")
+                  .content(objectMapper.writeValueAsString(request))
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message")
+              .value(containsString("색상 코드는 6자리 16진수입니다.")));
+    }
+
+    @Test
+    void 색상이_16진수_포맷이_아닌_경우_Bad_Request_응답을_반환한다() throws Exception {
+      // given
+      String invalidColor = "Z123!";
+      CreateGoalRequest request = new CreateGoalRequest(
+          validName, invalidColor, PrivacyType.PUBLIC);
+
+      given(goalService.create(any(Long.class), any(CreateGoalRequest.class)))
+          .willThrow(new IllegalArgumentException("올바르지 않은 색상 코드입니다. 색상 코드는 6자리 16진수입니다."));
+
+      // when then
+      mockMvc.perform(
+              post("/api/goals")
+                  .param("userId", "1")
+                  .content(objectMapper.writeValueAsString(request))
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message")
+              .value(containsString("올바르지 않은 색상 코드입니다. 색상 코드는 6자리 16진수입니다.")));
+    }
+
+    private static List<String> provide51Letters() {
+      String longString = "a".repeat(51);
+      return List.of(longString);
+    }
+
   }
 
-  @GetMapping("/{id}")
-  public ResponseEntity<GoalResponse> getGoal(
-      @PathVariable
-      Long id
-  ) {
-    GoalResponse response = goalService.getGoal(id);
+  @Nested
+  class 목표_수정_API_테스트 {
 
-    return ResponseEntity.ok(response);
-  }
+    @Test
+    void Put_목표_수정을_성공한다() throws Exception {
+      // given
+      UpdateGoalRequest request = new UpdateGoalRequest(
+          validName, GoalStatus.IN_PROGRESS, validColor, PrivacyType.PUBLIC);
 
-  @GetMapping
-  public ResponseEntity<List<GoalSummaryDTO>> getGoals(
-      @RequestParam
-      Long userId
-  ) {
-    List<GoalSummaryDTO> response = goalService.getGoals(userId);
+      GoalResponse response = new GoalResponse(
+          1L, validName, GoalStatus.IN_PROGRESS, validColor, PrivacyType.PUBLIC);
 
-    return ResponseEntity.ok(response);
-  }
+      given(goalService.update(any(Long.class), any(UpdateGoalRequest.class)))
+          .willReturn(response);
 
-  @ExceptionHandler(IllegalArgumentException.class)
-  public ResponseEntity<ErrorResponse> handleIllegalArgumentEx(IllegalArgumentException e) {
-    ErrorResponse response = new ErrorResponse(e.getMessage());
+      // when then
+      mockMvc.perform(
+              put("/api/goals/{id}", 1L)
+                  .content(objectMapper.writeValueAsString(request))
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.id").value(response.id()))
+          .andExpect(jsonPath("$.name").value(response.name()))
+          .andExpect(jsonPath("$.status").value(response.status()
+              .name()))
+          .andExpect(jsonPath("$.color").value(response.color()))
+          .andExpect(jsonPath("$.privacyType").value(response.privacyType()
+              .name()));
+    }
 
-    return ResponseEntity.badRequest()
-        .body(response);
-  }
+    class 단일_목표_조회_API_테스트 {
 
-  @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidEx(
-      MethodArgumentNotValidException e
-  ) {
-    String errorMessage = e.getBindingResult()
-        .getFieldErrors()
-        .stream()
-        .map(DefaultMessageSourceResolvable::getDefaultMessage)
-        .toList()
-        .toString();
+      @Test
+      void 목표를_조회할_수_있다() throws Exception {
+        // given
+        GoalResponse response = createGoalResponse();
 
-    ErrorResponse response = new ErrorResponse(errorMessage);
+        given(goalService.getGoal(any(Long.class))).willReturn(response);
 
-    return ResponseEntity.badRequest()
-        .body(response);
-  }
+        // when then
+        mockMvc.perform(
+                get("/api/goals/{id}", response.id())
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(response.id()))
+            .andExpect(jsonPath("$.name").value(response.name()))
+            .andExpect(jsonPath("$.status").value(response.status()
+                .name()))
+            .andExpect(jsonPath("$.color").value(response.color()))
+            .andExpect(jsonPath("$.privacyType").value(response.privacyType()
+                .name()));
+      }
 
-  @ExceptionHandler(InvalidFormatException.class)
-  public ResponseEntity<ErrorResponse> handleInvalidFormatEx(
-      InvalidFormatException e
-  ) {
-    Class<?> targetType = e.getTargetType();
-    String enumTypeName = targetType.getSimpleName();
-    String validValues = Arrays.stream(targetType.getEnumConstants())
-        .map(enumConstant -> ((Enum<?>) enumConstant).name())
-        .collect(Collectors.joining(", "));
+      @Test
+      void Put_유효하지_않은_목표_상태가_입력된_경우_Bad_Request_응답을_반환한다() throws Exception {
+        // given
+        String invalidRequestJson = """
+            {
+                "name": "dev course",
+                "status": "INVALID TYPE",
+                "color": "191919",
+                "privacyType": "PUBLIC"
+            }
+            """;
 
-    return ResponseEntity.badRequest()
-        .body(new ErrorResponse(enumTypeName + "는 [" + validValues + "] 중 하나여야 합니다."));
-  }
+        GoalResponse response = GoalResponse.builder()
+            .build();
 
-  @ExceptionHandler(EntityNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleEntityNotFoundEx(EntityNotFoundException e) {
-    ErrorResponse response = new ErrorResponse(e.getMessage());
+        given(goalService.update(any(Long.class), any(UpdateGoalRequest.class)))
+            .willReturn(response);
 
-    return ResponseEntity.status(NOT_FOUND)
-        .body(response);
+        // when then
+        mockMvc.perform(
+                put("/api/goals/{id}", 1L)
+                    .content(invalidRequestJson)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message")
+                .value(containsString("GoalStatus는 [IN_PROGRESS, DONE] 중 하나여야 합니다.")));
+      }
+
+      @Test
+      void Put_유효하지_않은_공개_설정이_입력된_경우_Bad_Request_응답을_반환한다() throws Exception {
+        // given
+        String invalidRequestJson = """
+            {
+                "name": "dev course",
+                "status": "IN_PROGRESS",
+                "color": "191919",
+                "privacyType": "INVALID TYPE"
+            }
+            """;
+
+        GoalResponse response = GoalResponse.builder()
+            .build();
+
+        given(goalService.update(any(Long.class), any(UpdateGoalRequest.class)))
+            .willReturn(response);
+
+        // when then
+        mockMvc.perform(
+                put("/api/goals/{id}", 1L)
+                    .content(invalidRequestJson)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message")
+                .value(containsString("PrivacyType는 [PRIVATE, FOLLOWER, PUBLIC] 중 하나여야 합니다.")));
+      }
+
+      @Test
+      void ID가_유효하지_않으면_Not_Found_응답을_반환한다() throws Exception {
+        // given
+        Long invalidId = -1L;
+        given(goalService.getGoal(any(Long.class)))
+            .willThrow(new EntityNotFoundException("해당 아이디를 가진 목표가 존재하지 않습니다."));
+
+        // when then
+        mockMvc.perform(
+                get("/api/goals/{id}", invalidId)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message")
+                .value(containsString("해당 아이디를 가진 목표가 존재하지 않습니다.")));
+      }
+
+      private static GoalResponse createGoalResponse() {
+        return GoalResponse.builder()
+            .id(1L)
+            .name("dev course")
+            .status(GoalStatus.IN_PROGRESS)
+            .color("191919")
+            .privacyType(PrivacyType.PRIVATE)
+            .build();
+      }
+
+    }
+
+    @Nested
+    class 전체_목표_조회_API_테스트 {
+
+      @Test
+      void Get_사용자의_전체_목표를_조회할_수_있다() throws Exception {
+        // given
+        List<GoalSummaryDTO> response = createGoalSummaryDTO();
+        GoalSummaryDTO firstElement = response.get(0);
+
+        given(goalService.getGoals(any(Long.class))).willReturn(response);
+
+        // when then
+        mockMvc.perform(
+                get("/api/goals")
+                    .param("userId", "1")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").isArray())
+            .andExpect(jsonPath("$[0].id").value(firstElement.id()))
+            .andExpect(jsonPath("$[0].name").value(firstElement.name()))
+            .andExpect(jsonPath("$[0].status").value(firstElement.status()))
+            .andExpect(jsonPath("$[0].color").value(firstElement.color()));
+      }
+
+      @Test
+      void Get_사용자가_존재하지_않은_경우_404_Not_Found_응답을_반환한다() throws Exception {
+        // given
+        String invalidUserId = "-1";
+        given(goalService.getGoals(any(Long.class))).willThrow(
+            new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."));
+
+        // when then
+        mockMvc.perform(
+                get("/api/goals")
+                    .queryParam("userId", invalidUserId)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message")
+                .value(containsString("해당 아이디를 가진 사용자가 존재하지 않습니다.")));
+      }
+
+      private List<GoalSummaryDTO> createGoalSummaryDTO() {
+        GoalSummaryDTO goalSummaryDTO = GoalSummaryDTO.builder()
+            .id(1L)
+            .name("dev course")
+            .status(GoalStatus.IN_PROGRESS.name())
+            .color("191919")
+            .build();
+
+        return List.of(goalSummaryDTO);
+      }
+
+    }
+
   }
 
 }

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -2,6 +2,7 @@ package com.ddudu.goal.controller;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -76,7 +77,7 @@ class GoalControllerTest {
       CreateGoalRequest request = new CreateGoalRequest(validName, validColor, PrivacyType.PUBLIC);
       CreateGoalResponse response = new CreateGoalResponse(1L, validName, validColor);
 
-      given(goalService.create(any(Long.class), any(CreateGoalRequest.class)))
+      given(goalService.create(anyLong(), any(CreateGoalRequest.class)))
           .willReturn(response);
 
       // when then
@@ -100,7 +101,7 @@ class GoalControllerTest {
       CreateGoalRequest request = new CreateGoalRequest(
           invalidName, validColor, PrivacyType.PUBLIC);
 
-      given(goalService.create(any(Long.class), any(CreateGoalRequest.class)))
+      given(goalService.create(anyLong(), any(CreateGoalRequest.class)))
           .willReturn(CreateGoalResponse.builder()
               .build());
 
@@ -122,7 +123,7 @@ class GoalControllerTest {
       // given
       CreateGoalRequest request = new CreateGoalRequest(longName, validColor, PrivacyType.PUBLIC);
 
-      given(goalService.create(any(Long.class), any(CreateGoalRequest.class)))
+      given(goalService.create(anyLong(), any(CreateGoalRequest.class)))
           .willReturn(CreateGoalResponse.builder()
               .build());
 
@@ -144,7 +145,7 @@ class GoalControllerTest {
       // given
       CreateGoalRequest request = new CreateGoalRequest(validName, longColor, PrivacyType.PUBLIC);
 
-      given(goalService.create(any(Long.class), any(CreateGoalRequest.class)))
+      given(goalService.create(anyLong(), any(CreateGoalRequest.class)))
           .willReturn(CreateGoalResponse.builder()
               .build());
 
@@ -167,7 +168,7 @@ class GoalControllerTest {
       CreateGoalRequest request = new CreateGoalRequest(
           validName, invalidColor, PrivacyType.PUBLIC);
 
-      given(goalService.create(any(Long.class), any(CreateGoalRequest.class)))
+      given(goalService.create(anyLong(), any(CreateGoalRequest.class)))
           .willThrow(new IllegalArgumentException("올바르지 않은 색상 코드입니다. 색상 코드는 6자리 16진수입니다."));
 
       // when then
@@ -201,7 +202,7 @@ class GoalControllerTest {
       GoalResponse response = new GoalResponse(
           1L, validName, GoalStatus.IN_PROGRESS, validColor, PrivacyType.PUBLIC);
 
-      given(goalService.update(any(Long.class), any(UpdateGoalRequest.class)))
+      given(goalService.update(anyLong(), any(UpdateGoalRequest.class)))
           .willReturn(response);
 
       // when then
@@ -228,7 +229,7 @@ class GoalControllerTest {
         // given
         GoalResponse response = createGoalResponse();
 
-        given(goalService.getById(any(Long.class))).willReturn(response);
+        given(goalService.getById(anyLong())).willReturn(response);
 
         // when then
         mockMvc.perform(
@@ -260,7 +261,7 @@ class GoalControllerTest {
         GoalResponse response = GoalResponse.builder()
             .build();
 
-        given(goalService.update(any(Long.class), any(UpdateGoalRequest.class)))
+        given(goalService.update(anyLong(), any(UpdateGoalRequest.class)))
             .willReturn(response);
 
         // when then
@@ -289,7 +290,7 @@ class GoalControllerTest {
         GoalResponse response = GoalResponse.builder()
             .build();
 
-        given(goalService.update(any(Long.class), any(UpdateGoalRequest.class)))
+        given(goalService.update(anyLong(), any(UpdateGoalRequest.class)))
             .willReturn(response);
 
         // when then
@@ -307,7 +308,7 @@ class GoalControllerTest {
       void ID가_유효하지_않으면_Not_Found_응답을_반환한다() throws Exception {
         // given
         Long invalidId = -1L;
-        given(goalService.getById(any(Long.class)))
+        given(goalService.getById(anyLong()))
             .willThrow(new EntityNotFoundException("해당 아이디를 가진 목표가 존재하지 않습니다."));
 
         // when then
@@ -341,7 +342,7 @@ class GoalControllerTest {
         List<GoalSummaryResponse> response = createGoalSummaryDTO();
         GoalSummaryResponse firstElement = response.get(0);
 
-        given(goalService.getAllById(any(Long.class))).willReturn(response);
+        given(goalService.getAllById(anyLong())).willReturn(response);
 
         // when then
         mockMvc.perform(
@@ -361,7 +362,7 @@ class GoalControllerTest {
       void Get_사용자가_존재하지_않은_경우_404_Not_Found_응답을_반환한다() throws Exception {
         // given
         String invalidUserId = "-1";
-        given(goalService.getAllById(any(Long.class))).willThrow(
+        given(goalService.getAllById(anyLong())).willThrow(
             new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."));
 
         // when then

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -220,6 +220,7 @@ class GoalControllerTest {
               .name()));
     }
 
+    @Nested
     class 단일_목표_조회_API_테스트 {
 
       @Test

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -147,7 +147,7 @@ class GoalControllerTest {
     }
 
     @Test
-    void 색상이_16진수_포맷이_아닌_경우_Bad_Rquest_응답을_반환한다() throws Exception {
+    void 색상이_16진수_포맷이_아닌_경우_Bad_Request_응답을_반환한다() throws Exception {
       // given
       String invalidColor = "Z123!";
       CreateGoalRequest request = new CreateGoalRequest(

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -17,7 +17,7 @@ import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.requset.UpdateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
 import com.ddudu.goal.dto.response.GoalResponse;
-import com.ddudu.goal.dto.response.GoalSummaryDTO;
+import com.ddudu.goal.dto.response.GoalSummaryResponse;
 import com.ddudu.goal.service.GoalService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityNotFoundException;
@@ -338,8 +338,8 @@ class GoalControllerTest {
       @Test
       void Get_사용자의_전체_목표를_조회할_수_있다() throws Exception {
         // given
-        List<GoalSummaryDTO> response = createGoalSummaryDTO();
-        GoalSummaryDTO firstElement = response.get(0);
+        List<GoalSummaryResponse> response = createGoalSummaryDTO();
+        GoalSummaryResponse firstElement = response.get(0);
 
         given(goalService.getGoals(any(Long.class))).willReturn(response);
 
@@ -375,15 +375,15 @@ class GoalControllerTest {
                 .value(containsString("해당 아이디를 가진 사용자가 존재하지 않습니다.")));
       }
 
-      private List<GoalSummaryDTO> createGoalSummaryDTO() {
-        GoalSummaryDTO goalSummaryDTO = GoalSummaryDTO.builder()
+      private List<GoalSummaryResponse> createGoalSummaryDTO() {
+        GoalSummaryResponse goalSummaryResponse = GoalSummaryResponse.builder()
             .id(1L)
             .name("dev course")
             .status(GoalStatus.IN_PROGRESS.name())
             .color("191919")
             .build();
 
-        return List.of(goalSummaryDTO);
+        return List.of(goalSummaryResponse);
       }
 
     }

--- a/src/test/java/com/ddudu/goal/domain/GoalTest.java
+++ b/src/test/java/com/ddudu/goal/domain/GoalTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -23,9 +24,19 @@ class GoalTest {
   static final Faker faker = new Faker();
 
   User user;
+  String name;
+  String color;
+  PrivacyType privacyType;
+
   @BeforeEach
   void setUp() {
     user = createUser();
+    name = faker.lorem()
+        .word();
+    color = faker.color()
+        .hex()
+        .substring(1);
+    privacyType = PrivacyType.PUBLIC;
   }
 
   @Nested
@@ -33,9 +44,6 @@ class GoalTest {
 
     @Test
     void 목표를_생성할_수_있다() {
-      // given
-      String name = "dev course";
-
       // when
       Goal goal = Goal.builder()
           .name(name)
@@ -51,11 +59,6 @@ class GoalTest {
 
     @Test
     void 색상_코드_보기_설정과_함께_목표를_생성할_수_있다() {
-      // given
-      String name = "dev course";
-      String color = "999999";
-      PrivacyType privacyType = PrivacyType.PUBLIC;
-
       // when
       Goal goal = Goal.builder()
           .name(name)
@@ -111,7 +114,7 @@ class GoalTest {
     void 색상_코드가_빈_문자열이면_기본값으로_저장된다(String emptyColor) {
       // when
       Goal goal = Goal.builder()
-          .name("dev course")
+          .name(name)
           .user(user)
           .color(emptyColor)
           .build();
@@ -129,7 +132,7 @@ class GoalTest {
       // when then
       assertThatThrownBy(() ->
           Goal.builder()
-              .name("dev course")
+              .name(name)
               .user(user)
               .color(invalidColor)
               .build()

--- a/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
@@ -10,7 +10,7 @@ import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.requset.UpdateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
 import com.ddudu.goal.dto.response.GoalResponse;
-import com.ddudu.goal.dto.response.GoalSummaryDTO;
+import com.ddudu.goal.dto.response.GoalSummaryResponse;
 import com.ddudu.goal.repository.GoalRepository;
 import com.ddudu.user.domain.User;
 import com.ddudu.user.repository.UserRepository;
@@ -215,7 +215,7 @@ class GoalServiceTest {
       List<Goal> expected = createGoals(user, List.of(validName));
 
       // when
-      List<GoalSummaryDTO> actual = goalService.getGoals(user.getId());
+      List<GoalSummaryResponse> actual = goalService.getGoals(user.getId());
 
       // then
       assertThat(actual).isNotEmpty();

--- a/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
@@ -219,7 +219,7 @@ class GoalServiceTest {
 
       // then
       assertThat(actual).isNotEmpty();
-      //assertThat(actual.size()).isEqualTo(expected.size());
+      assertThat(actual.size()).isEqualTo(expected.size());
       assertThat(actual.get(0)).extracting(
               "id",
               "name",

--- a/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
@@ -169,7 +169,7 @@ class GoalServiceTest {
       Long id = expected.getId();
 
       // when
-      GoalResponse actual = goalService.getGoal(id);
+      GoalResponse actual = goalService.getById(id);
 
       // then
       GoalStatus expectedStatus = expected.getStatus();
@@ -197,7 +197,7 @@ class GoalServiceTest {
       Long invalidId = -1L;
 
       // when
-      ThrowingCallable getGoal = () -> goalService.getGoal(invalidId);
+      ThrowingCallable getGoal = () -> goalService.getById(invalidId);
 
       // then
       assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(getGoal)
@@ -215,7 +215,7 @@ class GoalServiceTest {
       List<Goal> expected = createGoals(user, List.of(validName));
 
       // when
-      List<GoalSummaryResponse> actual = goalService.getGoals(user.getId());
+      List<GoalSummaryResponse> actual = goalService.getAllById(user.getId());
 
       // then
       assertThat(actual).isNotEmpty();
@@ -245,7 +245,7 @@ class GoalServiceTest {
       Long invalidUserId = 1234567890L;
 
       // when
-      ThrowingCallable getGoals = () -> goalService.getGoals(invalidUserId);
+      ThrowingCallable getGoals = () -> goalService.getAllById(invalidUserId);
 
       // then
       assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(getGoals)

--- a/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
@@ -9,10 +9,16 @@ import com.ddudu.goal.domain.PrivacyType;
 import com.ddudu.goal.dto.requset.CreateGoalRequest;
 import com.ddudu.goal.dto.response.CreateGoalResponse;
 import com.ddudu.goal.dto.response.GoalResponse;
+import com.ddudu.goal.dto.response.GoalSummaryDTO;
 import com.ddudu.goal.repository.GoalRepository;
+import com.ddudu.user.domain.User;
+import com.ddudu.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
 import java.util.Optional;
+import net.datafaker.Faker;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
@@ -21,6 +27,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -28,22 +35,33 @@ import org.springframework.transaction.annotation.Transactional;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class GoalServiceTest {
 
+  static final Faker faker = new Faker();
+
   @Autowired
   GoalService goalService;
 
   @Autowired
   GoalRepository goalRepository;
 
+  @Autowired
+  UserRepository userRepository;
+
+  User user;
+  String validName;
+  String validColor;
+
+  @BeforeEach
+  void setUp() {
+    user = createUser();
+    validName = faker.lorem()
+        .word();
+    validColor = faker.color()
+        .hex()
+        .substring(1);
+  }
+
   @Nested
   class 목표_생성_테스트 {
-
-    private String validName;
-    private String validColor;
-
-    목표_생성_테스트() {
-      validName = "dev course";
-      validColor = "F7A29D";
-    }
 
     @Test
     void 목표를_생성할_수_있다() {
@@ -51,7 +69,7 @@ class GoalServiceTest {
       CreateGoalRequest request = new CreateGoalRequest(validName, validColor, PrivacyType.PUBLIC);
 
       // when
-      CreateGoalResponse expected = goalService.create(request);
+      CreateGoalResponse expected = goalService.create(user.getId(), request);
 
       // then
       Optional<Goal> actual = goalRepository.findById(expected.id());
@@ -66,7 +84,7 @@ class GoalServiceTest {
       CreateGoalRequest request = new CreateGoalRequest(validName, validColor, PrivacyType.PUBLIC);
 
       // when
-      CreateGoalResponse expected = goalService.create(request);
+      CreateGoalResponse expected = goalService.create(user.getId(), request);
 
       // then
       Optional<Goal> actual = goalRepository.findById(expected.id());
@@ -81,7 +99,7 @@ class GoalServiceTest {
       CreateGoalRequest request = new CreateGoalRequest(validName, validColor, PrivacyType.PUBLIC);
 
       // when
-      CreateGoalResponse expected = goalService.create(request);
+      CreateGoalResponse expected = goalService.create(user.getId(), request);
 
       // then
       Optional<Goal> actual = goalRepository.findById(expected.id());
@@ -100,7 +118,7 @@ class GoalServiceTest {
           validName, invalidColor, PrivacyType.PUBLIC);
 
       // when
-      CreateGoalResponse expected = goalService.create(request);
+      CreateGoalResponse expected = goalService.create(user.getId(), request);
 
       // then
       Optional<Goal> actual = goalRepository.findById(expected.id());
@@ -115,7 +133,7 @@ class GoalServiceTest {
       CreateGoalRequest request = new CreateGoalRequest(validName, validColor, null);
 
       // when
-      CreateGoalResponse expected = goalService.create(request);
+      CreateGoalResponse expected = goalService.create(user.getId(), request);
 
       // then
       Optional<Goal> actual = goalRepository.findById(expected.id());
@@ -124,21 +142,29 @@ class GoalServiceTest {
           .getPrivacyType()).isEqualTo(PrivacyType.PRIVATE);
     }
 
+    @Test
+    void 사용자ID가_유효하지_않으면_예외가_발생한다() {
+      // given
+      Long invalidUserId = 1234567890L;
+      CreateGoalRequest request = new CreateGoalRequest(validName, validColor, null);
+
+      // when
+      ThrowingCallable create = () -> goalService.create(invalidUserId, request);
+
+      // then
+      assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(create)
+          .withMessage("해당 아이디를 가진 사용자가 존재하지 않습니다.");
+    }
+
   }
 
   @Nested
-  class 목표_조회_테스트 {
-
-    private String validName;
-
-    목표_조회_테스트() {
-      validName = "dev course";
-    }
+  class 단일_목표_조회_테스트 {
 
     @Test
-    void ID를_통해_단일_목표를_조회_할_수_있다() {
+    void ID를_통해_목표를_조회_할_수_있다() {
       // given
-      Goal expected = createGoal(validName);
+      Goal expected = createGoal(user, validName);
       Long id = expected.getId();
 
       // when
@@ -177,14 +203,87 @@ class GoalServiceTest {
           .withMessage("해당 아이디를 가진 목표가 존재하지 않습니다.");
     }
 
-    private Goal createGoal(String name) {
-      Goal goal = Goal.builder()
-          .name(name)
-          .build();
+  }
 
-      return goalRepository.save(goal);
+  @Nested
+  class 전체_목표_조회_테스트 {
+
+    @Test
+    void 사용자의_전체_목표를_조회_할_수_있다() {
+      // given
+      List<Goal> expected = createGoals(user, List.of(validName));
+
+      // when
+      List<GoalSummaryDTO> actual = goalService.getGoals(user.getId());
+
+      // then
+      assertThat(actual).isNotEmpty();
+      //assertThat(actual.size()).isEqualTo(expected.size());
+      assertThat(actual.get(0)).extracting(
+              "id",
+              "name",
+              "status",
+              "color"
+          )
+          .containsExactly(
+              expected.get(0)
+                  .getId(),
+              expected.get(0)
+                  .getName(),
+              expected.get(0)
+                  .getStatus()
+                  .name(),
+              expected.get(0)
+                  .getColor()
+          );
     }
 
+    @Test
+    void 유효하지_않은_사용자_ID인_경우_조회에_실패한다() {
+      // given
+      Long invalidUserId = 1234567890L;
+
+      // when
+      ThrowingCallable getGoals = () -> goalService.getGoals(invalidUserId);
+
+      // then
+      assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(getGoals)
+          .withMessage("해당 아이디를 가진 사용자가 존재하지 않습니다.");
+    }
+
+  }
+
+  private List<Goal> createGoals(User user, List<String> names) {
+    return names.stream()
+        .map(name -> createGoal(user, name))
+        .toList();
+  }
+
+  private Goal createGoal(User user, String name) {
+    Goal goal = Goal.builder()
+        .name(name)
+        .user(user)
+        .build();
+
+    return goalRepository.save(goal);
+  }
+
+  private User createUser() {
+    String email = faker.internet()
+        .emailAddress();
+    String password = faker.internet()
+        .password(8, 40, false, true, true);
+    String nickname = faker.oscarMovie()
+        .character();
+
+    User user = User.builder()
+        .passwordEncoder(new BCryptPasswordEncoder())
+        .email(email)
+        .password(password)
+        .nickname(nickname)
+        .build();
+
+    return userRepository.save(user);
   }
 
 }

--- a/src/test/java/com/ddudu/todo/domain/TodoTest.java
+++ b/src/test/java/com/ddudu/todo/domain/TodoTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ddudu.goal.domain.Goal;
+import com.ddudu.user.domain.User;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 class TodoTest {
 
@@ -111,12 +113,22 @@ class TodoTest {
     private static Goal createGoal(String name) {
       return Goal.builder()
           .name(name)
+          .user(createUser())
           .build();
     }
 
     private static List<String> provideLongString() {
       String longString = "a".repeat(100);
       return List.of(longString);
+    }
+
+    private static User createUser() {
+      return User.builder()
+          .passwordEncoder(new BCryptPasswordEncoder())
+          .email("email@naver.com")
+          .password("password123!")
+          .nickname("nickname")
+          .build();
     }
 
   }

--- a/src/test/java/com/ddudu/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/ddudu/todo/service/TodoServiceTest.java
@@ -114,7 +114,8 @@ class TodoServiceTest {
     @Test
     void 할_일_상태_업데이트를_성공한다() {
       // given
-      Goal goal = createGoal("dev course");
+      User user = createUser();
+      Goal goal = createGoal("dev course", user);
       Todo todo = createTodo("할 일 1개 조회 기능 구현", goal);
       TodoStatus beforeUpdated = todo.getStatus();
 


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
 Resolves #39 

## 🎊구현 내용
- Goal / User 다대일 연관 관계 매핑
- 전체 조회 시 목표 상태, 생성일 기준으로 정렬을 하기 위해 JPQL 사용
- 연관 관계 매핑에 따른 기존 테스트 코드 변경 및 Faker 도입

❗참고
- 로그인 구현 이전이기 때문에 임시로 userId를 QueryParam으로 입력 받습니다! (추후 변경 예정)
