### PR TITLE
목표 삭제 기능 구현

### DIFF
--- a/src/main/java/com/ddudu/common/BaseEntity.java
+++ b/src/main/java/com/ddudu/common/BaseEntity.java
@@ -30,4 +30,10 @@ public class BaseEntity {
   @Column(name = "is_deleted", nullable = false)
   private boolean isDeleted = DEFAULT_IS_DELETED;
 
+  public void delete() {
+    if (!isDeleted) {
+      isDeleted = true;
+    }
+  }
+
 }

--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -72,17 +72,17 @@ public class GoalController {
       @PathVariable
       Long id
   ) {
-    GoalResponse response = goalService.getById(id);
+    GoalResponse response = goalService.findById(id);
 
     return ResponseEntity.ok(response);
   }
 
   @GetMapping
-  public ResponseEntity<List<GoalSummaryResponse>> getAllById(
+  public ResponseEntity<List<GoalSummaryResponse>> getAllByUser(
       @RequestParam
       Long userId
   ) {
-    List<GoalSummaryResponse> response = goalService.getAllById(userId);
+    List<GoalSummaryResponse> response = goalService.findAllByUser(userId);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/ddudu/goal/controller/GoalController.java
+++ b/src/main/java/com/ddudu/goal/controller/GoalController.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -84,6 +85,17 @@ public class GoalController {
     List<GoalSummaryResponse> response = goalService.getAllById(userId);
 
     return ResponseEntity.ok(response);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity delete(
+      @PathVariable
+      Long id
+  ) {
+    goalService.delete(id);
+
+    return ResponseEntity.noContent()
+        .build();
   }
 
   @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -3,9 +3,8 @@ package com.ddudu.goal.domain;
 import static io.micrometer.common.util.StringUtils.isBlank;
 import static java.util.Objects.isNull;
 
-import com.ddudu.user.domain.User;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.ddudu.common.BaseEntity;
+import com.ddudu.user.domain.User;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -20,14 +19,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -91,12 +87,6 @@ public class Goal extends BaseEntity {
     this.status = status;
     this.color = new Color(color);
     this.privacyType = isNull(privacyType) ? DEFAULT_PRIVACY_TYPE : privacyType;
-  }
-
-  public void delete() {
-    if (!isDeleted) {
-      isDeleted = true;
-    }
   }
 
   private void validate(String name, User user) {

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -24,11 +24,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "goal")
 @EntityListeners(AuditingEntityListener.class)
+@SQLRestriction("is_deleted = 0")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Goal extends BaseEntity {

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -108,7 +108,9 @@ public class Goal {
   }
 
   public void delete() {
-    this.isDeleted = true;
+    if (!isDeleted) {
+      isDeleted = true;
+    }
   }
 
   private void validate(String name, User user) {

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -9,7 +9,6 @@ import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
@@ -25,11 +24,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "goal")
-@EntityListeners(AuditingEntityListener.class)
 @SQLRestriction("is_deleted = 0")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/src/main/java/com/ddudu/goal/domain/Goal.java
+++ b/src/main/java/com/ddudu/goal/domain/Goal.java
@@ -107,6 +107,10 @@ public class Goal {
     this.privacyType = isNull(privacyType) ? DEFAULT_PRIVACY_TYPE : privacyType;
   }
 
+  public void delete() {
+    this.isDeleted = true;
+  }
+
   private void validate(String name, User user) {
     validateName(name);
     validateUser(user);
@@ -127,5 +131,5 @@ public class Goal {
       throw new IllegalArgumentException("사용자는 필수값입니다.");
     }
   }
-  
+
 }

--- a/src/main/java/com/ddudu/goal/repository/GoalRepository.java
+++ b/src/main/java/com/ddudu/goal/repository/GoalRepository.java
@@ -1,22 +1,15 @@
 package com.ddudu.goal.repository;
 
 import com.ddudu.goal.domain.Goal;
-import com.ddudu.user.domain.User;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface GoalRepository extends JpaRepository<Goal, Long> {
+public interface GoalRepository extends JpaRepository<Goal, Long>, GoalRepositoryCustom {
 
   @Query(
       "SELECT g FROM Goal g WHERE g.id=:id AND g.isDeleted=false"
   )
   Optional<Goal> findById(Long id);
-
-  @Query(
-      "SELECT g FROM Goal g WHERE g.user=:user AND g.isDeleted=false ORDER BY g.status DESC, g.createdAt ASC"
-  )
-  List<Goal> findAllByUser(User user);
 
 }

--- a/src/main/java/com/ddudu/goal/repository/GoalRepository.java
+++ b/src/main/java/com/ddudu/goal/repository/GoalRepository.java
@@ -3,13 +3,9 @@ package com.ddudu.goal.repository;
 import com.ddudu.goal.domain.Goal;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface GoalRepository extends JpaRepository<Goal, Long>, GoalRepositoryCustom {
 
-  @Query(
-      "SELECT g FROM Goal g WHERE g.id=:id AND g.isDeleted=false"
-  )
   Optional<Goal> findById(Long id);
 
 }

--- a/src/main/java/com/ddudu/goal/repository/GoalRepository.java
+++ b/src/main/java/com/ddudu/goal/repository/GoalRepository.java
@@ -3,12 +3,20 @@ package com.ddudu.goal.repository;
 import com.ddudu.goal.domain.Goal;
 import com.ddudu.user.domain.User;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface GoalRepository extends JpaRepository<Goal, Long> {
 
-  @Query("SELECT g FROM Goal g WHERE g.user=:user ORDER BY g.status DESC, g.createdAt ASC")
+  @Query(
+      "SELECT g FROM Goal g WHERE g.id=:id AND g.isDeleted=false"
+  )
+  Optional<Goal> findById(Long id);
+
+  @Query(
+      "SELECT g FROM Goal g WHERE g.user=:user AND g.isDeleted=false ORDER BY g.status DESC, g.createdAt ASC"
+  )
   List<Goal> findAllByUser(User user);
 
 }

--- a/src/main/java/com/ddudu/goal/repository/GoalRepositoryCustom.java
+++ b/src/main/java/com/ddudu/goal/repository/GoalRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.ddudu.goal.repository;
+
+import com.ddudu.goal.domain.Goal;
+import com.ddudu.user.domain.User;
+import java.util.List;
+
+public interface GoalRepositoryCustom {
+
+  List<Goal> findAllByUser(User user);
+
+}

--- a/src/main/java/com/ddudu/goal/repository/GoalRepositoryImpl.java
+++ b/src/main/java/com/ddudu/goal/repository/GoalRepositoryImpl.java
@@ -22,11 +22,11 @@ public class GoalRepositoryImpl implements GoalRepositoryCustom {
   public List<Goal> findAllByUser(User user) {
     return jpaQueryFactory
         .selectFrom(goal)
-        .where(
-            goal.user.eq(user),
-            goal.isDeleted.eq(false)
+        .where(goal.user.eq(user))
+        .orderBy(
+            goal.status.desc(),
+            goal.createdAt.asc()
         )
-        .orderBy(goal.status.desc(), goal.createdAt.asc())
         .fetch();
   }
 

--- a/src/main/java/com/ddudu/goal/repository/GoalRepositoryImpl.java
+++ b/src/main/java/com/ddudu/goal/repository/GoalRepositoryImpl.java
@@ -25,7 +25,7 @@ public class GoalRepositoryImpl implements GoalRepositoryCustom {
         .where(goal.user.eq(user))
         .orderBy(
             goal.status.desc(),
-            goal.createdAt.asc()
+            goal.id.desc()
         )
         .fetch();
   }

--- a/src/main/java/com/ddudu/goal/repository/GoalRepositoryImpl.java
+++ b/src/main/java/com/ddudu/goal/repository/GoalRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.ddudu.goal.repository;
+
+import static com.ddudu.goal.domain.QGoal.goal;
+
+import com.ddudu.goal.domain.Goal;
+import com.ddudu.user.domain.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class GoalRepositoryImpl implements GoalRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  public GoalRepositoryImpl(EntityManager em) {
+    this.jpaQueryFactory = new JPAQueryFactory(em);
+  }
+
+  @Override
+  public List<Goal> findAllByUser(User user) {
+    return jpaQueryFactory
+        .selectFrom(goal)
+        .where(
+            goal.user.eq(user),
+            goal.isDeleted.eq(false)
+        )
+        .orderBy(goal.status.desc(), goal.createdAt.asc())
+        .fetch();
+  }
+
+}

--- a/src/main/java/com/ddudu/goal/service/GoalService.java
+++ b/src/main/java/com/ddudu/goal/service/GoalService.java
@@ -76,10 +76,8 @@ public class GoalService {
 
   @Transactional
   public void delete(Long id) {
-    Goal goal = goalRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 목표가 존재하지 않습니다."));
-
-    goal.delete();
+    goalRepository.findById(id)
+        .ifPresent(Goal::delete);
   }
 
 }

--- a/src/main/java/com/ddudu/goal/service/GoalService.java
+++ b/src/main/java/com/ddudu/goal/service/GoalService.java
@@ -74,4 +74,12 @@ public class GoalService {
         .toList();
   }
 
+  @Transactional
+  public void delete(Long id) {
+    Goal goal = goalRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 목표가 존재하지 않습니다."));
+
+    goal.delete();
+  }
+
 }

--- a/src/main/java/com/ddudu/goal/service/GoalService.java
+++ b/src/main/java/com/ddudu/goal/service/GoalService.java
@@ -56,14 +56,14 @@ public class GoalService {
     return GoalResponse.from(goal);
   }
 
-  public GoalResponse getById(Long id) {
+  public GoalResponse findById(Long id) {
     Goal goal = goalRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 목표가 존재하지 않습니다."));
 
     return GoalResponse.from(goal);
   }
 
-  public List<GoalSummaryResponse> getAllById(Long userId) {
+  public List<GoalSummaryResponse> findAllByUser(Long userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."));
 

--- a/src/main/java/com/ddudu/todo/domain/Todo.java
+++ b/src/main/java/com/ddudu/todo/domain/Todo.java
@@ -21,9 +21,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "todo")
+@SQLRestriction("is_deleted = 0")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Todo extends BaseEntity {

--- a/src/main/java/com/ddudu/user/domain/User.java
+++ b/src/main/java/com/ddudu/user/domain/User.java
@@ -17,10 +17,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Table(name = "users")
+@SQLRestriction("is_deleted = 0")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class User extends BaseEntity {

--- a/src/main/java/com/ddudu/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/ddudu/user/dto/request/SignUpRequest.java
@@ -12,7 +12,6 @@ public record SignUpRequest(
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     String email,
     @NotBlank(message = "비밀번호가 입력되지 않았습니다.")
-    @Size(min = 8, max = 50, message = "비밀번호는 8자리 이상이어야 합니다.")
     @Pattern(
         regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@!%*#?&^]).{8,50}$",
         message = "비밀번호는 영문, 숫자, 특수문자로 구성되어야 합니다."

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -71,10 +71,10 @@ class GoalControllerTest {
   }
 
   @Nested
-  class 목표_생성_API_테스트 {
+  class POST_목표_생성_API_테스트 {
 
     @Test
-    void 목표를_생성할_수_있다() throws Exception {
+    void 목표_생성을_성공한다() throws Exception {
       // given
       CreateGoalRequest request = new CreateGoalRequest(validName, validColor, PrivacyType.PUBLIC);
       CreateGoalResponse response = new CreateGoalResponse(1L, validName, validColor);
@@ -193,10 +193,10 @@ class GoalControllerTest {
   }
 
   @Nested
-  class 목표_수정_API_테스트 {
+  class PUT_목표_수정_API_테스트 {
 
     @Test
-    void Put_목표_수정을_성공한다() throws Exception {
+    void 목표_수정을_성공한다() throws Exception {
       // given
       UpdateGoalRequest request = new UpdateGoalRequest(
           validName, GoalStatus.IN_PROGRESS, validColor, PrivacyType.PUBLIC);
@@ -224,10 +224,10 @@ class GoalControllerTest {
     }
 
     @Nested
-    class 단일_목표_조회_API_테스트 {
+    class GET_단일_목표_조회_API_테스트 {
 
       @Test
-      void 목표를_조회할_수_있다() throws Exception {
+      void 목표_조회를_성공한다() throws Exception {
         // given
         GoalResponse response = createGoalResponse();
 
@@ -249,7 +249,7 @@ class GoalControllerTest {
       }
 
       @Test
-      void Put_유효하지_않은_목표_상태가_입력된_경우_Bad_Request_응답을_반환한다() throws Exception {
+      void 유효하지_않은_목표_상태가_입력된_경우_Bad_Request_응답을_반환한다() throws Exception {
         // given
         String invalidRequestJson = """
             {
@@ -278,7 +278,7 @@ class GoalControllerTest {
       }
 
       @Test
-      void Put_유효하지_않은_공개_설정이_입력된_경우_Bad_Request_응답을_반환한다() throws Exception {
+      void 유효하지_않은_공개_설정이_입력된_경우_Bad_Request_응답을_반환한다() throws Exception {
         // given
         String invalidRequestJson = """
             {
@@ -336,10 +336,10 @@ class GoalControllerTest {
     }
 
     @Nested
-    class 전체_목표_조회_API_테스트 {
+    class GET_전체_목표_조회_API_테스트 {
 
       @Test
-      void Get_사용자의_전체_목표를_조회할_수_있다() throws Exception {
+      void 사용자의_전체_목표_조회를_성공한다() throws Exception {
         // given
         List<GoalSummaryResponse> response = createGoalSummaryDTO();
         GoalSummaryResponse firstElement = response.get(0);
@@ -361,7 +361,7 @@ class GoalControllerTest {
       }
 
       @Test
-      void Get_사용자가_존재하지_않은_경우_404_Not_Found_응답을_반환한다() throws Exception {
+      void 사용자가_존재하지_않은_경우_Not_Found_응답을_반환한다() throws Exception {
         // given
         String invalidUserId = "-1";
         given(goalService.getAllById(anyLong())).willThrow(
@@ -394,10 +394,10 @@ class GoalControllerTest {
   }
 
   @Nested
-  class 목표_삭제_API_테스트 {
+  class DELETE_목표_삭제_API_테스트 {
 
     @Test
-    void DELETE_목표_삭제를_성공한다() throws Exception {
+    void 목표_삭제를_성공한다() throws Exception {
       // when then
       mockMvc.perform(
               delete("/api/goals/{id}", 1L)
@@ -407,7 +407,7 @@ class GoalControllerTest {
     }
 
     @Test
-    void DELETE_리소스가_존재하지_않으면_404_Not_Found_응답을_반환한다() throws Exception {
+    void 리소스가_존재하지_않으면_Not_Found_응답을_반환한다() throws Exception {
       // given
       willThrow(new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."))
           .given(goalService)

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -231,7 +231,7 @@ class GoalControllerTest {
         // given
         GoalResponse response = createGoalResponse();
 
-        given(goalService.getById(anyLong())).willReturn(response);
+        given(goalService.findById(anyLong())).willReturn(response);
 
         // when then
         mockMvc.perform(
@@ -310,7 +310,7 @@ class GoalControllerTest {
       void ID가_유효하지_않으면_Not_Found_응답을_반환한다() throws Exception {
         // given
         Long invalidId = -1L;
-        given(goalService.getById(anyLong()))
+        given(goalService.findById(anyLong()))
             .willThrow(new EntityNotFoundException("해당 아이디를 가진 목표가 존재하지 않습니다."));
 
         // when then
@@ -344,7 +344,7 @@ class GoalControllerTest {
         List<GoalSummaryResponse> response = createGoalSummaryDTO();
         GoalSummaryResponse firstElement = response.get(0);
 
-        given(goalService.getAllById(anyLong())).willReturn(response);
+        given(goalService.findAllByUser(anyLong())).willReturn(response);
 
         // when then
         mockMvc.perform(
@@ -364,7 +364,7 @@ class GoalControllerTest {
       void 사용자가_존재하지_않은_경우_Not_Found_응답을_반환한다() throws Exception {
         // given
         String invalidUserId = "-1";
-        given(goalService.getAllById(anyLong())).willThrow(
+        given(goalService.findAllByUser(anyLong())).willThrow(
             new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."));
 
         // when then

--- a/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/ddudu/goal/controller/GoalControllerTest.java
@@ -4,6 +4,8 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -387,6 +389,38 @@ class GoalControllerTest {
         return List.of(goalSummaryResponse);
       }
 
+    }
+
+  }
+
+  @Nested
+  class 목표_삭제_API_테스트 {
+
+    @Test
+    void DELETE_목표_삭제를_성공한다() throws Exception {
+      // when then
+      mockMvc.perform(
+              delete("/api/goals/{id}", 1L)
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void DELETE_리소스가_존재하지_않으면_404_Not_Found_응답을_반환한다() throws Exception {
+      // given
+      willThrow(new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."))
+          .given(goalService)
+          .delete(anyLong());
+
+      // when then
+      mockMvc.perform(
+              delete("/api/goals/{id}", 1L)
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.message")
+              .value(containsString("해당 아이디를 가진 사용자가 존재하지 않습니다.")));
     }
 
   }

--- a/src/test/java/com/ddudu/goal/domain/GoalTest.java
+++ b/src/test/java/com/ddudu/goal/domain/GoalTest.java
@@ -171,6 +171,23 @@ class GoalTest {
 
   }
 
+  @Nested
+  class 목표_삭제_테스트 {
+
+    @Test
+    void 목표를_삭제_상태로_변경할_수_있다() {
+      // given
+      Goal goal = createGoal();
+
+      // when
+      goal.delete();
+
+      // then
+      assertThat(goal.isDeleted()).isEqualTo(true);
+    }
+
+  }
+
   private User createUser() {
     String email = faker.internet()
         .emailAddress();

--- a/src/test/java/com/ddudu/goal/domain/GoalTest.java
+++ b/src/test/java/com/ddudu/goal/domain/GoalTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ddudu.user.domain.User;
+import java.time.LocalDateTime;
 import java.util.List;
 import net.datafaker.Faker;
 import org.junit.jupiter.api.BeforeEach;
@@ -184,6 +185,21 @@ class GoalTest {
 
       // then
       assertThat(goal.isDeleted()).isEqualTo(true);
+    }
+
+    @Test
+    void 이미_삭제된_목표를_재삭제_하면_업데이트_시간이_변경되지_않는다() {
+      // given
+      Goal goal = createGoal();
+      goal.delete();
+      LocalDateTime beforeReDelete = goal.getUpdatedAt();
+
+      // when
+      goal.delete();
+
+      // then
+      assertThat(goal.isDeleted()).isEqualTo(true);
+      assertThat(goal.getUpdatedAt()).isEqualTo(beforeReDelete);
     }
 
   }

--- a/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
@@ -14,6 +14,7 @@ import com.ddudu.goal.dto.response.GoalSummaryResponse;
 import com.ddudu.goal.repository.GoalRepository;
 import com.ddudu.user.domain.User;
 import com.ddudu.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +47,9 @@ class GoalServiceTest {
 
   @Autowired
   UserRepository userRepository;
+
+  @Autowired
+  EntityManager entityManager;
 
   User user;
   String validName;
@@ -196,6 +200,7 @@ class GoalServiceTest {
       // given
       Goal goal = createGoal(user, validName);
       goal.delete();
+      flushAndClearPersistence();
 
       // when
       ThrowingCallable getGoal = () -> goalService.findById(goal.getId());
@@ -308,6 +313,7 @@ class GoalServiceTest {
 
       // when
       goalService.delete(goal.getId());
+      flushAndClearPersistence();
 
       // then
       Optional<Goal> foundAfterDeleted = goalRepository.findById(goal.getId());
@@ -347,6 +353,11 @@ class GoalServiceTest {
         .build();
 
     return userRepository.save(user);
+  }
+
+  private void flushAndClearPersistence() {
+    entityManager.flush();
+    entityManager.clear();
   }
 
 }

--- a/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
@@ -169,7 +169,7 @@ class GoalServiceTest {
       Long id = expected.getId();
 
       // when
-      GoalResponse actual = goalService.getById(id);
+      GoalResponse actual = goalService.findById(id);
 
       // then
       GoalStatus expectedStatus = expected.getStatus();
@@ -198,7 +198,7 @@ class GoalServiceTest {
       goal.delete();
 
       // when
-      ThrowingCallable getGoal = () -> goalService.getById(goal.getId());
+      ThrowingCallable getGoal = () -> goalService.findById(goal.getId());
 
       // then
       assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(getGoal)
@@ -211,7 +211,7 @@ class GoalServiceTest {
       Long invalidId = -1L;
 
       // when
-      ThrowingCallable getGoal = () -> goalService.getById(invalidId);
+      ThrowingCallable getGoal = () -> goalService.findById(invalidId);
 
       // then
       assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(getGoal)
@@ -229,7 +229,7 @@ class GoalServiceTest {
       List<Goal> expected = createGoals(user, List.of(validName));
 
       // when
-      List<GoalSummaryResponse> actual = goalService.getAllById(user.getId());
+      List<GoalSummaryResponse> actual = goalService.findAllByUser(user.getId());
 
       // then
       assertThat(actual).isNotEmpty();
@@ -259,7 +259,7 @@ class GoalServiceTest {
       Long invalidUserId = 1234567890L;
 
       // when
-      ThrowingCallable getGoals = () -> goalService.getAllById(invalidUserId);
+      ThrowingCallable getGoals = () -> goalService.findAllByUser(invalidUserId);
 
       // then
       assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(getGoals)

--- a/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
@@ -195,7 +195,7 @@ class GoalServiceTest {
     void 삭제된_목표의_ID인_경우_조회에_실패한다() {
       // given
       Goal goal = createGoal(user, validName);
-      goalRepository.delete(goal);
+      goal.delete();
 
       // when
       ThrowingCallable getGoal = () -> goalService.getById(goal.getId());

--- a/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/ddudu/goal/service/GoalServiceTest.java
@@ -192,6 +192,20 @@ class GoalServiceTest {
     }
 
     @Test
+    void 삭제된_목표의_ID인_경우_조회에_실패한다() {
+      // given
+      Goal goal = createGoal(user, validName);
+      goalRepository.delete(goal);
+
+      // when
+      ThrowingCallable getGoal = () -> goalService.getById(goal.getId());
+
+      // then
+      assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(getGoal)
+          .withMessage("해당 아이디를 가진 목표가 존재하지 않습니다.");
+    }
+
+    @Test
     void 유효하지_않은_ID인_경우_조회에_실패한다() {
       // given
       Long invalidId = -1L;
@@ -278,6 +292,26 @@ class GoalServiceTest {
           .get();
       assertThat(actual).extracting("name", "status", "color", "privacyType")
           .containsExactly(changedName, changedStatus, changedColor, changedPrivacyType);
+    }
+
+  }
+
+  @Nested
+  class 목표_삭제_테스트 {
+
+    @Test
+    void 목표를_삭제_할_수_있다() {
+      // given
+      Goal goal = createGoal(user, validName);
+      Optional<Goal> found = goalRepository.findById(goal.getId());
+      assertThat(found).isNotEmpty();
+
+      // when
+      goalService.delete(goal.getId());
+
+      // then
+      Optional<Goal> foundAfterDeleted = goalRepository.findById(goal.getId());
+      assertThat(foundAfterDeleted).isEmpty();
     }
 
   }

--- a/src/test/java/com/ddudu/user/controller/UserControllerTest.java
+++ b/src/test/java/com/ddudu/user/controller/UserControllerTest.java
@@ -127,7 +127,7 @@ class UserControllerTest {
           Arguments.of(
               "비밀번호가 " + shortPassword,
               new SignUpRequest(username, email, shortPassword, nickname, intro),
-              "비밀번호는 8자리 이상이어야 합니다."
+              "비밀번호는 영문, 숫자, 특수문자로 구성되어야 합니다."
           ),
           Arguments.of(
               "비밀번호가 " + weakPassword,


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #57

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x]  목표 삭제 기능을 구현한다.
- [x] 목표 삭제 테스트 코드를 작성한다.

## 논의해 보고 싶은 내용
- GoalService에서 목표 조회 기능에 `getById()`, `getAllById()` 네이밍을 붙이다가 생각한 건데, update(), delete()도 `updateById()`, `deleteById()`로 네이밍을 바꿀까요? 

- GoalRepository에 `findById()`, `findAllByUser()`를 JPQL로 구현을 했는데요! SpringDataJpa를 사용하면 JPQL을 사용할 필요없이 
```
Optional<Goal> findByIdAndIsDeletedIsFalse(Long id);
``` 
처럼 사용할 수 있더라구요! 그런데 메서드명이 너무 길어져서 저는 JPQL을 사용했는데, 어떤 방식이 나을까요?

- Delete를 하고 현재 NoContent를 반환하는데요! OK를 반환하고 body에 삭제된 리소스의 아이디를 보내는 것이 더 나을까요?
