### PR TITLE
@Login 애너테이션 구현

### DIFF
--- a/src/main/java/com/ddudu/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/ddudu/auth/exception/AuthErrorCode.java
@@ -6,7 +6,8 @@ public enum AuthErrorCode implements ErrorCode {
   INVALID_TOKEN_AUTHORITY(5001, "유효하지 않은 토큰 권한입니다."),
   BAD_TOKEN_CONTENT(5002, "유효하지 않은 토큰 형식입니다."),
   EMAIL_NOT_EXISTING(5002, "이메일을 찾을 수 없습니다."),
-  BAD_CREDENTIALS(5003, "잘못된 비밀번호 입니다.");
+  BAD_CREDENTIALS(5003, "잘못된 비밀번호 입니다."),
+  INVALID_AUTHENTICATION(5004, "인증 정보가 유효하지 않거나 누락되었습니다.");
 
   private final int code;
   private final String message;

--- a/src/main/java/com/ddudu/common/annotation/Login.java
+++ b/src/main/java/com/ddudu/common/annotation/Login.java
@@ -1,0 +1,12 @@
+package com.ddudu.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+
+}

--- a/src/main/java/com/ddudu/common/annotation/LoginUserArgumentResolver.java
+++ b/src/main/java/com/ddudu/common/annotation/LoginUserArgumentResolver.java
@@ -1,0 +1,42 @@
+package com.ddudu.common.annotation;
+
+import static com.ddudu.auth.exception.AuthErrorCode.INVALID_AUTHENTICATION;
+
+import com.ddudu.auth.jwt.JwtAuthToken;
+import com.ddudu.common.exception.InvalidAuthenticationException;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    boolean hasLoginAnnotation = parameter.getParameterAnnotation(Login.class) != null;
+    boolean hasLongType = parameter.getParameterType()
+        .equals(Long.class);
+
+    return hasLoginAnnotation && hasLongType;
+  }
+
+  @Override
+  public Object resolveArgument(
+      MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+      WebDataBinderFactory binderFactory
+  ) throws InvalidAuthenticationException {
+    Authentication authentication = SecurityContextHolder.getContext()
+        .getAuthentication();
+
+    if (authentication != null && authentication instanceof JwtAuthToken) {
+      JwtAuthToken jwtAuthToken = (JwtAuthToken) authentication;
+      return jwtAuthToken.getUserId();
+    }
+
+    throw new InvalidAuthenticationException(INVALID_AUTHENTICATION);
+  }
+
+}

--- a/src/main/java/com/ddudu/config/WebConfig.java
+++ b/src/main/java/com/ddudu/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.ddudu.config;
+
+import com.ddudu.common.annotation.LoginUserArgumentResolver;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(new LoginUserArgumentResolver());
+  }
+
+}

--- a/src/main/java/com/ddudu/user/controller/UserController.java
+++ b/src/main/java/com/ddudu/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.ddudu.user.controller;
 
-import com.ddudu.auth.jwt.JwtAuthToken;
+import com.ddudu.common.annotation.Login;
 import com.ddudu.user.dto.request.SignUpRequest;
 import com.ddudu.user.dto.response.SignUpResponse;
 import com.ddudu.user.dto.response.UserResponse;
@@ -9,7 +9,6 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,9 +36,11 @@ public class UserController {
   }
 
   @GetMapping("/me")
-  public ResponseEntity<UserResponse> validateToken(Authentication authentication) {
-    long userId = ((JwtAuthToken) authentication).getUserId();
-    UserResponse response = userService.findById(userId);
+  public ResponseEntity<UserResponse> validateToken(
+      @Login
+      Long loginId
+  ) {
+    UserResponse response = userService.findById(loginId);
 
     return ResponseEntity.ok(response);
   }


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #71 

## 🎊구현 내용
로그인한 유저 정보가 필요할 때마다 Authentication을 인자로 받아 
```java
long userId = ((JwtAuthToken) authentication).getUserId();
```
를 하는 것이 조금  번거롭고, 해당 로직이 여러 컨트롤러에서 중복이 될 것 같더라구요!
그래서 컨트롤러 메서드의 파라미터 앞에 `@Login long loginId` 를 하면, 바로 로그인 유저 아이디를 쓸 수 있도록 하고 싶어 
`LoginUserArgumentResolver`를 구현했습니다!

**Done**
- `@Login` 애너테이션 생성
- `LoginUserArgumentResolver ` 생성
- `LoginUserArgumentResolver` 등록
- `LoginUserArgumentResolver` 도입