### PR TITLE
이메일 및 비밀번호 변경 기능 구현

### DIFF
--- a/src/main/java/com/ddudu/user/controller/UserController.java
+++ b/src/main/java/com/ddudu/user/controller/UserController.java
@@ -12,9 +12,9 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,14 +44,14 @@ public class UserController {
   @GetMapping("/me")
   public ResponseEntity<UserResponse> validateToken(
       @Login
-      Long loginId
+          Long loginId
   ) {
     UserResponse response = userService.findById(loginId);
 
     return ResponseEntity.ok(response);
   }
 
-  @PutMapping("/{id}/email")
+  @PatchMapping("/{id}/email")
   public ResponseEntity<UserResponse> updateEmail(
       @PathVariable
           Long id,
@@ -65,7 +65,7 @@ public class UserController {
     return ResponseEntity.ok(response);
   }
 
-  @PutMapping("/{id}/password")
+  @PatchMapping("/{id}/password")
   public ResponseEntity<String> updatePassword(
       @PathVariable
           Long id,

--- a/src/main/java/com/ddudu/user/controller/UserController.java
+++ b/src/main/java/com/ddudu/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.ddudu.user.dto.request.SignUpRequest;
 import com.ddudu.user.dto.request.UpdateEmailRequest;
 import com.ddudu.user.dto.request.UpdatePasswordRequest;
 import com.ddudu.user.dto.response.SignUpResponse;
+import com.ddudu.user.dto.response.UpdatePasswordResponse;
 import com.ddudu.user.dto.response.UserResponse;
 import com.ddudu.user.service.UserService;
 import jakarta.validation.Valid;
@@ -23,8 +24,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
-
-  private static final String PASSWORD_UPDATE_SUCCESS = "비밀번호가 성공적으로 변경되었습니다.";
 
   private final UserService userService;
 
@@ -66,16 +65,16 @@ public class UserController {
   }
 
   @PatchMapping("/{id}/password")
-  public ResponseEntity<String> updatePassword(
+  public ResponseEntity<UpdatePasswordResponse> updatePassword(
       @PathVariable
           Long id,
       @RequestBody
       @Valid
           UpdatePasswordRequest request
   ) {
-    userService.updatePassword(id, request);
+    UpdatePasswordResponse response = userService.updatePassword(id, request);
 
-    return ResponseEntity.ok(PASSWORD_UPDATE_SUCCESS);
+    return ResponseEntity.ok(response);
   }
 
 }

--- a/src/main/java/com/ddudu/user/controller/UserController.java
+++ b/src/main/java/com/ddudu/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.ddudu.user.controller;
 
 import com.ddudu.auth.jwt.JwtAuthToken;
 import com.ddudu.user.dto.request.SignUpRequest;
+import com.ddudu.user.dto.request.UpdateEmailRequest;
+import com.ddudu.user.dto.request.UpdatePasswordRequest;
 import com.ddudu.user.dto.response.SignUpResponse;
 import com.ddudu.user.dto.response.UserResponse;
 import com.ddudu.user.service.UserService;
@@ -11,7 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,13 +25,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserController {
 
+  private static final String PASSWORD_UPDATE_SUCCESS = "비밀번호가 성공적으로 변경되었습니다.";
+
   private final UserService userService;
 
   @PostMapping
   public ResponseEntity<SignUpResponse> signUp(
       @RequestBody
       @Valid
-      SignUpRequest request
+          SignUpRequest request
   ) {
     SignUpResponse response = userService.signUp(request);
     URI uri = URI.create("/api/users/" + response.id());
@@ -42,6 +48,33 @@ public class UserController {
     UserResponse response = userService.findById(userId);
 
     return ResponseEntity.ok(response);
+  }
+
+  @PutMapping("/{id}/email")
+  public ResponseEntity<UserResponse> updateEmail(
+      @PathVariable
+          Long id,
+      @RequestBody
+      @Valid
+          UpdateEmailRequest request
+
+  ) {
+    UserResponse response = userService.updateEmail(id, request);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @PutMapping("/{id}/password")
+  public ResponseEntity<String> updatePassword(
+      @PathVariable
+          Long id,
+      @RequestBody
+      @Valid
+          UpdatePasswordRequest request
+  ) {
+    userService.updatePassword(id, request);
+
+    return ResponseEntity.ok(PASSWORD_UPDATE_SUCCESS);
   }
 
 }

--- a/src/main/java/com/ddudu/user/controller/UserController.java
+++ b/src/main/java/com/ddudu/user/controller/UserController.java
@@ -59,7 +59,6 @@ public class UserController {
       @RequestBody
       @Valid
           UpdateEmailRequest request
-
   ) {
     UserResponse response = userService.updateEmail(loginId, id, request);
 

--- a/src/main/java/com/ddudu/user/controller/UserController.java
+++ b/src/main/java/com/ddudu/user/controller/UserController.java
@@ -52,6 +52,8 @@ public class UserController {
 
   @PatchMapping("/{id}/email")
   public ResponseEntity<UserResponse> updateEmail(
+      @Login
+          Long loginId,
       @PathVariable
           Long id,
       @RequestBody
@@ -59,20 +61,22 @@ public class UserController {
           UpdateEmailRequest request
 
   ) {
-    UserResponse response = userService.updateEmail(id, request);
+    UserResponse response = userService.updateEmail(loginId, id, request);
 
     return ResponseEntity.ok(response);
   }
 
   @PatchMapping("/{id}/password")
   public ResponseEntity<UpdatePasswordResponse> updatePassword(
+      @Login
+          Long loginId,
       @PathVariable
           Long id,
       @RequestBody
       @Valid
           UpdatePasswordRequest request
   ) {
-    UpdatePasswordResponse response = userService.updatePassword(id, request);
+    UpdatePasswordResponse response = userService.updatePassword(loginId, id, request);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/ddudu/user/domain/User.java
+++ b/src/main/java/com/ddudu/user/domain/User.java
@@ -125,4 +125,12 @@ public class User extends BaseEntity {
     }
   }
 
+  public void applyEmailUpdate(Email newEmail) {
+    this.email = newEmail;
+  }
+
+  public void applyPasswordUpdate(Password newPassword) {
+    this.password = newPassword;
+  }
+
 }

--- a/src/main/java/com/ddudu/user/dto/request/UpdateEmailRequest.java
+++ b/src/main/java/com/ddudu/user/dto/request/UpdateEmailRequest.java
@@ -1,0 +1,12 @@
+package com.ddudu.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateEmailRequest(
+    @NotBlank(message = "이메일이 입력되지 않았습니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    String email
+) {
+
+}

--- a/src/main/java/com/ddudu/user/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/ddudu/user/dto/request/UpdatePasswordRequest.java
@@ -7,7 +7,7 @@ public record UpdatePasswordRequest(
     @NotBlank(message = "비밀번호가 입력되지 않았습니다.")
     @Pattern(
         regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@!%*#?&^]).{8,50}$",
-        message = "비밀번호는 영문, 숫자, 특수문자로 구성되어야 합니다."
+        message = "비밀번호는 8자리 이상의 영문, 숫자, 특수문자로 구성되어야 합니다."
     )
     String password
 ) {

--- a/src/main/java/com/ddudu/user/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/ddudu/user/dto/request/UpdatePasswordRequest.java
@@ -1,0 +1,15 @@
+package com.ddudu.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdatePasswordRequest(
+    @NotBlank(message = "비밀번호가 입력되지 않았습니다.")
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@!%*#?&^]).{8,50}$",
+        message = "비밀번호는 영문, 숫자, 특수문자로 구성되어야 합니다."
+    )
+    String password
+) {
+
+}

--- a/src/main/java/com/ddudu/user/dto/response/UpdatePasswordResponse.java
+++ b/src/main/java/com/ddudu/user/dto/response/UpdatePasswordResponse.java
@@ -1,0 +1,5 @@
+package com.ddudu.user.dto.response;
+
+public record UpdatePasswordResponse(String message) {
+
+}

--- a/src/main/java/com/ddudu/user/exception/UserErrorCode.java
+++ b/src/main/java/com/ddudu/user/exception/UserErrorCode.java
@@ -20,8 +20,7 @@ public enum UserErrorCode implements ErrorCode {
   ID_NOT_EXISTING(1014, "해당 아이디를 가진 사용자가 존재하지 않습니다."),
   DUPLICATE_EXISTING_EMAIL(1016, "기존 이메일과 동일한 이메일입니다."),
   DUPLICATE_EXISTING_PASSWORD(1017, "기존 비밀번호와 동일한 비밀번호입니다.");
-
-
+  
   private final int code;
   private final String message;
 

--- a/src/main/java/com/ddudu/user/exception/UserErrorCode.java
+++ b/src/main/java/com/ddudu/user/exception/UserErrorCode.java
@@ -17,6 +17,7 @@ public enum UserErrorCode implements ErrorCode {
   DUPLICATE_EMAIL(1011, "이미 존재하는 이메일입니다."),
   DUPLICATE_OPTIONAL_USERNAME(1012, "이미 존재하는 아이디입니다."),
   INVALID_AUTHENTICATION(1013, "토큰과 사용자의 정보가 일치하지 않습니다."),
+  ID_NOT_EXISTING(1014, "해당 아이디를 가진 사용자가 존재하지 않습니다."),
   DUPLICATE_EXISTING_EMAIL(1016, "기존 이메일과 동일한 이메일입니다."),
   DUPLICATE_EXISTING_PASSWORD(1017, "기존 비밀번호와 동일한 비밀번호입니다.");
 

--- a/src/main/java/com/ddudu/user/exception/UserErrorCode.java
+++ b/src/main/java/com/ddudu/user/exception/UserErrorCode.java
@@ -16,7 +16,10 @@ public enum UserErrorCode implements ErrorCode {
   INVALID_PASSWORD_FORMAT(1010, "비밀번호는 영문, 숫자, 특수문자로 구성되어야 합니다."),
   DUPLICATE_EMAIL(1011, "이미 존재하는 이메일입니다."),
   DUPLICATE_OPTIONAL_USERNAME(1012, "이미 존재하는 아이디입니다."),
-  INVALID_AUTHENTICATION(1013, "토큰과 사용자의 정보가 일치하지 않습니다.");
+  INVALID_AUTHENTICATION(1013, "토큰과 사용자의 정보가 일치하지 않습니다."),
+  DUPLICATE_EXISTING_EMAIL(1016, "기존 이메일과 동일한 이메일입니다."),
+  DUPLICATE_EXISTING_PASSWORD(1017, "기존 비밀번호와 동일한 비밀번호입니다.");
+
 
   private final int code;
   private final String message;

--- a/src/main/java/com/ddudu/user/service/UserService.java
+++ b/src/main/java/com/ddudu/user/service/UserService.java
@@ -66,7 +66,7 @@ public class UserService {
   @Transactional
   public UserResponse updateEmail(Long userId, UpdateEmailRequest request) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new InvalidTokenException(UserErrorCode.INVALID_AUTHENTICATION));
+        .orElseThrow(() -> new InvalidTokenException(UserErrorCode.ID_NOT_EXISTING));
     Email newEmail = new Email(request.email());
 
     if (user.getEmail()
@@ -86,7 +86,7 @@ public class UserService {
   @Transactional
   public void updatePassword(Long userId, UpdatePasswordRequest request) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new InvalidTokenException(UserErrorCode.INVALID_AUTHENTICATION));
+        .orElseThrow(() -> new InvalidTokenException(UserErrorCode.ID_NOT_EXISTING));
     Password password = user.getPassword();
     Password newPassword = new Password(request.password(), passwordEncoder);
 

--- a/src/main/java/com/ddudu/user/service/UserService.java
+++ b/src/main/java/com/ddudu/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.ddudu.user.service;
 
+import com.ddudu.common.exception.DataNotFoundException;
 import com.ddudu.common.exception.DuplicateResourceException;
 import com.ddudu.common.exception.InvalidTokenException;
 import com.ddudu.user.domain.Email;
@@ -67,14 +68,18 @@ public class UserService {
   }
 
   @Transactional
-  public UserResponse updateEmail(Long userId, UpdateEmailRequest request) {
+  public UserResponse updateEmail(Long loginId, Long userId, UpdateEmailRequest request) {
+    if (!loginId.equals(userId)) {
+      throw new InvalidTokenException(UserErrorCode.INVALID_AUTHENTICATION);
+    }
+
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new InvalidTokenException(UserErrorCode.ID_NOT_EXISTING));
+        .orElseThrow(() -> new DataNotFoundException(UserErrorCode.ID_NOT_EXISTING));
     Email newEmail = new Email(request.email());
 
     if (user.getEmail()
         .equals(newEmail.getAddress())) {
-      throw new DuplicateResourceException(UserErrorCode.DUPLICATE_EXISTING_PASSWORD);
+      throw new DuplicateResourceException(UserErrorCode.DUPLICATE_EXISTING_EMAIL);
     }
 
     if (userRepository.existsByEmail(newEmail)) {
@@ -87,9 +92,15 @@ public class UserService {
   }
 
   @Transactional
-  public UpdatePasswordResponse updatePassword(Long userId, UpdatePasswordRequest request) {
+  public UpdatePasswordResponse updatePassword(
+      Long loginId, Long userId, UpdatePasswordRequest request
+  ) {
+    if (!loginId.equals(userId)) {
+      throw new InvalidTokenException(UserErrorCode.INVALID_AUTHENTICATION);
+    }
+
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new InvalidTokenException(UserErrorCode.ID_NOT_EXISTING));
+        .orElseThrow(() -> new DataNotFoundException(UserErrorCode.ID_NOT_EXISTING));
     Password password = user.getPassword();
     Password newPassword = new Password(request.password(), passwordEncoder);
 

--- a/src/main/java/com/ddudu/user/service/UserService.java
+++ b/src/main/java/com/ddudu/user/service/UserService.java
@@ -10,6 +10,7 @@ import com.ddudu.user.dto.request.SignUpRequest;
 import com.ddudu.user.dto.request.UpdateEmailRequest;
 import com.ddudu.user.dto.request.UpdatePasswordRequest;
 import com.ddudu.user.dto.response.SignUpResponse;
+import com.ddudu.user.dto.response.UpdatePasswordResponse;
 import com.ddudu.user.dto.response.UserResponse;
 import com.ddudu.user.exception.UserErrorCode;
 import com.ddudu.user.repository.UserRepository;
@@ -23,6 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
+
+  private static final String PASSWORD_UPDATE_SUCCESS = "비밀번호가 성공적으로 변경되었습니다.";
 
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
@@ -84,7 +87,7 @@ public class UserService {
   }
 
   @Transactional
-  public void updatePassword(Long userId, UpdatePasswordRequest request) {
+  public UpdatePasswordResponse updatePassword(Long userId, UpdatePasswordRequest request) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new InvalidTokenException(UserErrorCode.ID_NOT_EXISTING));
     Password password = user.getPassword();
@@ -95,6 +98,8 @@ public class UserService {
     }
 
     user.applyPasswordUpdate(newPassword);
+
+    return new UpdatePasswordResponse(PASSWORD_UPDATE_SUCCESS);
   }
 
 }

--- a/src/test/java/com/ddudu/user/controller/UserControllerTest.java
+++ b/src/test/java/com/ddudu/user/controller/UserControllerTest.java
@@ -4,11 +4,9 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -22,6 +20,7 @@ import com.ddudu.user.dto.request.SignUpRequest;
 import com.ddudu.user.dto.request.UpdateEmailRequest;
 import com.ddudu.user.dto.request.UpdatePasswordRequest;
 import com.ddudu.user.dto.response.SignUpResponse;
+import com.ddudu.user.dto.response.UpdatePasswordResponse;
 import com.ddudu.user.dto.response.UserResponse;
 import com.ddudu.user.exception.UserErrorCode;
 import com.ddudu.user.service.UserService;
@@ -405,9 +404,11 @@ class UserControllerTest {
       String newPassword = faker.internet()
           .password(8, 40, true, true, true);
       UpdatePasswordRequest request = new UpdatePasswordRequest(newPassword);
+      String successMessage = "비밀번호가 성공적으로 변경되었습니다.";
+      UpdatePasswordResponse response = new UpdatePasswordResponse(successMessage);
 
-      willDoNothing().given(userService)
-          .updatePassword(anyLong(), any(UpdatePasswordRequest.class));
+      given(userService.updatePassword(anyLong(), any(UpdatePasswordRequest.class)))
+          .willReturn(response);
 
       // when
       ResultActions actions = mockMvc.perform(patch("/api/users/{id}/password", userId)
@@ -416,7 +417,7 @@ class UserControllerTest {
 
       // then
       actions.andExpect(status().isOk())
-          .andExpect(content().string("비밀번호가 성공적으로 변경되었습니다."));
+          .andExpect(jsonPath("$.message").value(successMessage));
     }
 
   }

--- a/src/test/java/com/ddudu/user/controller/UserControllerTest.java
+++ b/src/test/java/com/ddudu/user/controller/UserControllerTest.java
@@ -6,8 +6,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -277,7 +277,7 @@ class UserControllerTest {
   }
 
   @Nested
-  class PUT_이메일_변경_API_테스트 {
+  class PATCH_이메일_변경_API_테스트 {
 
     static Stream<Arguments> provideUpdateEmailRequestAndStrings() {
       String wrongEmail = faker.internet()
@@ -311,7 +311,7 @@ class UserControllerTest {
           .nextLong();
 
       // when
-      ResultActions actions = mockMvc.perform(put("/api/users/{id}/email", userId)
+      ResultActions actions = mockMvc.perform(patch("/api/users/{id}/email", userId)
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(request)));
 
@@ -339,7 +339,7 @@ class UserControllerTest {
           .willReturn(response);
 
       // when
-      ResultActions actions = mockMvc.perform(put("/api/users/{id}/email", userId)
+      ResultActions actions = mockMvc.perform(patch("/api/users/{id}/email", userId)
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(request)));
 
@@ -351,7 +351,7 @@ class UserControllerTest {
   }
 
   @Nested
-  class 비밀번호_변경_API_테스트 {
+  class PATCH_비밀번호_변경_API_테스트 {
 
     static Stream<Arguments> provideUpdatePasswordRequestAndStrings() {
       String shortPassword = faker.internet()
@@ -387,7 +387,7 @@ class UserControllerTest {
           .nextLong();
 
       // when
-      ResultActions actions = mockMvc.perform(put("/api/users/{id}/password", userId)
+      ResultActions actions = mockMvc.perform(patch("/api/users/{id}/password", userId)
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(request)));
 
@@ -410,7 +410,7 @@ class UserControllerTest {
           .updatePassword(anyLong(), any(UpdatePasswordRequest.class));
 
       // when
-      ResultActions actions = mockMvc.perform(put("/api/users/{id}/password", userId)
+      ResultActions actions = mockMvc.perform(patch("/api/users/{id}/password", userId)
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(request)));
 

--- a/src/test/java/com/ddudu/user/controller/UserControllerTest.java
+++ b/src/test/java/com/ddudu/user/controller/UserControllerTest.java
@@ -369,12 +369,12 @@ class UserControllerTest {
           Arguments.of(
               "비밀번호가 " + shortPassword,
               new UpdatePasswordRequest(shortPassword),
-              "비밀번호는 영문, 숫자, 특수문자로 구성되어야 합니다."
+              "비밀번호는 8자리 이상의 영문, 숫자, 특수문자로 구성되어야 합니다."
           ),
           Arguments.of(
               "비밀번호가 " + weakPassword,
               new UpdatePasswordRequest(weakPassword),
-              "비밀번호는 영문, 숫자, 특수문자로 구성되어야 합니다."
+              "비밀번호는 8자리 이상의 영문, 숫자, 특수문자로 구성되어야 합니다."
           )
       );
     }
@@ -408,7 +408,7 @@ class UserControllerTest {
       long userId = faker.random()
           .nextLong();
       String token = createBearerToken(userId);
-      
+
       String newPassword = faker.internet()
           .password(8, 40, true, true, true);
       UpdatePasswordRequest request = new UpdatePasswordRequest(newPassword);

--- a/src/test/java/com/ddudu/user/service/UserServiceTest.java
+++ b/src/test/java/com/ddudu/user/service/UserServiceTest.java
@@ -225,7 +225,7 @@ class UserServiceTest {
 
       // then
       assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(updateEmail)
-          .withMessage(UserErrorCode.INVALID_AUTHENTICATION.getMessage());
+          .withMessage(UserErrorCode.ID_NOT_EXISTING.getMessage());
     }
 
     @Test
@@ -317,7 +317,7 @@ class UserServiceTest {
 
       // then
       assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(updatePassword)
-          .withMessage(UserErrorCode.INVALID_AUTHENTICATION.getMessage());
+          .withMessage(UserErrorCode.ID_NOT_EXISTING.getMessage());
     }
 
     @Test

--- a/src/test/java/com/ddudu/user/service/UserServiceTest.java
+++ b/src/test/java/com/ddudu/user/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.ddudu.auth.jwt.converter.JwtConverter;
+import com.ddudu.common.exception.DataNotFoundException;
 import com.ddudu.common.exception.DuplicateResourceException;
 import com.ddudu.common.exception.InvalidTokenException;
 import com.ddudu.user.domain.User;
@@ -91,16 +92,6 @@ class UserServiceTest {
           Arguments.of(new SignUpRequest(username, email, password, nickname, null), "자기소개만 미입력"),
           Arguments.of(new SignUpRequest(null, email, password, nickname, null), "선택 아이디와 자기소개 미입력")
       );
-    }
-
-    @BeforeEach
-    void setUp() {
-      builderWithEncoder = User.builder()
-          .passwordEncoder(passwordEncoder);
-      password = faker.internet()
-          .password(8, 40, true, true, true);
-      nickname = faker.oscarMovie()
-          .character();
     }
 
     @Test
@@ -212,6 +203,25 @@ class UserServiceTest {
   class 이메일_변경_테스트 {
 
     @Test
+    void 로그인한_사용자와_이메일_변경할_사용자가_다르면_변경을_실패한다() {
+      // given
+      long loginRandomId = faker.random()
+          .nextLong();
+      long randomId = faker.random()
+          .nextLong();
+      String newEmail = faker.internet()
+          .emailAddress();
+
+      // when
+      ThrowingCallable updateEmail = () -> userService.updateEmail(
+          loginRandomId, randomId, new UpdateEmailRequest(newEmail));
+
+      // then
+      assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(updateEmail)
+          .withMessage(UserErrorCode.INVALID_AUTHENTICATION.getMessage());
+    }
+
+    @Test
     void 존재하지_않는_사용자_아이디_이메일_변경을_실패한다() {
       // given
       long randomId = faker.random()
@@ -221,10 +231,10 @@ class UserServiceTest {
 
       // when
       ThrowingCallable updateEmail = () -> userService.updateEmail(
-          randomId, new UpdateEmailRequest(newEmail));
+          randomId, randomId, new UpdateEmailRequest(newEmail));
 
       // then
-      assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(updateEmail)
+      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(updateEmail)
           .withMessage(UserErrorCode.ID_NOT_EXISTING.getMessage());
     }
 
@@ -241,11 +251,12 @@ class UserServiceTest {
       UpdateEmailRequest request = new UpdateEmailRequest(email);
 
       // when
-      ThrowingCallable updateEmail = () -> userService.updateEmail(user.getId(), request);
+      ThrowingCallable updateEmail = () -> userService.updateEmail(
+          user.getId(), user.getId(), request);
 
       // then
       assertThatExceptionOfType(DuplicateResourceException.class).isThrownBy(updateEmail)
-          .withMessage(UserErrorCode.DUPLICATE_EXISTING_PASSWORD.getMessage());
+          .withMessage(UserErrorCode.DUPLICATE_EXISTING_EMAIL.getMessage());
     }
 
     @Test
@@ -267,7 +278,8 @@ class UserServiceTest {
       UpdateEmailRequest request = new UpdateEmailRequest(email2);
 
       // when
-      ThrowingCallable updateEmail = () -> userService.updateEmail(user1.getId(), request);
+      ThrowingCallable updateEmail = () -> userService.updateEmail(
+          user1.getId(), user1.getId(), request);
 
       // then
       assertThatExceptionOfType(DuplicateResourceException.class).isThrownBy(updateEmail)
@@ -284,13 +296,14 @@ class UserServiceTest {
           .nickname(nickname)
           .build();
       User savedUser = userRepository.save(user);
+      Long userId = user.getId();
 
       String newEmail = faker.internet()
           .emailAddress();
       UpdateEmailRequest updateEmailRequest = new UpdateEmailRequest(newEmail);
 
       // when
-      userService.updateEmail(savedUser.getId(), updateEmailRequest);
+      userService.updateEmail(userId, userId, updateEmailRequest);
 
       // then
       User updatedUser = userRepository.findById(savedUser.getId())
@@ -304,6 +317,25 @@ class UserServiceTest {
   class 비밀번호_변경_테스트 {
 
     @Test
+    void 로그인한_사용자와_비밀번호_변경할_사용자가_다르면_변경을_실패한다() {
+      // given
+      long loginRandomId = faker.random()
+          .nextLong();
+      long randomId = faker.random()
+          .nextLong();
+      String newPassword = faker.internet()
+          .password(8, 40, true, true, true);
+
+      // when
+      ThrowingCallable updatePassword = () -> userService.updatePassword(
+          loginRandomId, randomId, new UpdatePasswordRequest(newPassword));
+
+      // then
+      assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(updatePassword)
+          .withMessage(UserErrorCode.INVALID_AUTHENTICATION.getMessage());
+    }
+
+    @Test
     void 존재하지_않는_사용자_아이디_비밀번호_변경을_실패한다() {
       // given
       long randomId = faker.random()
@@ -313,15 +345,15 @@ class UserServiceTest {
 
       // when
       ThrowingCallable updatePassword = () -> userService.updatePassword(
-          randomId, new UpdatePasswordRequest(newPassword));
+          randomId, randomId, new UpdatePasswordRequest(newPassword));
 
       // then
-      assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(updatePassword)
+      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(updatePassword)
           .withMessage(UserErrorCode.ID_NOT_EXISTING.getMessage());
     }
 
     @Test
-    void 변경할_이메일이_기존_이메일과_동일한_경우_이메일_변경을_실패한다() {
+    void 변경할_비밀번호가_기존_비밀번호와_동일한_경우_비밀번호_변경을_실패한다() {
       // given
       String email = faker.internet()
           .emailAddress();
@@ -329,11 +361,12 @@ class UserServiceTest {
           .password(password)
           .nickname(nickname)
           .build();
-      userRepository.save(user);
+      User savedUser = userRepository.save(user);
+      Long userId = savedUser.getId();
       UpdatePasswordRequest request = new UpdatePasswordRequest(password);
 
       // when
-      ThrowingCallable updatePassword = () -> userService.updatePassword(user.getId(), request);
+      ThrowingCallable updatePassword = () -> userService.updatePassword(userId, userId, request);
 
       // then
       assertThatExceptionOfType(DuplicateResourceException.class).isThrownBy(updatePassword)
@@ -355,10 +388,11 @@ class UserServiceTest {
           .nickname(nickname)
           .build();
       User savedUser = userRepository.save(user);
+      Long userId = savedUser.getId();
       UpdatePasswordRequest updatePasswordRequest = new UpdatePasswordRequest(newPassword);
 
       // when
-      userService.updatePassword(savedUser.getId(), updatePasswordRequest);
+      userService.updatePassword(userId, userId, updatePasswordRequest);
 
       // then
       User updatedUser = userRepository.findById(savedUser.getId())


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #45 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] [이메일 변경 API 설계](https://www.notion.so/backend-devcourse/1b012612aa324bac8119de7cb032d97f?pvs=4)
- [x] [비밀번호 변경 API 설계](https://www.notion.so/backend-devcourse/8647e23471ea438e8f49420a55b2df02?pvs=4)
- [x] 이메일 및 비밀번호 변경 기능 구현
- [x] 테스트 코드 작성

## 코멘트
* 이메일 변경 시, 변경 전 이메일과 변경할 이메일이 동일하거나 변경할 이메일이 중복되면 이메일 변경에 실패합니다.
* 비밀번호 변경 시, 변경 전 비밀번호와 변경할 비밀번호가 동일하면 비밀번호 변경에 실패합니다.