### PR TITLE
할 일 삭제 기능 구현

### DIFF
--- a/src/main/java/com/ddudu/common/exception/ForbiddenException.java
+++ b/src/main/java/com/ddudu/common/exception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package com.ddudu.common.exception;
+
+public class ForbiddenException extends BusinessException {
+
+  public ForbiddenException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+}

--- a/src/main/java/com/ddudu/common/exception/GeneralExceptionHandler.java
+++ b/src/main/java/com/ddudu/common/exception/GeneralExceptionHandler.java
@@ -81,6 +81,18 @@ public class GeneralExceptionHandler {
         .body(response);
   }
 
+  @ExceptionHandler(ForbiddenException.class)
+  public ResponseEntity<ErrorResponse> handleForbiddenException(
+      ForbiddenException e
+  ) {
+    log.warn(e.getMessage(), e);
+
+    ErrorResponse response = ErrorResponse.from(e);
+
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .body(response);
+  }
+
   @ExceptionHandler(DataNotFoundException.class)
   public ResponseEntity<ErrorResponse> handleDataNotFoundException(DataNotFoundException e) {
     log.warn(e.getMessage(), e);

--- a/src/main/java/com/ddudu/todo/controller/TodoController.java
+++ b/src/main/java/com/ddudu/todo/controller/TodoController.java
@@ -1,5 +1,6 @@
 package com.ddudu.todo.controller;
 
+import com.ddudu.common.annotation.Login;
 import com.ddudu.todo.dto.request.CreateTodoRequest;
 import com.ddudu.todo.dto.response.TodoCompletionResponse;
 import com.ddudu.todo.dto.response.TodoInfo;
@@ -15,6 +16,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -100,6 +102,19 @@ public class TodoController {
   ) {
     TodoResponse response = todoService.updateStatus(id);
     return ResponseEntity.ok(response);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity delete(
+      @Login
+      Long userId,
+      @PathVariable
+      Long id
+  ) {
+    todoService.delete(userId, id);
+
+    return ResponseEntity.noContent()
+        .build();
   }
 
 }

--- a/src/main/java/com/ddudu/todo/exception/TodoErrorCode.java
+++ b/src/main/java/com/ddudu/todo/exception/TodoErrorCode.java
@@ -9,7 +9,8 @@ public enum TodoErrorCode implements ErrorCode {
   EXCESSIVE_NAME_LENGTH(2003, "할 일 내용이 최대 글자수를 초과했습니다."),
   ID_NOT_EXISTING(2004, "할 일 아이디가 존재하지 않습니다."),
   GOAL_NOT_EXISTING(2005, "목표 아이디가 존재하지 않습니다."),
-  USER_NOT_EXISTING(2006, "사용자 아이디가 존재하지 않습니다.");
+  USER_NOT_EXISTING(2006, "사용자 아이디가 존재하지 않습니다."),
+  INVALID_AUTHORITY(2007, "해당 기능에 대한 사용자 권한이 없습니다.");
 
   private final int code;
   private final String message;

--- a/src/main/java/com/ddudu/todo/service/TodoService.java
+++ b/src/main/java/com/ddudu/todo/service/TodoService.java
@@ -1,6 +1,7 @@
 package com.ddudu.todo.service;
 
 import com.ddudu.common.exception.DataNotFoundException;
+import com.ddudu.common.exception.ForbiddenException;
 import com.ddudu.goal.domain.Goal;
 import com.ddudu.goal.repository.GoalRepository;
 import com.ddudu.todo.domain.Todo;
@@ -22,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -106,6 +108,25 @@ public class TodoService {
     LocalDateTime endDate = startDate.plusMonths(1);
 
     return generateCompletions(startDate, endDate);
+  }
+
+  @Transactional
+  public void delete(Long loginId, Long id) {
+    Optional<Todo> optionalTodo = todoRepository.findById(id);
+
+    if (optionalTodo.isEmpty()) {
+      return;
+    }
+
+    Todo todo = optionalTodo.get();
+    Long userId = todo.getUser()
+        .getId();
+
+    if (!userId.equals(loginId)) {
+      throw new ForbiddenException(TodoErrorCode.INVALID_AUTHORITY);
+    }
+
+    todo.delete();
   }
 
   private List<TodoCompletionResponse> generateCompletions(

--- a/src/test/java/com/ddudu/todo/controller/TodoControllerTest.java
+++ b/src/test/java/com/ddudu/todo/controller/TodoControllerTest.java
@@ -1,9 +1,12 @@
 package com.ddudu.todo.controller;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -11,7 +14,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.ddudu.auth.domain.authority.Authority;
 import com.ddudu.common.exception.DataNotFoundException;
+import com.ddudu.common.exception.ForbiddenException;
 import com.ddudu.config.JwtConfig;
 import com.ddudu.config.WebSecurityConfig;
 import com.ddudu.support.TestProperties;
@@ -22,6 +27,7 @@ import com.ddudu.todo.dto.response.TodoCompletionResponse;
 import com.ddudu.todo.dto.response.TodoInfo;
 import com.ddudu.todo.dto.response.TodoListResponse;
 import com.ddudu.todo.dto.response.TodoResponse;
+import com.ddudu.todo.exception.TodoErrorCode;
 import com.ddudu.todo.service.TodoService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.DayOfWeek;
@@ -44,6 +50,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = TodoController.class)
@@ -61,6 +73,9 @@ class TodoControllerTest {
 
   @Autowired
   ObjectMapper objectMapper;
+
+  @Autowired
+  JwtEncoder jwtEncoder;
 
   @Nested
   class POST_할_일_생성_API_테스트 {
@@ -377,6 +392,68 @@ class TodoControllerTest {
       mockMvc.perform(patch("/api/todos/{id}/status", invalidId)
               .contentType(MediaType.APPLICATION_JSON))
           .andExpect(status().isNotFound());
+    }
+
+  }
+
+  @Nested
+  class DELETE_할_일_삭제_테스트 {
+
+    static final JwsHeader header = JwsHeader.with(MacAlgorithm.HS512)
+        .build();
+    static final JwtClaimsSet.Builder claimSet = JwtClaimsSet.builder()
+        .claim("auth", Authority.NORMAL);
+
+    Long userId;
+
+    @BeforeEach
+    void setup() {
+      userId = faker.random()
+          .nextLong();
+    }
+
+    @Test
+    void 할_일_삭제에_성공한다() throws Exception {
+      // given
+      String token = createBearerToken(userId);
+
+      // when then
+      mockMvc.perform(
+              delete("/api/todos/{id}", userId)
+                  .header("Authorization", token)
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isNoContent());
+
+    }
+
+    @Test
+    void 할_일_삭제_권한이_없으면_Forbidden_응답을_반환한다() throws Exception {
+      // given
+      String token = createBearerToken(userId);
+
+      willThrow(new ForbiddenException(TodoErrorCode.INVALID_AUTHORITY))
+          .given(todoService)
+          .delete(anyLong(), anyLong());
+
+      // when then
+      mockMvc.perform(
+              delete("/api/todos/{id}", userId)
+                  .header("Authorization", token)
+                  .contentType(MediaType.APPLICATION_JSON)
+          )
+          .andExpect(status().isForbidden())
+          .andExpect(
+              jsonPath("$.code", is(TodoErrorCode.INVALID_AUTHORITY.getCode())))
+          .andExpect(
+              jsonPath("$.message", is(TodoErrorCode.INVALID_AUTHORITY.getMessage())));
+    }
+
+    private String createBearerToken(long userId) {
+      JwtClaimsSet claims = claimSet.claim("user", userId)
+          .build();
+      Jwt jwt = jwtEncoder.encode(JwtEncoderParameters.from(header, claims));
+      return "Bearer " + jwt.getTokenValue();
     }
 
   }

--- a/src/test/java/com/ddudu/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/ddudu/todo/service/TodoServiceTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
+import com.ddudu.auth.domain.authority.Authority;
 import com.ddudu.common.exception.DataNotFoundException;
+import com.ddudu.common.exception.ForbiddenException;
 import com.ddudu.goal.domain.Goal;
 import com.ddudu.goal.repository.GoalRepository;
 import com.ddudu.todo.domain.Todo;
@@ -18,11 +20,13 @@ import com.ddudu.todo.exception.TodoErrorCode;
 import com.ddudu.todo.repository.TodoRepository;
 import com.ddudu.user.domain.User;
 import com.ddudu.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Optional;
 import net.datafaker.Faker;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +37,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -53,6 +61,12 @@ class TodoServiceTest {
 
   @Autowired
   UserRepository userRepository;
+
+  @Autowired
+  EntityManager entityManager;
+
+  @Autowired
+  JwtEncoder jwtEncoder;
 
   @Nested
   class 할_일_생성_테스트 {
@@ -274,6 +288,66 @@ class TodoServiceTest {
 
   }
 
+  @Nested
+  class 할_일_삭제_테스트 {
+
+    static final JwsHeader header = JwsHeader.with(MacAlgorithm.HS512)
+        .build();
+    static final JwtClaimsSet.Builder claimSet = JwtClaimsSet.builder()
+        .claim("auth", Authority.NORMAL);
+
+    String validName;
+    String validGoalName;
+
+    @BeforeEach
+    void setUp() {
+      validName = faker.lorem()
+          .word();
+      validGoalName = faker.lorem()
+          .word();
+    }
+
+    @Test
+    void 할_일을_삭제_할_수_있다() {
+      // given
+      User user = createUser();
+      Goal goal = createGoal(validGoalName, user);
+      Todo todo = createTodo(validName, goal, user);
+
+      Optional<Todo> found = todoRepository.findById(todo.getId());
+      assertThat(found).isNotEmpty();
+
+      // when
+      todoService.delete(user.getId(), todo.getId());
+      flushAndClearPersistence();
+
+      // then
+      Optional<Todo> foundAfterDeleted = todoRepository.findById(todo.getId());
+      assertThat(foundAfterDeleted).isEmpty();
+    }
+
+    @Test
+    void 로그인_사용자_아이디와_삭제할_할_일_사용자_아이디가_다르면_삭제할_수_없다() {
+      // given
+      Long randomId = faker.random()
+          .nextLong();
+      User user = createUser();
+      Goal goal = createGoal(validGoalName, user);
+      Todo todo = createTodo(validName, goal, user);
+
+      Optional<Todo> found = todoRepository.findById(todo.getId());
+      assertThat(found).isNotEmpty();
+
+      // when
+      ThrowingCallable delete = () -> todoService.delete(randomId, todo.getId());
+
+      // then
+      assertThatExceptionOfType(ForbiddenException.class).isThrownBy(delete)
+          .withMessage(TodoErrorCode.INVALID_AUTHORITY.getMessage());
+    }
+
+  }
+
   private Goal createGoal(String name, User user) {
     Goal goal = Goal.builder()
         .name(name)
@@ -309,6 +383,11 @@ class TodoServiceTest {
         .build();
 
     return userRepository.save(user);
+  }
+
+  private void flushAndClearPersistence() {
+    entityManager.flush();
+    entityManager.clear();
   }
 
 }


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #77 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 로그인한 유저가 자신의 할 일만 삭제할 수 있도록, 서비스 로직에 검증을 추가했습니다!
- 만약 할 일의 유저와 로그인 유저가 다를 경우 `ForbiddenException(TodoErrorCode.INVALID_AUTHORITY)` 예외를 던집니다!
