### PR TITLE
할 일 좋아요 관련 기능 구현

### DIFF
--- a/src/main/java/com/ddudu/common/BaseEntity.java
+++ b/src/main/java/com/ddudu/common/BaseEntity.java
@@ -36,4 +36,10 @@ public class BaseEntity {
     }
   }
 
+  public void undelete() {
+    if (isDeleted) {
+      isDeleted = false;
+    }
+  }
+
 }

--- a/src/main/java/com/ddudu/like/controller/LikeController.java
+++ b/src/main/java/com/ddudu/like/controller/LikeController.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,6 +49,16 @@ public class LikeController {
 
     return ResponseEntity.noContent()
         .build();
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<LikeResponse> getById(
+      @PathVariable
+          Long id
+  ) {
+    LikeResponse response = likeService.findById(id);
+
+    return ResponseEntity.ok(response);
   }
 
 }

--- a/src/main/java/com/ddudu/like/controller/LikeController.java
+++ b/src/main/java/com/ddudu/like/controller/LikeController.java
@@ -5,11 +5,8 @@ import com.ddudu.like.dto.request.LikeRequest;
 import com.ddudu.like.dto.response.LikeResponse;
 import com.ddudu.like.service.LikeService;
 import jakarta.validation.Valid;
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,31 +20,16 @@ public class LikeController {
   private final LikeService likeService;
 
   @PostMapping
-  public ResponseEntity<LikeResponse> create(
+  public ResponseEntity<LikeResponse> toggle(
       @Login
           Long loginId,
       @RequestBody
       @Valid
           LikeRequest request
   ) {
-    LikeResponse response = likeService.create(loginId, request);
-    URI uri = URI.create("/api/likes/" + response.id());
+    LikeResponse response = likeService.toggle(loginId, request);
 
-    return ResponseEntity.created(uri)
-        .body(response);
-  }
-
-  @DeleteMapping("/{id}")
-  public ResponseEntity<Void> delete(
-      @Login
-          Long loginId,
-      @PathVariable
-          Long id
-  ) {
-    likeService.delete(loginId, id);
-
-    return ResponseEntity.noContent()
-        .build();
+    return ResponseEntity.ok(response);
   }
 
 }

--- a/src/main/java/com/ddudu/like/controller/LikeController.java
+++ b/src/main/java/com/ddudu/like/controller/LikeController.java
@@ -1,0 +1,38 @@
+package com.ddudu.like.controller;
+
+import com.ddudu.common.annotation.Login;
+import com.ddudu.like.dto.request.LikeRequest;
+import com.ddudu.like.dto.response.LikeResponse;
+import com.ddudu.like.service.LikeService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/likes")
+public class LikeController {
+
+  private final LikeService likeService;
+
+  @PostMapping
+  public ResponseEntity<LikeResponse> create(
+      @Login
+          Long loginId,
+      @RequestBody
+      @Valid
+          LikeRequest request
+  ) {
+    LikeResponse response = likeService.create(loginId, request);
+    URI uri = URI.create("/api/likes/" + response.id());
+
+    return ResponseEntity.created(uri)
+        .body(response);
+  }
+
+}

--- a/src/main/java/com/ddudu/like/controller/LikeController.java
+++ b/src/main/java/com/ddudu/like/controller/LikeController.java
@@ -9,7 +9,6 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -49,16 +48,6 @@ public class LikeController {
 
     return ResponseEntity.noContent()
         .build();
-  }
-
-  @GetMapping("/{id}")
-  public ResponseEntity<LikeResponse> getById(
-      @PathVariable
-          Long id
-  ) {
-    LikeResponse response = likeService.findById(id);
-
-    return ResponseEntity.ok(response);
   }
 
 }

--- a/src/main/java/com/ddudu/like/controller/LikeController.java
+++ b/src/main/java/com/ddudu/like/controller/LikeController.java
@@ -8,6 +8,8 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +35,19 @@ public class LikeController {
 
     return ResponseEntity.created(uri)
         .body(response);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(
+      @Login
+          Long loginId,
+      @PathVariable
+          Long id
+  ) {
+    likeService.delete(loginId, id);
+
+    return ResponseEntity.noContent()
+        .build();
   }
 
 }

--- a/src/main/java/com/ddudu/like/domain/Like.java
+++ b/src/main/java/com/ddudu/like/domain/Like.java
@@ -4,6 +4,7 @@ import com.ddudu.common.BaseEntity;
 import com.ddudu.common.exception.InvalidParameterException;
 import com.ddudu.like.exception.LikeErrorCode;
 import com.ddudu.todo.domain.Todo;
+import com.ddudu.todo.domain.TodoStatus;
 import com.ddudu.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -60,6 +61,11 @@ public class Like extends BaseEntity {
 
     if (user.equals(todo.getUser())) {
       throw new InvalidParameterException(LikeErrorCode.SELF_LIKE_UNAVAILABLE);
+    }
+
+    if (todo.getStatus()
+        .equals(TodoStatus.UNCOMPLETED)) {
+      throw new InvalidParameterException(LikeErrorCode.UNAVAILABLE_UNCOMPLETED_TODO);
     }
   }
 

--- a/src/main/java/com/ddudu/like/domain/Like.java
+++ b/src/main/java/com/ddudu/like/domain/Like.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
-@Table(name = "goal")
+@Table(name = "likes")
 @SQLRestriction("is_deleted = 0")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/src/main/java/com/ddudu/like/domain/Like.java
+++ b/src/main/java/com/ddudu/like/domain/Like.java
@@ -1,0 +1,66 @@
+package com.ddudu.like.domain;
+
+import com.ddudu.common.BaseEntity;
+import com.ddudu.common.exception.InvalidParameterException;
+import com.ddudu.like.exception.LikeErrorCode;
+import com.ddudu.todo.domain.Todo;
+import com.ddudu.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "goal")
+@SQLRestriction("is_deleted = 0")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Like extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "todo_id", nullable = false)
+  private Todo todo;
+
+  @Builder
+  public Like(User user, Todo todo) {
+    validate(user, todo);
+
+    this.user = user;
+    this.todo = todo;
+  }
+
+  private void validate(User user, Todo todo) {
+    if (Objects.isNull(user)) {
+      throw new InvalidParameterException(LikeErrorCode.NULL_USER);
+    }
+
+    if (Objects.isNull(todo)) {
+      throw new InvalidParameterException(LikeErrorCode.NULL_TODO);
+    }
+
+    if (user.equals(todo.getUser())) {
+      throw new InvalidParameterException(LikeErrorCode.SELF_LIKE_UNAVAILABLE);
+    }
+  }
+
+}

--- a/src/main/java/com/ddudu/like/domain/Like.java
+++ b/src/main/java/com/ddudu/like/domain/Like.java
@@ -20,11 +20,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "likes")
-@SQLRestriction("is_deleted = 0")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Like extends BaseEntity {

--- a/src/main/java/com/ddudu/like/dto/request/LikeRequest.java
+++ b/src/main/java/com/ddudu/like/dto/request/LikeRequest.java
@@ -1,0 +1,12 @@
+package com.ddudu.like.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record LikeRequest(
+    @NotNull(message = "좋아요를 누르려는 사용자의 아이디를 확인할 수 없습니다.")
+    Long userId,
+    @NotNull(message = "좋아요 대상 할 일의 아이디를 확인할 수 없습니다.")
+    Long todoId
+) {
+
+}

--- a/src/main/java/com/ddudu/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/ddudu/like/dto/response/LikeResponse.java
@@ -1,0 +1,19 @@
+package com.ddudu.like.dto.response;
+
+import com.ddudu.like.domain.Like;
+import lombok.Builder;
+
+@Builder
+public record LikeResponse(Long id, Long userId, Long todoId) {
+
+  public static LikeResponse from(Like like) {
+    return LikeResponse.builder()
+        .id(like.getId())
+        .userId(like.getUser()
+            .getId())
+        .todoId(like.getTodo()
+            .getId())
+        .build();
+  }
+
+}

--- a/src/main/java/com/ddudu/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/ddudu/like/dto/response/LikeResponse.java
@@ -4,16 +4,16 @@ import com.ddudu.like.domain.Like;
 import lombok.Builder;
 
 @Builder
-public record LikeResponse(Long id, Long userId, Long todoId, String message) {
+public record LikeResponse(Long id, Long userId, Long todoId, Boolean isDeleted) {
 
-  public static LikeResponse from(Like like, String message) {
+  public static LikeResponse from(Like like) {
     return LikeResponse.builder()
         .id(like.getId())
         .userId(like.getUser()
             .getId())
         .todoId(like.getTodo()
             .getId())
-        .message(message)
+        .isDeleted(like.isDeleted())
         .build();
   }
 

--- a/src/main/java/com/ddudu/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/ddudu/like/dto/response/LikeResponse.java
@@ -4,15 +4,16 @@ import com.ddudu.like.domain.Like;
 import lombok.Builder;
 
 @Builder
-public record LikeResponse(Long id, Long userId, Long todoId) {
+public record LikeResponse(Long id, Long userId, Long todoId, String message) {
 
-  public static LikeResponse from(Like like) {
+  public static LikeResponse from(Like like, String message) {
     return LikeResponse.builder()
         .id(like.getId())
         .userId(like.getUser()
             .getId())
         .todoId(like.getTodo()
             .getId())
+        .message(message)
         .build();
   }
 

--- a/src/main/java/com/ddudu/like/exception/LikeErrorCode.java
+++ b/src/main/java/com/ddudu/like/exception/LikeErrorCode.java
@@ -3,9 +3,14 @@ package com.ddudu.like.exception;
 import com.ddudu.common.exception.ErrorCode;
 
 public enum LikeErrorCode implements ErrorCode {
-  NULL_USER(7001, "사용자가 반드시 존재해야 합니다."),
-  NULL_TODO(7002, "좋아요할 할 일이 반드시 존재해야 합니다."),
-  SELF_LIKE_UNAVAILABLE(7003, "본인의 할 일에 좋아요를 할 수 없습니다.");
+  NULL_USER(7001, "사용자는 반드시 존재해야 합니다."),
+  NULL_TODO(7002, "좋아요할 할 일은 반드시 존재해야 합니다."),
+  SELF_LIKE_UNAVAILABLE(7003, "본인의 할 일에는 좋아요를 할 수 없습니다."),
+  USER_NOT_EXISTING(7004, "좋아요를 보내려는 사용자를 찾을 수 없습니다."),
+  TODO_NOT_EXISTING(7005, "좋아요를 보내려는 할 일을 찾을 수 없습니다."),
+  ALREADY_LIKED(7006, "이미 좋아요를 눌렀습니다."),
+  UNAVAILABLE_UNCOMPLETED_TODO(7007, "완료한 다음에 좋아요를 보낼 수 있습니다"),
+  INVALID_AUTHORITY(7008, "해당 기능에 대한 사용자 권한이 없습니다.");
 
   private final int code;
   private final String message;

--- a/src/main/java/com/ddudu/like/exception/LikeErrorCode.java
+++ b/src/main/java/com/ddudu/like/exception/LikeErrorCode.java
@@ -9,9 +9,8 @@ public enum LikeErrorCode implements ErrorCode {
   USER_NOT_EXISTING(7004, "좋아요를 보내려는 사용자를 찾을 수 없습니다."),
   TODO_NOT_EXISTING(7005, "좋아요를 보내려는 할 일을 찾을 수 없습니다."),
   LIKE_NOT_EXISTING(7006, "좋아요를 찾을 수 없습니다."),
-  ALREADY_LIKED(7007, "이미 좋아요를 눌렀습니다."),
-  UNAVAILABLE_UNCOMPLETED_TODO(7008, "완료한 다음에 좋아요를 보낼 수 있습니다"),
-  INVALID_AUTHORITY(7009, "해당 기능에 대한 사용자 권한이 없습니다.");
+  UNAVAILABLE_UNCOMPLETED_TODO(7007, "완료한 다음에 좋아요를 보낼 수 있습니다"),
+  INVALID_AUTHORITY(7008, "해당 기능에 대한 사용자 권한이 없습니다.");
 
   private final int code;
   private final String message;

--- a/src/main/java/com/ddudu/like/exception/LikeErrorCode.java
+++ b/src/main/java/com/ddudu/like/exception/LikeErrorCode.java
@@ -1,0 +1,27 @@
+package com.ddudu.like.exception;
+
+import com.ddudu.common.exception.ErrorCode;
+
+public enum LikeErrorCode implements ErrorCode {
+  NULL_USER(7001, "사용자가 반드시 존재해야 합니다."),
+  NULL_TODO(7002, "좋아요할 할 일이 반드시 존재해야 합니다."),
+  SELF_LIKE_UNAVAILABLE(7003, "본인의 할 일에 좋아요를 할 수 없습니다.");
+
+  private final int code;
+  private final String message;
+
+  LikeErrorCode(int code, String message) {
+    this.code = code;
+    this.message = message;
+  }
+
+  @Override
+  public int getCode() {
+    return code;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/main/java/com/ddudu/like/exception/LikeErrorCode.java
+++ b/src/main/java/com/ddudu/like/exception/LikeErrorCode.java
@@ -8,9 +8,10 @@ public enum LikeErrorCode implements ErrorCode {
   SELF_LIKE_UNAVAILABLE(7003, "본인의 할 일에는 좋아요를 할 수 없습니다."),
   USER_NOT_EXISTING(7004, "좋아요를 보내려는 사용자를 찾을 수 없습니다."),
   TODO_NOT_EXISTING(7005, "좋아요를 보내려는 할 일을 찾을 수 없습니다."),
-  ALREADY_LIKED(7006, "이미 좋아요를 눌렀습니다."),
-  UNAVAILABLE_UNCOMPLETED_TODO(7007, "완료한 다음에 좋아요를 보낼 수 있습니다"),
-  INVALID_AUTHORITY(7008, "해당 기능에 대한 사용자 권한이 없습니다.");
+  LIKE_NOT_EXISTING(7006, "좋아요를 찾을 수 없습니다."),
+  ALREADY_LIKED(7007, "이미 좋아요를 눌렀습니다."),
+  UNAVAILABLE_UNCOMPLETED_TODO(7008, "완료한 다음에 좋아요를 보낼 수 있습니다"),
+  INVALID_AUTHORITY(7009, "해당 기능에 대한 사용자 권한이 없습니다.");
 
   private final int code;
   private final String message;

--- a/src/main/java/com/ddudu/like/repository/LikeRepository.java
+++ b/src/main/java/com/ddudu/like/repository/LikeRepository.java
@@ -1,0 +1,12 @@
+package com.ddudu.like.repository;
+
+import com.ddudu.like.domain.Like;
+import com.ddudu.todo.domain.Todo;
+import com.ddudu.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+  boolean existsByUserAndTodo(User user, Todo todo);
+
+}

--- a/src/main/java/com/ddudu/like/repository/LikeRepository.java
+++ b/src/main/java/com/ddudu/like/repository/LikeRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
-  boolean existsByUserAndTodo(User user, Todo todo);
+  Like findByUserAndTodo(User user, Todo todo);
 
 }

--- a/src/main/java/com/ddudu/like/repository/LikeRepository.java
+++ b/src/main/java/com/ddudu/like/repository/LikeRepository.java
@@ -5,7 +5,7 @@ import com.ddudu.todo.domain.Todo;
 import com.ddudu.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LikeRepository extends JpaRepository<Like, Long> {
+public interface LikeRepository extends JpaRepository<Like, Long>, LikeRepositoryCustom {
 
   Like findByUserAndTodo(User user, Todo todo);
 

--- a/src/main/java/com/ddudu/like/repository/LikeRepositoryCustom.java
+++ b/src/main/java/com/ddudu/like/repository/LikeRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.ddudu.like.repository;
+
+import com.ddudu.like.domain.Like;
+import com.ddudu.todo.domain.Todo;
+import java.util.List;
+
+public interface LikeRepositoryCustom {
+
+  List<Like> findByTodos(List<Todo> todos);
+
+}

--- a/src/main/java/com/ddudu/like/repository/LikeRepositoryImpl.java
+++ b/src/main/java/com/ddudu/like/repository/LikeRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.ddudu.like.repository;
+
+import static com.ddudu.like.domain.QLike.like;
+
+import com.ddudu.like.domain.Like;
+import com.ddudu.todo.domain.Todo;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class LikeRepositoryImpl implements LikeRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  public LikeRepositoryImpl(EntityManager em) {
+    this.jpaQueryFactory = new JPAQueryFactory(em);
+  }
+
+  @Override
+  public List<Like> findByTodos(List<Todo> todos) {
+    return jpaQueryFactory
+        .selectFrom(like)
+        .where(
+            like.todo.in(todos),
+            like.isDeleted.eq(false)
+        )
+        .fetch();
+  }
+
+}

--- a/src/main/java/com/ddudu/like/service/LikeService.java
+++ b/src/main/java/com/ddudu/like/service/LikeService.java
@@ -1,7 +1,6 @@
 package com.ddudu.like.service;
 
 import com.ddudu.common.exception.DataNotFoundException;
-import com.ddudu.common.exception.DuplicateResourceException;
 import com.ddudu.common.exception.ForbiddenException;
 import com.ddudu.like.domain.Like;
 import com.ddudu.like.dto.request.LikeRequest;
@@ -12,24 +11,24 @@ import com.ddudu.todo.domain.Todo;
 import com.ddudu.todo.repository.TodoRepository;
 import com.ddudu.user.domain.User;
 import com.ddudu.user.repository.UserRepository;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.annotation.Validated;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class LikeService {
 
+  private static final String SUCCESS = "좋아요";
+  private static final String CANCEL = "좋아요 취소";
+
   private final LikeRepository likeRepository;
   private final UserRepository userRepository;
   private final TodoRepository todoRepository;
 
   @Transactional
-  @Validated
-  public LikeResponse create(Long loginId, @Valid LikeRequest request) {
+  public LikeResponse toggle(Long loginId, LikeRequest request) {
     checkPermission(loginId, request.userId());
 
     User user = userRepository.findById(request.userId())
@@ -37,8 +36,10 @@ public class LikeService {
     Todo todo = todoRepository.findById(request.todoId())
         .orElseThrow(() -> new DataNotFoundException(LikeErrorCode.TODO_NOT_EXISTING));
 
-    if (likeRepository.existsByUserAndTodo(user, todo)) {
-      throw new DuplicateResourceException(LikeErrorCode.ALREADY_LIKED);
+    Like existingLike = likeRepository.findByUserAndTodo(user, todo);
+
+    if (existingLike != null) {
+      return LikeResponse.from(existingLike, switchLikeStatus(existingLike));
     }
 
     Like like = Like.builder()
@@ -46,23 +47,23 @@ public class LikeService {
         .todo(todo)
         .build();
 
-    return LikeResponse.from(likeRepository.save(like));
-  }
-
-  @Transactional
-  public void delete(Long loginId, Long id) {
-    likeRepository.findById(id)
-        .ifPresent(like -> {
-          checkPermission(loginId, like.getUser()
-              .getId());
-          like.delete();
-        });
+    return LikeResponse.from(likeRepository.save(like), SUCCESS);
   }
 
   private void checkPermission(Long loginId, Long userId) {
     if (!loginId.equals(userId)) {
       throw new ForbiddenException(LikeErrorCode.INVALID_AUTHORITY);
     }
+  }
+
+  private String switchLikeStatus(Like like) {
+    if (!like.isDeleted()) {
+      like.delete();
+      return CANCEL;
+    }
+
+    like.undelete();
+    return SUCCESS;
   }
 
 }

--- a/src/main/java/com/ddudu/like/service/LikeService.java
+++ b/src/main/java/com/ddudu/like/service/LikeService.java
@@ -20,9 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class LikeService {
 
-  private static final String SUCCESS = "좋아요";
-  private static final String CANCEL = "좋아요 취소";
-
   private final LikeRepository likeRepository;
   private final UserRepository userRepository;
   private final TodoRepository todoRepository;
@@ -39,7 +36,7 @@ public class LikeService {
     Like existingLike = likeRepository.findByUserAndTodo(user, todo);
 
     if (existingLike != null) {
-      return LikeResponse.from(existingLike, switchLikeStatus(existingLike));
+      return LikeResponse.from(switchLikeStatus(existingLike));
     }
 
     Like like = Like.builder()
@@ -47,7 +44,7 @@ public class LikeService {
         .todo(todo)
         .build();
 
-    return LikeResponse.from(likeRepository.save(like), SUCCESS);
+    return LikeResponse.from(likeRepository.save(like));
   }
 
   private void checkPermission(Long loginId, Long userId) {
@@ -56,14 +53,14 @@ public class LikeService {
     }
   }
 
-  private String switchLikeStatus(Like like) {
+  private Like switchLikeStatus(Like like) {
     if (!like.isDeleted()) {
       like.delete();
-      return CANCEL;
+      return like;
     }
 
     like.undelete();
-    return SUCCESS;
+    return like;
   }
 
 }

--- a/src/main/java/com/ddudu/like/service/LikeService.java
+++ b/src/main/java/com/ddudu/like/service/LikeService.java
@@ -59,15 +59,6 @@ public class LikeService {
         });
   }
 
-  public LikeResponse findById(Long id) {
-    Like like = likeRepository.findById(id)
-        .orElseThrow(() -> new DataNotFoundException(LikeErrorCode.LIKE_NOT_EXISTING));
-
-    // TODO: 모든 사용자가 좋아요를 조회할 수 있어 checkPermission 필요 없음, 추후 loginId는 authority가 NORMAL인지 확인하는 용도로 사용
-
-    return LikeResponse.from(like);
-  }
-
   private void checkPermission(Long loginId, Long userId) {
     if (!loginId.equals(userId)) {
       throw new ForbiddenException(LikeErrorCode.INVALID_AUTHORITY);

--- a/src/main/java/com/ddudu/like/service/LikeService.java
+++ b/src/main/java/com/ddudu/like/service/LikeService.java
@@ -59,6 +59,15 @@ public class LikeService {
         });
   }
 
+  public LikeResponse findById(Long id) {
+    Like like = likeRepository.findById(id)
+        .orElseThrow(() -> new DataNotFoundException(LikeErrorCode.LIKE_NOT_EXISTING));
+
+    // TODO: 모든 사용자가 좋아요를 조회할 수 있어 checkPermission 필요 없음, 추후 loginId는 authority가 NORMAL인지 확인하는 용도로 사용
+
+    return LikeResponse.from(like);
+  }
+
   private void checkPermission(Long loginId, Long userId) {
     if (!loginId.equals(userId)) {
       throw new ForbiddenException(LikeErrorCode.INVALID_AUTHORITY);

--- a/src/main/java/com/ddudu/like/service/LikeService.java
+++ b/src/main/java/com/ddudu/like/service/LikeService.java
@@ -49,6 +49,16 @@ public class LikeService {
     return LikeResponse.from(likeRepository.save(like));
   }
 
+  @Transactional
+  public void delete(Long loginId, Long id) {
+    likeRepository.findById(id)
+        .ifPresent(like -> {
+          checkPermission(loginId, like.getUser()
+              .getId());
+          like.delete();
+        });
+  }
+
   private void checkPermission(Long loginId, Long userId) {
     if (!loginId.equals(userId)) {
       throw new ForbiddenException(LikeErrorCode.INVALID_AUTHORITY);

--- a/src/main/java/com/ddudu/like/service/LikeService.java
+++ b/src/main/java/com/ddudu/like/service/LikeService.java
@@ -1,0 +1,58 @@
+package com.ddudu.like.service;
+
+import com.ddudu.common.exception.DataNotFoundException;
+import com.ddudu.common.exception.DuplicateResourceException;
+import com.ddudu.common.exception.ForbiddenException;
+import com.ddudu.like.domain.Like;
+import com.ddudu.like.dto.request.LikeRequest;
+import com.ddudu.like.dto.response.LikeResponse;
+import com.ddudu.like.exception.LikeErrorCode;
+import com.ddudu.like.repository.LikeRepository;
+import com.ddudu.todo.domain.Todo;
+import com.ddudu.todo.repository.TodoRepository;
+import com.ddudu.user.domain.User;
+import com.ddudu.user.repository.UserRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LikeService {
+
+  private final LikeRepository likeRepository;
+  private final UserRepository userRepository;
+  private final TodoRepository todoRepository;
+
+  @Transactional
+  @Validated
+  public LikeResponse create(Long loginId, @Valid LikeRequest request) {
+    checkPermission(loginId, request.userId());
+
+    User user = userRepository.findById(request.userId())
+        .orElseThrow(() -> new DataNotFoundException(LikeErrorCode.USER_NOT_EXISTING));
+    Todo todo = todoRepository.findById(request.todoId())
+        .orElseThrow(() -> new DataNotFoundException(LikeErrorCode.TODO_NOT_EXISTING));
+
+    if (likeRepository.existsByUserAndTodo(user, todo)) {
+      throw new DuplicateResourceException(LikeErrorCode.ALREADY_LIKED);
+    }
+
+    Like like = Like.builder()
+        .user(user)
+        .todo(todo)
+        .build();
+
+    return LikeResponse.from(likeRepository.save(like));
+  }
+
+  private void checkPermission(Long loginId, Long userId) {
+    if (!loginId.equals(userId)) {
+      throw new ForbiddenException(LikeErrorCode.INVALID_AUTHORITY);
+    }
+  }
+
+}

--- a/src/main/java/com/ddudu/todo/dto/response/LikeInfo.java
+++ b/src/main/java/com/ddudu/todo/dto/response/LikeInfo.java
@@ -1,0 +1,19 @@
+package com.ddudu.todo.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record LikeInfo(
+    int count,
+    List<Long> users
+) {
+
+  public static LikeInfo from(List<Long> users) {
+    return LikeInfo.builder()
+        .count(users.size())
+        .users(users)
+        .build();
+  }
+
+}

--- a/src/main/java/com/ddudu/todo/dto/response/TodoInfo.java
+++ b/src/main/java/com/ddudu/todo/dto/response/TodoInfo.java
@@ -8,7 +8,8 @@ import lombok.Builder;
 public record TodoInfo(
     Long id,
     String name,
-    TodoStatus status
+    TodoStatus status,
+    LikeInfo likeInfo
 ) {
 
   public static TodoInfo from(Todo todo) {
@@ -16,6 +17,15 @@ public record TodoInfo(
         .id(todo.getId())
         .name(todo.getName())
         .status(todo.getStatus())
+        .build();
+  }
+
+  public static TodoInfo from(Todo todo, LikeInfo likeInfo) {
+    return TodoInfo.builder()
+        .id(todo.getId())
+        .name(todo.getName())
+        .status(todo.getStatus())
+        .likeInfo(likeInfo)
         .build();
   }
 

--- a/src/main/java/com/ddudu/todo/dto/response/TodoInfo.java
+++ b/src/main/java/com/ddudu/todo/dto/response/TodoInfo.java
@@ -9,7 +9,7 @@ public record TodoInfo(
     Long id,
     String name,
     TodoStatus status,
-    LikeInfo likeInfo
+    LikeInfo likes
 ) {
 
   public static TodoInfo from(Todo todo) {
@@ -25,7 +25,7 @@ public record TodoInfo(
         .id(todo.getId())
         .name(todo.getName())
         .status(todo.getStatus())
-        .likeInfo(likeInfo)
+        .likes(likeInfo)
         .build();
   }
 

--- a/src/main/java/com/ddudu/todo/service/TodoService.java
+++ b/src/main/java/com/ddudu/todo/service/TodoService.java
@@ -96,21 +96,7 @@ public class TodoService {
             .getId()));
 
     return goals.stream()
-        .map(goal -> {
-          List<TodoInfo> todoInfos = todosByGoal.getOrDefault(goal.getId(), Collections.emptyList())
-              .stream()
-              .map(todo -> {
-                List<Like> likes = likesByTodo.getOrDefault(todo.getId(), Collections.emptyList());
-                List<Long> likedUsers = likes.stream()
-                    .map(like -> like.getUser()
-                        .getId())
-                    .collect(Collectors.toList());
-                return TodoInfo.from(todo, LikeInfo.from(likedUsers));
-              })
-              .toList();
-
-          return TodoListResponse.from(goal, todoInfos);
-        })
+        .map(goal -> mapGoalToTodoListResponse(goal, todosByGoal, likesByTodo))
         .toList();
   }
 
@@ -236,6 +222,27 @@ public class TodoService {
     }
 
     return List.of(PrivacyType.PUBLIC);
+  }
+
+  private TodoListResponse mapGoalToTodoListResponse(
+      Goal goal, Map<Long, List<Todo>> todosByGoal, Map<Long, List<Like>> likesByTodo
+  ) {
+    List<TodoInfo> todoInfos = todosByGoal.getOrDefault(goal.getId(), Collections.emptyList())
+        .stream()
+        .map(todo -> mapTodoToTodoInfoWithLikes(todo, likesByTodo))
+        .toList();
+
+    return TodoListResponse.from(goal, todoInfos);
+  }
+
+  private TodoInfo mapTodoToTodoInfoWithLikes(Todo todo, Map<Long, List<Like>> likesByTodo) {
+    List<Long> likedUsers = likesByTodo.getOrDefault(todo.getId(), Collections.emptyList())
+        .stream()
+        .map(like -> like.getUser()
+            .getId())
+        .toList();
+
+    return TodoInfo.from(todo, LikeInfo.from(likedUsers));
   }
 
 }

--- a/src/main/resources/db/data/afterMigrate.sql
+++ b/src/main/resources/db/data/afterMigrate.sql
@@ -4,6 +4,7 @@ truncate table users;
 truncate table goal;
 truncate table todo;
 truncate table followings;
+truncate table likes;
 SET foreign_key_checks = 1;
 
 -- USER
@@ -19,18 +20,18 @@ insert into users(id, optional_username, email, password, nickname) values (9,'d
 insert into users(id, optional_username, email, password, nickname) values (10,'dingmon', 'coding@mon.co.kr', '$2a$10$k3/gS0YD9tAr69nRZRBjQOmf.MiqXa29hdCSa.Kg0i5U4/gISOsDG', '코딩몬');
 
 -- GOAL
-insert into goal(id, user_id, name, color, privacy) values (1, 8, 'dev course', '75D7E4', 'PUBLIC');
-insert into goal(id, user_id, name, color, privacy) values (2, 8, 'study', 'F3D056', 'PUBLIC');
-insert into goal(id, user_id, name, color, privacy) values (3, 8, 'event', 'F1B5CA', 'PRIVATE');
-insert into goal(id, user_id, name, color, privacy) values (4, 8, 'etc', 'C7D567', 'PUBLIC');
-insert into goal(id, user_id, name, privacy, status) values (5, 8, 'college', 'PUBLIC', 'DONE');
+insert into goal(id, user_id, name, color, privacy) values (1, 1, 'dev course', '75D7E4', 'PUBLIC');
+insert into goal(id, user_id, name, color, privacy) values (2, 1, 'study', 'F3D056', 'PUBLIC');
+insert into goal(id, user_id, name, color, privacy) values (3, 1, 'event', 'F1B5CA', 'PRIVATE');
+insert into goal(id, user_id, name, color, privacy) values (4, 1, 'etc', 'C7D567', 'PUBLIC');
+insert into goal(id, user_id, name, privacy, status) values (5, 1, 'college', 'PUBLIC', 'DONE');
 
 -- TO DO
-insert into todo(id, name, user_id, goal_id, status) values (1, '10시 30분 마르코 팀미팅', 8, 1, 'UNCOMPLETED');
-insert into todo(id, name, user_id, goal_id, status, end_at) values (2, '9시 QR 출셕', 8, 1, 'COMPLETE', NOW());
-insert into todo(id, name, user_id, goal_id, status) values (3, '1시 RBF', 8, 1, 'UNCOMPLETED');
-insert into todo(id, name, user_id, goal_id, status) values (4, '2시 말코리즘 간단 리뷰', 8, 1, 'UNCOMPLETED');
-insert into todo(id, name, user_id, goal_id, status, end_at, is_deleted) values (5, '9시 뚜두뚜두 스크럼', 8, 1, 'COMPLETE', NOW(), 1);
+insert into todo(id, name, user_id, goal_id, status) values (1, '10시 30분 마르코 팀미팅', 1, 1, 'UNCOMPLETED');
+insert into todo(id, name, user_id, goal_id, status, end_at) values (2, '9시 QR 출셕', 1, 1, 'COMPLETE', NOW());
+insert into todo(id, name, user_id, goal_id, status) values (3, '1시 RBF', 1, 1, 'UNCOMPLETED');
+insert into todo(id, name, user_id, goal_id, status) values (4, '2시 말코리즘 간단 리뷰', 1, 1, 'UNCOMPLETED');
+insert into todo(id, name, user_id, goal_id, status, end_at, is_deleted) values (5, '9시 뚜두뚜두 스크럼', 1, 1, 'COMPLETE', NOW(), 1);
 
 -- FOLLOWING
 insert into followings(id, follower_id, followee_id, status) values (1, 1, 2, 'FOLLOWING');

--- a/src/main/resources/db/data/afterMigrate.sql
+++ b/src/main/resources/db/data/afterMigrate.sql
@@ -30,7 +30,7 @@ insert into goal(id, user_id, name, privacy, status) values (5, 1, 'college', 'P
 insert into todo(id, name, user_id, goal_id, status) values (1, '10시 30분 마르코 팀미팅', 1, 1, 'UNCOMPLETED');
 insert into todo(id, name, user_id, goal_id, status, end_at) values (2, '9시 QR 출셕', 1, 1, 'COMPLETE', NOW());
 insert into todo(id, name, user_id, goal_id, status) values (3, '1시 RBF', 1, 1, 'UNCOMPLETED');
-insert into todo(id, name, user_id, goal_id, status) values (4, '2시 말코리즘 간단 리뷰', 1, 1, 'CONPLETE');
+insert into todo(id, name, user_id, goal_id, status) values (4, '2시 말코리즘 간단 리뷰', 1, 1, 'COMPLETE');
 insert into todo(id, name, user_id, goal_id, status, end_at, is_deleted) values (5, '9시 뚜두뚜두 스크럼', 1, 1, 'COMPLETE', NOW(), 1);
 
 -- FOLLOWING
@@ -47,8 +47,6 @@ insert into followings(id, follower_id, followee_id, status) values (10, 10, 7, 
 
 
 -- LIKE
-insert into likes(id, user_id, todo_id) values (1, 2, 1);
-insert into likes(id, user_id, todo_id) values (2, 2, 2);
-insert into likes(id, user_id, todo_id) values (3, 2, 3);
-insert into likes(id, user_id, todo_id) values (4, 2, 4);
-insert into likes(id, user_id, todo_id) values (5, 3, 1);
+insert into likes(id, user_id, todo_id) values (1, 2, 2);
+insert into likes(id, user_id, todo_id) values (2, 2, 4);
+insert into likes(id, user_id, todo_id) values (3, 3, 2);

--- a/src/main/resources/db/data/afterMigrate.sql
+++ b/src/main/resources/db/data/afterMigrate.sql
@@ -1,54 +1,54 @@
 -- CLEAR
 SET foreign_key_checks = 0;
-TRUNCATE TABLE users;
-TRUNCATE TABLE goal;
-TRUNCATE TABLE todo;
-TRUNCATE TABLE followings;
-TRUNCATE TABLE likes;
+truncate table users;
+truncate table goal;
+truncate table todo;
+truncate table followings;
+truncate table likes;
 SET foreign_key_checks = 1;
 
 -- USER
-INSERT INTO users(id, email, password, nickname) VALUES (1, 'nicolette.mills@hotmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Kenya Dewit');
-INSERT INTO users(id, email, password, nickname) VALUES (2, 'brian.mayer@hotmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Jack Pott');
-INSERT INTO users(id, email, password, nickname) VALUES (3, 'shayne.bogisich@gmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Lou Pole');
-INSERT INTO users(id, email, password, nickname) VALUES (4, 'josh.thiel@yahoo.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Candice B. Fureal');
-INSERT INTO users(id, email, password, nickname) VALUES (5, 'stacia.beahan@gmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Marshall Law');
-INSERT INTO users(id, optional_username, email, password, nickname) VALUES (6,'pinkblack', 'ddudu@ddudu.com', '$2a$10$oG6/71OlxogWxhxeLYckn.MbWYsXvGgMzP1zGq9sxcxScn3SekKyW', '뚜두뚜두');
-INSERT INTO users(id, optional_username, email, password, nickname) VALUES (7,'devcourselove', 'love@devcourse.com', '$2a$10$eFFAmSR2O/W9lUCmKL5fe.OmH3j/T5/23iUvpRWHm7dBmupdOatOO', '데브코스 사랑함');
-INSERT INTO users(id, optional_username, email, password, nickname) VALUES (8,'injaesong', 'injaesong0@gmail.com', '$2a$10$39InvdkmJm3.4xIy4kGCyuoohtLK5rGF09HEKpBFu2fgqfCzYLPiG', '송인재');
-INSERT INTO users(id, optional_username, email, password, nickname) VALUES (9,'devcrazy', 'crazy@example.com', '$2a$10$5ZXbGs1etnGkrath/enkB.TdMj8U//jdmH3GXSRj3F3ACHi5LABHC', '개발 미친 사람');
-INSERT INTO users(id, optional_username, email, password, nickname, follows_after_approval) VALUES (10,'dingmon', 'coding@mon.co.kr', '$2a$10$k3/gS0YD9tAr69nRZRBjQOmf.MiqXa29hdCSa.Kg0i5U4/gISOsDG', '코딩몬', true);
+insert into users(id, email, password, nickname) values (1, 'nicolette.mills@hotmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Kenya Dewit');
+insert into users(id, email, password, nickname) values (2, 'brian.mayer@hotmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Jack Pott');
+insert into users(id, email, password, nickname) values (3, 'shayne.bogisich@gmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Lou Pole');
+insert into users(id, email, password, nickname) values (4, 'josh.thiel@yahoo.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Candice B. Fureal');
+insert into users(id, email, password, nickname) values (5, 'stacia.beahan@gmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Marshall Law');
+insert into users(id, optional_username, email, password, nickname) values (6,'pinkblack', 'ddudu@ddudu.com', '$2a$10$oG6/71OlxogWxhxeLYckn.MbWYsXvGgMzP1zGq9sxcxScn3SekKyW', '뚜두뚜두');
+insert into users(id, optional_username, email, password, nickname) values (7,'devcourselove', 'love@devcourse.com', '$2a$10$eFFAmSR2O/W9lUCmKL5fe.OmH3j/T5/23iUvpRWHm7dBmupdOatOO', '데브코스 사랑함');
+insert into users(id, optional_username, email, password, nickname) values (8,'injaesong', 'injaesong0@gmail.com', '$2a$10$39InvdkmJm3.4xIy4kGCyuoohtLK5rGF09HEKpBFu2fgqfCzYLPiG', '송인재');
+insert into users(id, optional_username, email, password, nickname) values (9,'devcrazy', 'crazy@example.com', '$2a$10$5ZXbGs1etnGkrath/enkB.TdMj8U//jdmH3GXSRj3F3ACHi5LABHC', '개발 미친 사람');
+insert into users(id, optional_username, email, password, nickname, follows_after_approval) values (10,'dingmon', 'coding@mon.co.kr', '$2a$10$k3/gS0YD9tAr69nRZRBjQOmf.MiqXa29hdCSa.Kg0i5U4/gISOsDG', '코딩몬', true);
 
 -- GOAL
 INSERT INTO goal(id, user_id, name, color, privacy) VALUES (1, 1, 'dev course', '75D7E4', 'PUBLIC');
-INSERT INTO goal(id, user_id, name, color, privacy) VALUES (2, 1, 'study', 'F3D056', 'PUBLIC');
-INSERT INTO goal(id, user_id, name, color, privacy) VALUES (3, 1, 'event', 'F1B5CA', 'PRIVATE');
-INSERT INTO goal(id, user_id, name, color, privacy) VALUES (4, 1, 'etc', 'C7D567', 'PUBLIC');
-INSERT INTO goal(id, user_id, name, privacy, status) VALUES (5, 1, 'college', 'PUBLIC', 'DONE');
+insert into goal(id, user_id, name, color, privacy) values (2, 1, 'study', 'F3D056', 'PUBLIC');
+insert into goal(id, user_id, name, color, privacy) values (3, 1, 'event', 'F1B5CA', 'PRIVATE');
+insert into goal(id, user_id, name, color, privacy) values (4, 1, 'etc', 'C7D567', 'PUBLIC');
+insert into goal(id, user_id, name, privacy, status) values (5, 1, 'college', 'PUBLIC', 'DONE');
 
 -- TO DO
-INSERT INTO todo(id, name, user_id, goal_id, status) VALUES (1, '10시 30분 마르코 팀미팅', 1, 1, 'UNCOMPLETED');
-INSERT INTO todo(id, name, user_id, goal_id, status, end_at) VALUES (2, '9시 QR 출셕', 1, 1, 'COMPLETE', NOW());
-INSERT INTO todo(id, name, user_id, goal_id, status) VALUES (3, '1시 RBF', 1, 1, 'UNCOMPLETED');
-INSERT INTO todo(id, name, user_id, goal_id, status) VALUES (4, '2시 말코리즘 간단 리뷰', 1, 1, 'UNCOMPLETED');
-INSERT INTO todo(id, name, user_id, goal_id, status, end_at, is_deleted) VALUES (5, '9시 뚜두뚜두 스크럼', 1, 1, 'COMPLETE', NOW(), 1);
+insert into todo(id, name, user_id, goal_id, status) values (1, '10시 30분 마르코 팀미팅', 1, 1, 'UNCOMPLETED');
+insert into todo(id, name, user_id, goal_id, status, end_at) values (2, '9시 QR 출셕', 1, 1, 'COMPLETE', NOW());
+insert into todo(id, name, user_id, goal_id, status) values (3, '1시 RBF', 1, 1, 'UNCOMPLETED');
+insert into todo(id, name, user_id, goal_id, status) values (4, '2시 말코리즘 간단 리뷰', 1, 1, 'CONPLETE');
+insert into todo(id, name, user_id, goal_id, status, end_at, is_deleted) values (5, '9시 뚜두뚜두 스크럼', 1, 1, 'COMPLETE', NOW(), 1);
 
 -- FOLLOWING
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (1, 1, 2, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (2, 2, 1, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (3, 1, 10, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (4, 2, 10, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (5, 3, 10, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (6, 4, 10, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (7, 5, 10, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (8, 6, 10, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (9, 10, 6, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (10, 10, 7, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (1, 1, 2, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (2, 2, 1, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (3, 1, 10, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (4, 2, 10, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (5, 3, 10, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (6, 4, 10, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (7, 5, 10, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (8, 6, 10, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (9, 10, 6, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (10, 10, 7, 'FOLLOWING');
 
 
 -- LIKE
-INSERT INTO likes(id, user_id, todo_id) VALUES (1, 2, 1);
-INSERT INTO likes(id, user_id, todo_id) VALUES (2, 2, 2);
-INSERT INTO likes(id, user_id, todo_id) VALUES (3, 2, 3);
-INSERT INTO likes(id, user_id, todo_id) VALUES (4, 2, 4);
-INSERT INTO likes(id, user_id, todo_id) VALUES (5, 3, 1);
+insert into likes(id, user_id, todo_id) values (1, 2, 1);
+insert into likes(id, user_id, todo_id) values (2, 2, 2);
+insert into likes(id, user_id, todo_id) values (3, 2, 3);
+insert into likes(id, user_id, todo_id) values (4, 2, 4);
+insert into likes(id, user_id, todo_id) values (5, 3, 1);

--- a/src/main/resources/db/data/afterMigrate.sql
+++ b/src/main/resources/db/data/afterMigrate.sql
@@ -1,29 +1,29 @@
 -- CLEAR
 SET foreign_key_checks = 0;
-TRUNCATE TABLE users;
-TRUNCATE TABLE goal;
-TRUNCATE TABLE todo;
-TRUNCATE TABLE followings;
+truncate table users;
+truncate table goal;
+truncate table todo;
+truncate table followings;
 SET foreign_key_checks = 1;
 
 -- USER
-INSERT INTO users(id, email, password, nickname) VALUES (1, 'nicolette.mills@hotmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Kenya Dewit');
-INSERT INTO users(id, email, password, nickname) VALUES (2, 'brian.mayer@hotmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Jack Pott');
-INSERT INTO users(id, email, password, nickname) VALUES (3, 'shayne.bogisich@gmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Lou Pole');
-INSERT INTO users(id, email, password, nickname) VALUES (4, 'josh.thiel@yahoo.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Candice B. Fureal');
-INSERT INTO users(id, email, password, nickname) VALUES (5, 'stacia.beahan@gmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Marshall Law');
-INSERT INTO users(id, optional_username, email, password, nickname) VALUES (6,'pinkblack', 'ddudu@ddudu.com', '$2a$10$oG6/71OlxogWxhxeLYckn.MbWYsXvGgMzP1zGq9sxcxScn3SekKyW', '뚜두뚜두');
-INSERT INTO users(id, optional_username, email, password, nickname) VALUES (7,'devcourselove', 'love@devcourse.com', '$2a$10$eFFAmSR2O/W9lUCmKL5fe.OmH3j/T5/23iUvpRWHm7dBmupdOatOO', '데브코스 사랑함');
-INSERT INTO users(id, optional_username, email, password, nickname) VALUES (8,'injaesong', 'injaesong0@gmail.com', '$2a$10$39InvdkmJm3.4xIy4kGCyuoohtLK5rGF09HEKpBFu2fgqfCzYLPiG', '송인재');
-INSERT INTO users(id, optional_username, email, password, nickname) VALUES (9,'devcrazy', 'crazy@example.com', '$2a$10$5ZXbGs1etnGkrath/enkB.TdMj8U//jdmH3GXSRj3F3ACHi5LABHC', '개발 미친 사람');
-INSERT INTO users(id, optional_username, email, password, nickname) VALUES (10,'dingmon', 'coding@mon.co.kr', '$2a$10$k3/gS0YD9tAr69nRZRBjQOmf.MiqXa29hdCSa.Kg0i5U4/gISOsDG', '코딩몬');
+insert into users(id, email, password, nickname) values (1, 'nicolette.mills@hotmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Kenya Dewit');
+insert into users(id, email, password, nickname) values (2, 'brian.mayer@hotmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Jack Pott');
+insert into users(id, email, password, nickname) values (3, 'shayne.bogisich@gmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Lou Pole');
+insert into users(id, email, password, nickname) values (4, 'josh.thiel@yahoo.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Candice B. Fureal');
+insert into users(id, email, password, nickname) values (5, 'stacia.beahan@gmail.com', '$2a$10$Q6KjyLPE6QrpqkGkFb0ezOqe0EaZZpaht11UgefOqNyUB0N0XjnQO', 'Marshall Law');
+insert into users(id, optional_username, email, password, nickname) values (6,'pinkblack', 'ddudu@ddudu.com', '$2a$10$oG6/71OlxogWxhxeLYckn.MbWYsXvGgMzP1zGq9sxcxScn3SekKyW', '뚜두뚜두');
+insert into users(id, optional_username, email, password, nickname) values (7,'devcourselove', 'love@devcourse.com', '$2a$10$eFFAmSR2O/W9lUCmKL5fe.OmH3j/T5/23iUvpRWHm7dBmupdOatOO', '데브코스 사랑함');
+insert into users(id, optional_username, email, password, nickname) values (8,'injaesong', 'injaesong0@gmail.com', '$2a$10$39InvdkmJm3.4xIy4kGCyuoohtLK5rGF09HEKpBFu2fgqfCzYLPiG', '송인재');
+insert into users(id, optional_username, email, password, nickname) values (9,'devcrazy', 'crazy@example.com', '$2a$10$5ZXbGs1etnGkrath/enkB.TdMj8U//jdmH3GXSRj3F3ACHi5LABHC', '개발 미친 사람');
+insert into users(id, optional_username, email, password, nickname) values (10,'dingmon', 'coding@mon.co.kr', '$2a$10$k3/gS0YD9tAr69nRZRBjQOmf.MiqXa29hdCSa.Kg0i5U4/gISOsDG', '코딩몬');
 
 -- GOAL
-INSERT INTO goal(id, user_id, name, color, privacy) VALUES (1, 8, 'dev course', '75D7E4', 'PUBLIC');
-INSERT INTO goal(id, user_id, name, color, privacy) VALUES (2, 8, 'study', 'F3D056', 'PUBLIC');
-INSERT INTO goal(id, user_id, name, color, privacy) VALUES (3, 8, 'event', 'F1B5CA', 'PRIVATE');
-INSERT INTO goal(id, user_id, name, color, privacy) VALUES (4, 8, 'etc', 'C7D567', 'PUBLIC');
-INSERT INTO goal(id, user_id, name, privacy, status) VALUES (5, 8, 'college', 'PUBLIC', 'DONE');
+insert into goal(id, user_id, name, color, privacy) values (1, 8, 'dev course', '75D7E4', 'PUBLIC');
+insert into goal(id, user_id, name, color, privacy) values (2, 8, 'study', 'F3D056', 'PUBLIC');
+insert into goal(id, user_id, name, color, privacy) values (3, 8, 'event', 'F1B5CA', 'PRIVATE');
+insert into goal(id, user_id, name, color, privacy) values (4, 8, 'etc', 'C7D567', 'PUBLIC');
+insert into goal(id, user_id, name, privacy, status) values (5, 8, 'college', 'PUBLIC', 'DONE');
 
 -- TO DO
 insert into todo(id, name, user_id, goal_id, status) values (1, '10시 30분 마르코 팀미팅', 8, 1, 'UNCOMPLETED');
@@ -33,13 +33,21 @@ insert into todo(id, name, user_id, goal_id, status) values (4, '2시 말코리�
 insert into todo(id, name, user_id, goal_id, status, end_at, is_deleted) values (5, '9시 뚜두뚜두 스크럼', 8, 1, 'COMPLETE', NOW(), 1);
 
 -- FOLLOWING
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (1, 1, 2, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (2, 2, 1, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (3, 1, 10, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (4, 2, 10, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (5, 3, 10, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (6, 4, 10, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (7, 5, 10, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (8, 6, 10, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (9, 10, 6, 'FOLLOWING');
-INSERT INTO followings(id, follower_id, followee_id, status) VALUES (10, 10, 7, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (1, 1, 2, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (2, 2, 1, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (3, 1, 10, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (4, 2, 10, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (5, 3, 10, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (6, 4, 10, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (7, 5, 10, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (8, 6, 10, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (9, 10, 6, 'FOLLOWING');
+insert into followings(id, follower_id, followee_id, status) values (10, 10, 7, 'FOLLOWING');
+
+
+-- LIKE
+insert into likes(id, user_id, todo_id) values (1, 2, 1);
+insert into likes(id, user_id, todo_id) values (2, 2, 2);
+insert into likes(id, user_id, todo_id) values (3, 2, 3);
+insert into likes(id, user_id, todo_id) values (4, 2, 4);
+insert into likes(id, user_id, todo_id) values (5, 3, 1);

--- a/src/main/resources/db/migration/V1__schema.sql
+++ b/src/main/resources/db/migration/V1__schema.sql
@@ -1,5 +1,5 @@
 -- USER
-CREATE TABLE IF NOT EXISTS users
+create TABLE IF NOT EXISTS users
 (
     id                BIGINT       AUTO_INCREMENT,
     optional_username VARCHAR(20)  NULL,
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS users
     authority         VARCHAR(15)  NOT NULL DEFAULT 'NORMAL',
     status            VARCHAR(20)  NOT NULL DEFAULT 'ACTIVE',
     created_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted        TINYINT(1)   NOT NULL DEFAULT 0,
     CONSTRAINT pk_user_id PRIMARY KEY (id),
     CONSTRAINT uk_user_optional_username UNIQUE (optional_username),
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS users
 );
 
 -- GOAL
-CREATE TABLE IF NOT EXISTS goal
+create TABLE IF NOT EXISTS goal
 (
     id         BIGINT      AUTO_INCREMENT,
     user_id    BIGINT      NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS goal
     privacy    VARCHAR(20) NOT NULL DEFAULT 'PRIVATE',
     status     VARCHAR(20) NOT NULL DEFAULT 'IN_PROGRESS',
     created_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted TINYINT(1)  NOT NULL DEFAULT 0,
     CONSTRAINT pk_goal_id PRIMARY KEY (id),
     CONSTRAINT fk_goal_user_id FOREIGN KEY (user_id) REFERENCES users (id),
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS goal
 );
 
 -- TO DO
-CREATE TABLE IF NOT EXISTS todo
+create TABLE IF NOT EXISTS todo
 (
     id         BIGINT      AUTO_INCREMENT,
     user_id    BIGINT      NOT NULL,
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS todo
     begin_at   TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
     end_at     TIMESTAMP   NULL,
     created_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted TINYINT(1)  NOT NULL DEFAULT 0,
     CONSTRAINT pk_todo_id PRIMARY KEY (id),
     CONSTRAINT fk_todo_user_id FOREIGN KEY (user_id) REFERENCES users (id),
@@ -53,16 +53,31 @@ CREATE TABLE IF NOT EXISTS todo
 );
 
 -- FOLLOWING
-CREATE TABLE IF NOT EXISTS followings
+create TABLE IF NOT EXISTS followings
 (
     id          BIGINT      AUTO_INCREMENT,
     follower_id BIGINT      NOT NULL,
     followee_id BIGINT      NOT NULL,
     status      VARCHAR(20) NOT NULL DEFAULT 'FOLLOWING',
     created_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted TINYINT(1)  NOT NULL DEFAULT 0,
     CONSTRAINT pk_friend_id PRIMARY KEY (id),
-    CONSTRAINT fk_follower_id FOREIGN KEY (follower_id) REFERENCES users (id) ON DELETE CASCADE,
-    CONSTRAINT fk_followee_id FOREIGN KEY (followee_id) REFERENCES users (id) ON DELETE CASCADE
+    CONSTRAINT fk_follower_id FOREIGN KEY (follower_id) REFERENCES users (id) ON delete CASCADE,
+    CONSTRAINT fk_followee_id FOREIGN KEY (followee_id) REFERENCES users (id) ON delete CASCADE
 );
+
+-- Likes
+create TABLE IF NOT EXISTS likes
+(
+    id         BIGINT      AUTO_INCREMENT,
+    user_id    BIGINT      NOT NULL,
+    todo_id    BIGINT      NOT NULL,
+    created_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    is_deleted TINYINT(1)  NOT NULL DEFAULT 0,
+    CONSTRAINT pk_like_id PRIMARY KEY (id),
+    CONSTRAINT fk_user_id FOREIGN KEY (user_id) REFERENCES users (id) ON delete CASCADE,
+    CONSTRAINT fk_todo_id FOREIGN KEY (todo_id) REFERENCES todo (id) ON delete CASCADE
+);
+

--- a/src/main/resources/db/migration/V1__schema.sql
+++ b/src/main/resources/db/migration/V1__schema.sql
@@ -77,7 +77,7 @@ create TABLE IF NOT EXISTS likes
     updated_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted TINYINT(1)  NOT NULL DEFAULT 0,
     CONSTRAINT pk_like_id PRIMARY KEY (id),
-    CONSTRAINT fk_user_id FOREIGN KEY (user_id) REFERENCES users (id) ON delete CASCADE,
-    CONSTRAINT fk_todo_id FOREIGN KEY (todo_id) REFERENCES todo (id) ON delete CASCADE
+    CONSTRAINT fk_like_user_id FOREIGN KEY (user_id) REFERENCES users (id) ON delete CASCADE,
+    CONSTRAINT fk_like_todo_id FOREIGN KEY (todo_id) REFERENCES todo (id) ON delete CASCADE
 );
 

--- a/src/test/java/com/ddudu/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/ddudu/like/controller/LikeControllerTest.java
@@ -4,6 +4,8 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -114,21 +116,6 @@ class LikeControllerTest {
           .andExpect(jsonPath("$.[0].message", is(message)));
     }
 
-//    @Test
-//    void 로그인한_사용자가_없으면_401_Unauthorized를_반환한다() throws Exception {
-//      // given
-//      LikeRequest request = new LikeRequest(userId, todoId);
-//
-//      // when
-//      ResultActions actions = mockMvc.perform(post("/api/likes")
-//          .content(objectMapper.writeValueAsString(request))
-//          .contentType(MediaType.APPLICATION_JSON));
-//
-//      // then
-//      actions.andExpect(status().isUnauthorized())
-//          .andExpect(header().string(HttpHeaders.WWW_AUTHENTICATE, "Bearer"));
-//    }
-
     @Test
     void 좋아요하고_201_Created를_반환한다() throws Exception {
       // given
@@ -146,7 +133,30 @@ class LikeControllerTest {
 
       // then
       actions.andExpect(status().isCreated())
-          .andExpect(header().exists("location"));
+          .andExpect(header().string("location", is("/api/likes/" + response.id())));
+    }
+
+  }
+
+  @Nested
+  class DELETE_좋아요_취소_API_테스트 {
+
+    @Test
+    void 좋아요_취소를_성공하면_204_No_Content를_반환한다() throws Exception {
+      // given
+      Long id = faker.random()
+          .nextLong(Long.MAX_VALUE);
+
+      willDoNothing().given(likeService)
+          .delete(anyLong(), anyLong());
+
+      // when
+      ResultActions actions = mockMvc.perform(delete("/api/likes/{id}", id)
+          .header("Authorization", token)
+          .contentType(MediaType.APPLICATION_JSON));
+
+      // then
+      actions.andExpect(status().isNoContent());
     }
 
   }

--- a/src/test/java/com/ddudu/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/ddudu/like/controller/LikeControllerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -158,29 +157,6 @@ class LikeControllerTest {
 
       // then
       actions.andExpect(status().isNoContent());
-    }
-
-  }
-
-  @Nested
-  class GET_좋아요_단일_조회_API_테스트 {
-
-    @Test
-    void 좋아요_단일_조회를_성공하면_200_OK를_반환한다() throws Exception {
-      // given
-      Long id = faker.random()
-          .nextLong(Long.MAX_VALUE);
-      LikeResponse response = createLikeResponse(userId, todoId);
-
-      given(likeService.findById(anyLong())).willReturn(response);
-
-      // when
-      ResultActions actions = mockMvc.perform(get("/api/likes/{id}", id)
-          .contentType(MediaType.APPLICATION_JSON));
-
-      // then
-      actions.andExpect(status().isOk())
-          .andExpect(jsonPath("$.id").value(response.id()));
     }
 
   }

--- a/src/test/java/com/ddudu/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/ddudu/like/controller/LikeControllerTest.java
@@ -1,0 +1,169 @@
+package com.ddudu.like.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ddudu.auth.domain.authority.Authority;
+import com.ddudu.config.JwtConfig;
+import com.ddudu.config.WebSecurityConfig;
+import com.ddudu.like.dto.request.LikeRequest;
+import com.ddudu.like.dto.response.LikeResponse;
+import com.ddudu.like.service.LikeService;
+import com.ddudu.support.TestProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.stream.Stream;
+import net.datafaker.Faker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(LikeController.class)
+@Import({WebSecurityConfig.class, TestProperties.class, JwtConfig.class})
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class LikeControllerTest {
+
+  static final Faker faker = new Faker();
+  static final JwsHeader header = JwsHeader.with(MacAlgorithm.HS512)
+      .build();
+  static final JwtClaimsSet.Builder claimSet = JwtClaimsSet.builder()
+      .claim("auth", Authority.NORMAL);
+
+  @MockBean
+  LikeService likeService;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  JwtEncoder jwtEncoder;
+
+  Long userId;
+  Long todoId;
+  String token;
+
+  @BeforeEach
+  void setUp() {
+    userId = faker.random()
+        .nextLong(Long.MAX_VALUE);
+    todoId = faker.random()
+        .nextLong(Long.MAX_VALUE);
+    token = createBearerToken(userId);
+  }
+
+  @Nested
+  class POST_좋아요_API_테스트 {
+
+    static Stream<Arguments> provideLikeRequestAndStrings() {
+      Long userId = faker.random()
+          .nextLong(Long.MAX_VALUE);
+      Long todoId = faker.random()
+          .nextLong(Long.MAX_VALUE);
+
+      return Stream.of(
+          Arguments.of(
+              "사용자가 null", new LikeRequest(null, todoId),
+              "좋아요를 누르려는 사용자의 아이디를 확인할 수 없습니다."
+          ),
+          Arguments.of(
+              "할 일이 null", new LikeRequest(userId, null),
+              "좋아요 대상 할 일의 아이디를 확인할 수 없습니다."
+          )
+      );
+    }
+
+    @ParameterizedTest(name = "{0}일 때, {2}를 응답한다.")
+    @MethodSource("provideLikeRequestAndStrings")
+    void 유효하지_않은_요청이면_400_Bad_Request를_반환한다(String cause, LikeRequest request, String message)
+        throws Exception {
+      // when
+      ResultActions actions = mockMvc.perform(post("/api/likes")
+          .header("Authorization", token)
+          .content(objectMapper.writeValueAsString(request))
+          .contentType(MediaType.APPLICATION_JSON));
+
+      // then
+      actions.andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.[0].code", is(1)))
+          .andExpect(jsonPath("$.[0].message", is(message)));
+    }
+
+//    @Test
+//    void 로그인한_사용자가_없으면_401_Unauthorized를_반환한다() throws Exception {
+//      // given
+//      LikeRequest request = new LikeRequest(userId, todoId);
+//
+//      // when
+//      ResultActions actions = mockMvc.perform(post("/api/likes")
+//          .content(objectMapper.writeValueAsString(request))
+//          .contentType(MediaType.APPLICATION_JSON));
+//
+//      // then
+//      actions.andExpect(status().isUnauthorized())
+//          .andExpect(header().string(HttpHeaders.WWW_AUTHENTICATE, "Bearer"));
+//    }
+
+    @Test
+    void 좋아요하고_201_Created를_반환한다() throws Exception {
+      // given
+      LikeRequest request = new LikeRequest(userId, todoId);
+      LikeResponse response = createLikeResponse(userId, todoId);
+
+      given(likeService.create(anyLong(), any(LikeRequest.class)))
+          .willReturn(response);
+
+      // when
+      ResultActions actions = mockMvc.perform(post("/api/likes")
+          .header("Authorization", token)
+          .content(objectMapper.writeValueAsString(request))
+          .contentType(MediaType.APPLICATION_JSON));
+
+      // then
+      actions.andExpect(status().isCreated())
+          .andExpect(header().exists("location"));
+    }
+
+  }
+
+  private String createBearerToken(long userId) {
+    JwtClaimsSet claims = claimSet.claim("user", userId)
+        .build();
+    Jwt jwt = jwtEncoder.encode(JwtEncoderParameters.from(header, claims));
+    return "Bearer " + jwt.getTokenValue();
+  }
+
+  private LikeResponse createLikeResponse(Long userId, Long todoId) {
+    return LikeResponse.builder()
+        .id(1L)
+        .userId(userId)
+        .todoId(todoId)
+        .build();
+  }
+
+}

--- a/src/test/java/com/ddudu/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/ddudu/like/controller/LikeControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -157,6 +158,29 @@ class LikeControllerTest {
 
       // then
       actions.andExpect(status().isNoContent());
+    }
+
+  }
+
+  @Nested
+  class GET_좋아요_단일_조회_API_테스트 {
+
+    @Test
+    void 좋아요_단일_조회를_성공하면_200_OK를_반환한다() throws Exception {
+      // given
+      Long id = faker.random()
+          .nextLong(Long.MAX_VALUE);
+      LikeResponse response = createLikeResponse(userId, todoId);
+
+      given(likeService.findById(anyLong())).willReturn(response);
+
+      // when
+      ResultActions actions = mockMvc.perform(get("/api/likes/{id}", id)
+          .contentType(MediaType.APPLICATION_JSON));
+
+      // then
+      actions.andExpect(status().isOk())
+          .andExpect(jsonPath("$.id").value(response.id()));
     }
 
   }

--- a/src/test/java/com/ddudu/like/domain/LikeTest.java
+++ b/src/test/java/com/ddudu/like/domain/LikeTest.java
@@ -74,9 +74,26 @@ class LikeTest {
     }
 
     @Test
+    void 사용자는_미완료된_할_일에_좋아요를_할_수_없다() {
+      // given
+      User other = createUser();
+
+      // when
+      ThrowingCallable construct = () -> Like.builder()
+          .user(other)
+          .todo(todo)
+          .build();
+
+      // then
+      assertThatExceptionOfType(InvalidParameterException.class).isThrownBy(construct)
+          .withMessage(LikeErrorCode.UNAVAILABLE_UNCOMPLETED_TODO.getMessage());
+    }
+
+    @Test
     void 좋아요_생성을_성공한다() {
       // given
       User other = createUser();
+      todo.switchStatus();
 
       // when
       Like like = Like.builder()

--- a/src/test/java/com/ddudu/like/domain/LikeTest.java
+++ b/src/test/java/com/ddudu/like/domain/LikeTest.java
@@ -1,0 +1,132 @@
+package com.ddudu.like.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.ddudu.common.exception.InvalidParameterException;
+import com.ddudu.goal.domain.Goal;
+import com.ddudu.like.exception.LikeErrorCode;
+import com.ddudu.todo.domain.Todo;
+import com.ddudu.user.domain.User;
+import net.datafaker.Faker;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class LikeTest {
+
+  static final Faker faker = new Faker();
+
+  User user;
+  Goal goal;
+  Todo todo;
+
+  @BeforeEach
+  void setUp() {
+    user = createUser();
+    goal = createGoal(user);
+    todo = createTodo(user, goal);
+  }
+
+  @Nested
+  class 좋아요_생성_테스트 {
+
+    @Test
+    void 사용자가_NULL이면_좋아요_생성을_실패한다() {
+      // when
+      ThrowingCallable construct = () -> Like.builder()
+          .todo(todo)
+          .build();
+
+      //then
+      assertThatExceptionOfType(InvalidParameterException.class).isThrownBy(construct)
+          .withMessage(LikeErrorCode.NULL_USER.getMessage());
+    }
+
+    @Test
+    void 좋아요할_할_일이_NULL이면_좋아요_생성을_실패한다() {
+      // when
+      ThrowingCallable construct = () -> Like.builder()
+          .user(user)
+          .build();
+
+      //then
+      assertThatExceptionOfType(InvalidParameterException.class).isThrownBy(construct)
+          .withMessage(LikeErrorCode.NULL_TODO.getMessage());
+    }
+
+    @Test
+    void 사용자는_본인의_할_일에_좋아요를_할_수_없다() {
+      // when
+      ThrowingCallable construct = () -> Like.builder()
+          .user(user)
+          .todo(todo)
+          .build();
+
+      //then
+      assertThatExceptionOfType(InvalidParameterException.class).isThrownBy(construct)
+          .withMessage(LikeErrorCode.SELF_LIKE_UNAVAILABLE.getMessage());
+    }
+
+    @Test
+    void 좋아요_생성을_성공한다() {
+      // given
+      User other = createUser();
+
+      // when
+      Like like = Like.builder()
+          .user(other)
+          .todo(todo)
+          .build();
+
+      // then
+      assertThat(like)
+          .extracting("user", "todo")
+          .containsExactly(other, todo);
+    }
+
+  }
+
+  private User createUser() {
+    String email = faker.internet()
+        .emailAddress();
+    String password = faker.internet()
+        .password(8, 40, true, true, true);
+    String nickname = faker.oscarMovie()
+        .character();
+
+    return User.builder()
+        .passwordEncoder(new BCryptPasswordEncoder())
+        .email(email)
+        .password(password)
+        .nickname(nickname)
+        .build();
+  }
+
+  private Goal createGoal(User user) {
+    String name = faker.lorem()
+        .word();
+
+    return Goal.builder()
+        .name(name)
+        .user(user)
+        .build();
+  }
+
+  private Todo createTodo(User user, Goal goal) {
+    String name = faker.lorem()
+        .word();
+
+    return Todo.builder()
+        .name(name)
+        .user(user)
+        .goal(goal)
+        .build();
+  }
+
+}

--- a/src/test/java/com/ddudu/like/service/LikeServiceTest.java
+++ b/src/test/java/com/ddudu/like/service/LikeServiceTest.java
@@ -223,40 +223,6 @@ class LikeServiceTest {
 
   }
 
-  @Nested
-  class 좋아요_단일_조회_테스트 {
-
-    @Test
-    void 좋아요_아이디가_존재하지_않으면_단일_조회를_실패한다() {
-      // given
-      Long invalidId = faker.random()
-          .nextLong(Long.MAX_VALUE);
-
-      // when
-      ThrowingCallable findById = () -> likeService.findById(invalidId);
-
-      // then
-      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(findById)
-          .withMessage(LikeErrorCode.LIKE_NOT_EXISTING.getMessage());
-    }
-
-    @Test
-    void 좋아요_단일_조회를_성공한다() {
-      // given
-      User other = createUser();
-      Like like = createLike(other, todo);
-
-      // when
-      LikeResponse actual = likeService.findById(like.getId());
-
-      // then
-      assertThat(actual.id()).isEqualTo(like.getId());
-      assertThat(actual).extracting("userId", "todoId")
-          .containsExactly(other.getId(), todo.getId());
-    }
-
-  }
-
   private User createUser() {
     String email = faker.internet()
         .emailAddress();

--- a/src/test/java/com/ddudu/like/service/LikeServiceTest.java
+++ b/src/test/java/com/ddudu/like/service/LikeServiceTest.java
@@ -36,8 +36,6 @@ import org.springframework.transaction.annotation.Transactional;
 class LikeServiceTest {
 
   static final Faker faker = new Faker();
-  static final String SUCCESS = "좋아요";
-  static final String CANCEL = "좋아요 취소";
 
   @Autowired
   LikeService likeService;
@@ -82,10 +80,8 @@ class LikeServiceTest {
       // then
       Optional<Like> actual = likeRepository.findById(like.getId());
       assertThat(actual).isPresent();
-      assertThat(actual.get()
-          .isDeleted()).isTrue();
-      assertThat(expected).extracting("userId", "todoId", "message")
-          .containsExactly(other.getId(), todo.getId(), CANCEL);
+      assertThat(expected).extracting("userId", "todoId", "isDeleted")
+          .containsExactly(other.getId(), todo.getId(), true);
     }
 
     @Test
@@ -102,10 +98,8 @@ class LikeServiceTest {
       // then
       Optional<Like> actual = likeRepository.findById(like.getId());
       assertThat(actual).isPresent();
-      assertThat(actual.get()
-          .isDeleted()).isFalse();
-      assertThat(expected).extracting("userId", "todoId", "message")
-          .containsExactly(other.getId(), todo.getId(), SUCCESS);
+      assertThat(expected).extracting("userId", "todoId", "isDeleted")
+          .containsExactly(other.getId(), todo.getId(), false);
     }
 
     @Test
@@ -119,8 +113,8 @@ class LikeServiceTest {
       // then
       Optional<Like> actual = likeRepository.findById(expected.id());
       assertThat(actual).isPresent();
-      assertThat(expected).extracting("userId", "todoId", "message")
-          .containsExactly(other.getId(), todo.getId(), SUCCESS);
+      assertThat(expected).extracting("userId", "todoId", "isDeleted")
+          .containsExactly(other.getId(), todo.getId(), false);
     }
 
     @Test

--- a/src/test/java/com/ddudu/like/service/LikeServiceTest.java
+++ b/src/test/java/com/ddudu/like/service/LikeServiceTest.java
@@ -279,7 +279,6 @@ class LikeServiceTest {
   private void flushAndClearPersistence() {
     entityManager.flush();
     entityManager.clear();
-    ;
   }
 
 }

--- a/src/test/java/com/ddudu/like/service/LikeServiceTest.java
+++ b/src/test/java/com/ddudu/like/service/LikeServiceTest.java
@@ -1,0 +1,199 @@
+package com.ddudu.like.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.ddudu.common.exception.DataNotFoundException;
+import com.ddudu.common.exception.DuplicateResourceException;
+import com.ddudu.common.exception.ForbiddenException;
+import com.ddudu.goal.domain.Goal;
+import com.ddudu.goal.domain.PrivacyType;
+import com.ddudu.goal.repository.GoalRepository;
+import com.ddudu.like.domain.Like;
+import com.ddudu.like.dto.request.LikeRequest;
+import com.ddudu.like.dto.response.LikeResponse;
+import com.ddudu.like.exception.LikeErrorCode;
+import com.ddudu.like.repository.LikeRepository;
+import com.ddudu.todo.domain.Todo;
+import com.ddudu.todo.repository.TodoRepository;
+import com.ddudu.user.domain.User;
+import com.ddudu.user.repository.UserRepository;
+import java.util.Optional;
+import net.datafaker.Faker;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class LikeServiceTest {
+
+  static final Faker faker = new Faker();
+
+  @Autowired
+  LikeService likeService;
+
+  @Autowired
+  LikeRepository likeRepository;
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Autowired
+  GoalRepository goalRepository;
+
+  @Autowired
+  TodoRepository todoRepository;
+
+  User user;
+  Goal goal;
+  Todo todo;
+
+  @BeforeEach
+  void setUp() {
+    user = createUser();
+    goal = createGoal(user);
+    todo = createTodo(user, goal);
+    todo.switchStatus();
+  }
+
+  @Nested
+  class 좋아요_생성_테스트 {
+
+    @Test
+    void 로그인한_사용자가_좋아요할_사용자와_다르면_좋아요_생성을_실패한다() {
+      // given
+      User other = createUser();
+      LikeRequest request = new LikeRequest(user.getId(), todo.getId());
+
+      // when
+      ThrowingCallable create = () -> likeService.create(other.getId(), request);
+
+      // then
+      assertThatExceptionOfType(ForbiddenException.class).isThrownBy(create)
+          .withMessage(LikeErrorCode.INVALID_AUTHORITY.getMessage());
+    }
+
+    @Test
+    void 사용자_아이디가_존재하지_않으면_좋아요_생성을_실패한다() {
+      // given
+      Long invalidUserId = faker.random()
+          .nextLong(Long.MAX_VALUE);
+      LikeRequest request = new LikeRequest(invalidUserId, todo.getId());
+
+      // when
+      ThrowingCallable create = () -> likeService.create(invalidUserId, request);
+
+      // then
+      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(create)
+          .withMessage(LikeErrorCode.USER_NOT_EXISTING.getMessage());
+    }
+
+    @Test
+    void 할_일_아이디가_존재하지_않으면_좋아요_생성을_실패한다() {
+      // given
+      User other = createUser();
+      Long invalidTodoId = faker.random()
+          .nextLong(Long.MAX_VALUE);
+      LikeRequest request = new LikeRequest(other.getId(), invalidTodoId);
+
+      // when
+      ThrowingCallable create = () -> likeService.create(other.getId(), request);
+
+      // then
+      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(create)
+          .withMessage(LikeErrorCode.TODO_NOT_EXISTING.getMessage());
+    }
+
+    @Test
+    void 이미_좋아요를_눌렀다면_좋아요_생성을_실패한다() {
+      // given
+      User other = createUser();
+
+      Like like = Like.builder()
+          .user(other)
+          .todo(todo)
+          .build();
+      likeRepository.save(like);
+
+      LikeRequest request = new LikeRequest(other.getId(), todo.getId());
+
+      // when
+      ThrowingCallable create = () -> likeService.create(other.getId(), request);
+
+      // then
+      assertThatExceptionOfType(DuplicateResourceException.class).isThrownBy(create)
+          .withMessage(LikeErrorCode.ALREADY_LIKED.getMessage());
+    }
+
+    @Test
+    void 완료된_할_일에_대해_좋아요_생성을_성공한다() {
+      // given
+      User other = createUser();
+      LikeRequest request = new LikeRequest(other.getId(), todo.getId());
+
+      // when
+      LikeResponse expected = likeService.create(other.getId(), request);
+
+      // then
+      Optional<Like> actual = likeRepository.findById(expected.id());
+      assertThat(actual).isPresent();
+      assertThat(actual.get()).extracting("user", "todo")
+          .containsExactly(other, todo);
+    }
+
+  }
+
+  private User createUser() {
+    String email = faker.internet()
+        .emailAddress();
+    String password = faker.internet()
+        .password(8, 40, true, true, true);
+    String nickname = faker.oscarMovie()
+        .character();
+
+    User user = User.builder()
+        .passwordEncoder(new BCryptPasswordEncoder())
+        .email(email)
+        .password(password)
+        .nickname(nickname)
+        .build();
+
+    return userRepository.save(user);
+  }
+
+  private Goal createGoal(User user) {
+    String name = faker.lorem()
+        .word();
+
+    Goal goal = Goal.builder()
+        .name(name)
+        .user(user)
+        .privacyType(PrivacyType.PUBLIC)
+        .build();
+
+    return goalRepository.save(goal);
+  }
+
+  private Todo createTodo(User user, Goal goal) {
+    String name = faker.lorem()
+        .word();
+
+    Todo todo = Todo.builder()
+        .name(name)
+        .user(user)
+        .goal(goal)
+        .build();
+
+    return todoRepository.save(todo);
+  }
+
+}

--- a/src/test/java/com/ddudu/like/service/LikeServiceTest.java
+++ b/src/test/java/com/ddudu/like/service/LikeServiceTest.java
@@ -223,6 +223,40 @@ class LikeServiceTest {
 
   }
 
+  @Nested
+  class 좋아요_단일_조회_테스트 {
+
+    @Test
+    void 좋아요_아이디가_존재하지_않으면_단일_조회를_실패한다() {
+      // given
+      Long invalidId = faker.random()
+          .nextLong(Long.MAX_VALUE);
+
+      // when
+      ThrowingCallable findById = () -> likeService.findById(invalidId);
+
+      // then
+      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(findById)
+          .withMessage(LikeErrorCode.LIKE_NOT_EXISTING.getMessage());
+    }
+
+    @Test
+    void 좋아요_단일_조회를_성공한다() {
+      // given
+      User other = createUser();
+      Like like = createLike(other, todo);
+
+      // when
+      LikeResponse actual = likeService.findById(like.getId());
+
+      // then
+      assertThat(actual.id()).isEqualTo(like.getId());
+      assertThat(actual).extracting("userId", "todoId")
+          .containsExactly(other.getId(), todo.getId());
+    }
+
+  }
+
   private User createUser() {
     String email = faker.internet()
         .emailAddress();

--- a/src/test/java/com/ddudu/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/ddudu/todo/service/TodoServiceTest.java
@@ -11,6 +11,8 @@ import com.ddudu.following.service.FollowingService;
 import com.ddudu.goal.domain.Goal;
 import com.ddudu.goal.domain.PrivacyType;
 import com.ddudu.goal.repository.GoalRepository;
+import com.ddudu.like.domain.Like;
+import com.ddudu.like.repository.LikeRepository;
 import com.ddudu.todo.domain.Todo;
 import com.ddudu.todo.domain.TodoStatus;
 import com.ddudu.todo.dto.request.CreateTodoRequest;
@@ -64,6 +66,9 @@ class TodoServiceTest {
 
   @Autowired
   FollowingService followingService;
+
+  @Autowired
+  LikeRepository likeRepository;
 
   @Autowired
   EntityManager entityManager;
@@ -252,6 +257,37 @@ class TodoServiceTest {
       // then
       assertThat(responses).hasSize(0);
       assertThat(goal.getPrivacyType()).isEqualTo(PrivacyType.PRIVATE);
+    }
+
+    @Test
+    void 주어진_날짜에_할_일_리스트_및_좋아요_조회를_성공한다() {
+      // given
+      Goal goal = createGoal(goalName, user);
+      Todo todo = createTodo(name, goal, user);
+      todo.switchStatus();
+
+      LocalDate date = LocalDate.now();
+
+      User other = createUser();
+      Like like = createLike(other, todo);
+
+      // when
+      List<TodoListResponse> responses = todoService.findAllByDate(
+          user.getId(), user.getId(), date);
+
+      // then
+      assertThat(responses).hasSize(1);
+
+      TodoListResponse response = responses.get(0);
+      assertThat(response.todolist()).hasSize(1);
+
+      TodoInfo todoInfo = responses.get(0)
+          .todolist()
+          .get(0);
+      assertThat(todoInfo.likeInfo()
+          .count()).isEqualTo(1);
+      assertThat(todoInfo.likeInfo()
+          .users()).containsExactly(other.getId());
     }
 
     @Test
@@ -722,6 +758,14 @@ class TodoServiceTest {
         .build();
 
     return userRepository.save(user);
+  }
+
+  private Like createLike(User user, Todo todo) {
+    Like like = Like.builder()
+        .user(user)
+        .todo(todo)
+        .build();
+    return likeRepository.save(like);
   }
 
   private void flushAndClearPersistence() {

--- a/src/test/java/com/ddudu/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/ddudu/todo/service/TodoServiceTest.java
@@ -284,9 +284,9 @@ class TodoServiceTest {
       TodoInfo todoInfo = responses.get(0)
           .todolist()
           .get(0);
-      assertThat(todoInfo.likeInfo()
+      assertThat(todoInfo.likes()
           .count()).isEqualTo(1);
-      assertThat(todoInfo.likeInfo()
+      assertThat(todoInfo.likes()
           .users()).containsExactly(other.getId());
     }
 


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #82
Resolves #94 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
* 좋아요 기능 구현
* 좋아요 취소 기능 구현
* 좋아요 단일 조회 기능 구현

## 코멘트

- todomate 앱을 보니까 **단일 조회**의 경우 꼭 좋아요를 한 사용자만 조회할 수 있는 것이 아니고 모든 사용자가 좋아요를 조회할 수 있기에, `@Login`을 따로 추가하지 않았습니다. 그래도 추후 확장성을 위해 @Login을 추가하는 것이 좋을까요?
- 기존에 구현된 기능과 비슷하기에 한 번에 PR을 날렸는데 양이 생각보다 많네요.. 😢 