### PR TITLE
팔로이 조회 api

### DIFF
--- a/src/main/java/com/ddudu/auth/service/AuthService.java
+++ b/src/main/java/com/ddudu/auth/service/AuthService.java
@@ -12,7 +12,6 @@ import com.ddudu.config.properties.JwtProperties;
 import com.ddudu.user.domain.Email;
 import com.ddudu.user.domain.Password;
 import com.ddudu.user.domain.User;
-import com.ddudu.user.dto.response.UserResponse;
 import com.ddudu.user.repository.UserRepository;
 import java.time.Duration;
 import java.util.HashMap;

--- a/src/main/java/com/ddudu/following/service/FollowingService.java
+++ b/src/main/java/com/ddudu/following/service/FollowingService.java
@@ -15,11 +15,9 @@ import com.ddudu.following.repository.FollowingRepository;
 import com.ddudu.user.domain.Options;
 import com.ddudu.user.domain.User;
 import com.ddudu.user.repository.UserRepository;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.annotation.Validated;
 
 @Service
 @RequiredArgsConstructor
@@ -29,15 +27,8 @@ public class FollowingService {
   private final UserRepository userRepository;
   private final FollowingRepository followingRepository;
 
-  private static void checkPermission(Long loginId, Following following) {
-    if (!following.isOwnedBy(loginId)) {
-      throw new ForbiddenException(FollowingErrorCode.WRONG_OWNER);
-    }
-  }
-
   @Transactional
-  @Validated
-  public FollowingResponse create(Long followerId, @Valid FollowRequest request) {
+  public FollowingResponse create(Long followerId, FollowRequest request) {
     User follower = userRepository.findById(followerId)
         .orElseThrow(() -> new DataNotFoundException(FollowingErrorCode.FOLLOWER_NOT_EXISTING));
     User followee = userRepository.findById(request.followeeId())
@@ -89,6 +80,12 @@ public class FollowingService {
           checkPermission(loginId, following);
           followingRepository.delete(following);
         });
+  }
+
+  private void checkPermission(Long loginId, Following following) {
+    if (!following.isOwnedBy(loginId)) {
+      throw new ForbiddenException(FollowingErrorCode.WRONG_OWNER);
+    }
   }
 
 }

--- a/src/main/java/com/ddudu/user/controller/UserController.java
+++ b/src/main/java/com/ddudu/user/controller/UserController.java
@@ -9,9 +9,11 @@ import com.ddudu.user.dto.response.SignUpResponse;
 import com.ddudu.user.dto.response.UpdateEmailResponse;
 import com.ddudu.user.dto.response.UpdatePasswordResponse;
 import com.ddudu.user.dto.response.UserProfileResponse;
+import com.ddudu.user.dto.response.UserResponse;
 import com.ddudu.user.service.UserService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -96,6 +98,18 @@ public class UserController {
     UserProfileResponse response = userService.updateProfile(loginId, id, request);
 
     return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/{id}/followees")
+  public ResponseEntity<List<UserResponse>> getFollowees(
+      @Login
+      Long loginId,
+      @PathVariable
+      Long id
+  ) {
+    List<UserResponse> responses = userService.findFollowees(loginId, id);
+
+    return ResponseEntity.ok(responses);
   }
 
 }

--- a/src/main/java/com/ddudu/user/controller/UserController.java
+++ b/src/main/java/com/ddudu/user/controller/UserController.java
@@ -6,9 +6,9 @@ import com.ddudu.user.dto.request.UpdateEmailRequest;
 import com.ddudu.user.dto.request.UpdatePasswordRequest;
 import com.ddudu.user.dto.request.UpdateProfileRequest;
 import com.ddudu.user.dto.response.SignUpResponse;
+import com.ddudu.user.dto.response.UpdateEmailResponse;
 import com.ddudu.user.dto.response.UpdatePasswordResponse;
 import com.ddudu.user.dto.response.UserProfileResponse;
-import com.ddudu.user.dto.response.UserResponse;
 import com.ddudu.user.service.UserService;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -44,17 +44,17 @@ public class UserController {
   }
 
   @GetMapping("/{id}")
-  public ResponseEntity<UserResponse> getById(
+  public ResponseEntity<UserProfileResponse> getById(
       @PathVariable
       Long id
   ) {
-    UserResponse response = userService.findById(id);
+    UserProfileResponse response = userService.findById(id);
 
     return ResponseEntity.ok(response);
   }
 
   @PatchMapping("/{id}/email")
-  public ResponseEntity<UserResponse> updateEmail(
+  public ResponseEntity<UpdateEmailResponse> updateEmail(
       @Login
       Long loginId,
       @PathVariable
@@ -63,7 +63,7 @@ public class UserController {
       @Valid
       UpdateEmailRequest request
   ) {
-    UserResponse response = userService.updateEmail(loginId, id, request);
+    UpdateEmailResponse response = userService.updateEmail(loginId, id, request);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/ddudu/user/dto/response/UpdateEmailResponse.java
+++ b/src/main/java/com/ddudu/user/dto/response/UpdateEmailResponse.java
@@ -1,0 +1,5 @@
+package com.ddudu.user.dto.response;
+
+public record UpdateEmailResponse(String email) {
+
+}

--- a/src/main/java/com/ddudu/user/dto/response/UserResponse.java
+++ b/src/main/java/com/ddudu/user/dto/response/UserResponse.java
@@ -4,14 +4,12 @@ import com.ddudu.user.domain.User;
 import lombok.Builder;
 
 @Builder
-public record UserResponse(Long id, String email, String optionalUsername, String nickname) {
+public record UserResponse(Long id, String nickname, String introduction) {
 
   public static UserResponse from(User user) {
     return UserResponse.builder()
         .id(user.getId())
-        .email(user.getEmail())
         .nickname(user.getNickname())
-        .optionalUsername(user.getOptionalUsername())
         .build();
   }
 

--- a/src/main/java/com/ddudu/user/dto/response/UserResponse.java
+++ b/src/main/java/com/ddudu/user/dto/response/UserResponse.java
@@ -4,7 +4,7 @@ import com.ddudu.user.domain.User;
 import lombok.Builder;
 
 @Builder
-public record UserResponse(Long id, String nickname, String introduction) {
+public record UserResponse(Long id, String nickname) {
 
   public static UserResponse from(User user) {
     return UserResponse.builder()

--- a/src/main/java/com/ddudu/user/repository/UserRepository.java
+++ b/src/main/java/com/ddudu/user/repository/UserRepository.java
@@ -5,7 +5,7 @@ import com.ddudu.user.domain.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
   boolean existsByEmail(Email email);
 

--- a/src/main/java/com/ddudu/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/ddudu/user/repository/UserRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.ddudu.user.repository;
+
+import com.ddudu.user.domain.User;
+import java.util.List;
+
+public interface UserRepositoryCustom {
+
+  List<User> findFolloweesOfUser(User follower);
+
+}

--- a/src/main/java/com/ddudu/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/ddudu/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.ddudu.user.repository;
+
+import static com.ddudu.following.domain.QFollowing.following;
+
+import com.ddudu.user.domain.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserRepositoryImpl implements UserRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  public UserRepositoryImpl(EntityManager em) {
+    this.jpaQueryFactory = new JPAQueryFactory(em);
+  }
+
+  @Override
+  public List<User> findFolloweesOfUser(User follower) {
+    return jpaQueryFactory
+        .select(following.followee)
+        .from(following)
+        .where(following.follower.eq(follower))
+        .fetch();
+  }
+
+}

--- a/src/main/java/com/ddudu/user/service/UserService.java
+++ b/src/main/java/com/ddudu/user/service/UserService.java
@@ -13,9 +13,9 @@ import com.ddudu.user.dto.request.UpdateEmailRequest;
 import com.ddudu.user.dto.request.UpdatePasswordRequest;
 import com.ddudu.user.dto.request.UpdateProfileRequest;
 import com.ddudu.user.dto.response.SignUpResponse;
+import com.ddudu.user.dto.response.UpdateEmailResponse;
 import com.ddudu.user.dto.response.UpdatePasswordResponse;
 import com.ddudu.user.dto.response.UserProfileResponse;
-import com.ddudu.user.dto.response.UserResponse;
 import com.ddudu.user.exception.UserErrorCode;
 import com.ddudu.user.repository.UserRepository;
 import java.util.Objects;
@@ -77,7 +77,7 @@ public class UserService {
     return UserProfileResponse.from(user);
   }
 
-  public UserResponse updateEmail(Long loginId, Long userId, UpdateEmailRequest request) {
+  public UpdateEmailResponse updateEmail(Long loginId, Long userId, UpdateEmailRequest request) {
     if (!loginId.equals(userId)) {
       throw new InvalidTokenException(UserErrorCode.INVALID_AUTHENTICATION);
     }
@@ -97,7 +97,7 @@ public class UserService {
 
     user.applyEmailUpdate(newEmail);
 
-    return UserResponse.from(user);
+    return new UpdateEmailResponse(newEmail.getAddress());
   }
 
   @Transactional
@@ -122,11 +122,11 @@ public class UserService {
     return new UpdatePasswordResponse(PASSWORD_UPDATE_SUCCESS);
   }
 
-  public UserResponse findById(Long userId) {
+  public UserProfileResponse findById(Long userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new DataNotFoundException(UserErrorCode.ID_NOT_EXISTING));
 
-    return UserResponse.from(user);
+    return UserProfileResponse.from(user);
   }
 
 }

--- a/src/main/java/com/ddudu/user/service/UserService.java
+++ b/src/main/java/com/ddudu/user/service/UserService.java
@@ -16,8 +16,10 @@ import com.ddudu.user.dto.response.SignUpResponse;
 import com.ddudu.user.dto.response.UpdateEmailResponse;
 import com.ddudu.user.dto.response.UpdatePasswordResponse;
 import com.ddudu.user.dto.response.UserProfileResponse;
+import com.ddudu.user.dto.response.UserResponse;
 import com.ddudu.user.exception.UserErrorCode;
 import com.ddudu.user.repository.UserRepository;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -127,6 +129,21 @@ public class UserService {
         .orElseThrow(() -> new DataNotFoundException(UserErrorCode.ID_NOT_EXISTING));
 
     return UserProfileResponse.from(user);
+  }
+
+  public List<UserResponse> findFollowees(Long loginId, Long id) {
+    if (!loginId.equals(id)) {
+      throw new ForbiddenException(UserErrorCode.INVALID_AUTHORITY);
+    }
+
+    User user = userRepository.findById(loginId)
+        .orElseThrow(() -> new DataNotFoundException(UserErrorCode.ID_NOT_EXISTING));
+
+    List<User> followees = userRepository.findFolloweesOfUser(user);
+
+    return followees.stream()
+        .map(UserResponse::from)
+        .toList();
   }
 
 }

--- a/src/test/java/com/ddudu/user/controller/UserControllerTest.java
+++ b/src/test/java/com/ddudu/user/controller/UserControllerTest.java
@@ -24,9 +24,9 @@ import com.ddudu.user.dto.request.UpdateEmailRequest;
 import com.ddudu.user.dto.request.UpdatePasswordRequest;
 import com.ddudu.user.dto.request.UpdateProfileRequest;
 import com.ddudu.user.dto.response.SignUpResponse;
+import com.ddudu.user.dto.response.UpdateEmailResponse;
 import com.ddudu.user.dto.response.UpdatePasswordResponse;
 import com.ddudu.user.dto.response.UserProfileResponse;
-import com.ddudu.user.dto.response.UserResponse;
 import com.ddudu.user.exception.UserErrorCode;
 import com.ddudu.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -257,9 +257,8 @@ class UserControllerTest {
       // given
       long userId = faker.random()
           .nextLong(Long.MAX_VALUE);
-      UserResponse expected = UserResponse.builder()
+      UserProfileResponse expected = UserProfileResponse.builder()
           .id(userId)
-          .email(email)
           .nickname(nickname)
           .build();
 
@@ -350,11 +349,7 @@ class UserControllerTest {
       String newEmail = faker.internet()
           .emailAddress();
       UpdateEmailRequest request = new UpdateEmailRequest(newEmail);
-      UserResponse response = UserResponse.builder()
-          .id(userId)
-          .email(request.email())
-          .nickname(nickname)
-          .build();
+      UpdateEmailResponse response = new UpdateEmailResponse(newEmail);
 
       given(userService.updateEmail(anyLong(), anyLong(), any(UpdateEmailRequest.class)))
           .willReturn(response);

--- a/src/test/java/com/ddudu/user/service/UserServiceTest.java
+++ b/src/test/java/com/ddudu/user/service/UserServiceTest.java
@@ -15,7 +15,7 @@ import com.ddudu.user.dto.request.UpdateEmailRequest;
 import com.ddudu.user.dto.request.UpdatePasswordRequest;
 import com.ddudu.user.dto.request.UpdateProfileRequest;
 import com.ddudu.user.dto.response.SignUpResponse;
-import com.ddudu.user.dto.response.UserResponse;
+import com.ddudu.user.dto.response.UserProfileResponse;
 import com.ddudu.user.exception.UserErrorCode;
 import com.ddudu.user.repository.UserRepository;
 import java.util.List;
@@ -193,7 +193,7 @@ class UserServiceTest {
       User expected = userRepository.save(user);
 
       // when
-      UserResponse actual = userService.findById(expected.getId());
+      UserProfileResponse actual = userService.findById(expected.getId());
 
       // then
       assertThat(actual.id()).isEqualTo(expected.getId());


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
* #98 
## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
* 불필요한 Response 축소 (완료는 아니고 별개로 리팩토링 할 때 더 할게용)
  * 유저 단일 조회: `id, email, nickname, optionalUsername` -> `nickname, introduction`
  * 이메일 변경 API 응답: `id, email, nickname, optionalUsername` -> `email`
* 로그인 사용자의 팔로이 조회 API: `GET /api/users/{id}/followees`