### PR TITLE
팔로워 조회 기능 구현

### DIFF
--- a/src/main/java/com/ddudu/user/controller/UserController.java
+++ b/src/main/java/com/ddudu/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.ddudu.user.controller;
 
 import com.ddudu.common.annotation.Login;
 import com.ddudu.common.exception.ForbiddenException;
+import com.ddudu.user.dto.FollowingSearchType;
 import com.ddudu.user.dto.request.FollowRequest;
 import com.ddudu.user.dto.request.SignUpRequest;
 import com.ddudu.user.dto.request.UpdateEmailRequest;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -129,18 +131,20 @@ public class UserController {
     return ResponseEntity.ok(response);
   }
 
-  @GetMapping("/{id}/followees")
-  public ResponseEntity<UsersResponse> getFollowees(
+  @GetMapping("/{id}/followings")
+  public ResponseEntity<UsersResponse> getFromFollowings(
       @Login
       Long loginId,
       @PathVariable
-      Long id
+      Long id,
+      @RequestParam
+      FollowingSearchType searchType
   ) {
     checkAuthority(loginId, id);
 
-    UsersResponse responses = userService.findFollowees(id);
+    UsersResponse response = userService.findFromFollowings(id, searchType);
 
-    return ResponseEntity.ok(responses);
+    return ResponseEntity.ok(response);
   }
 
   @PostMapping("/{id}/followings")

--- a/src/main/java/com/ddudu/user/controller/UserController.java
+++ b/src/main/java/com/ddudu/user/controller/UserController.java
@@ -138,7 +138,7 @@ public class UserController {
   ) {
     checkAuthority(loginId, id);
 
-    UsersResponse responses = userService.findFollowees(loginId, id);
+    UsersResponse responses = userService.findFollowees(id);
 
     return ResponseEntity.ok(responses);
   }

--- a/src/main/java/com/ddudu/user/dto/FollowingSearchType.java
+++ b/src/main/java/com/ddudu/user/dto/FollowingSearchType.java
@@ -1,0 +1,10 @@
+package com.ddudu.user.dto;
+
+public enum FollowingSearchType {
+  FOLLOWEE,
+  FOLLOWER;
+
+  public static boolean isSearchingFollower(FollowingSearchType searchType) {
+    return searchType == FOLLOWER;
+  }
+}

--- a/src/main/java/com/ddudu/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/ddudu/user/repository/UserRepositoryCustom.java
@@ -1,10 +1,11 @@
 package com.ddudu.user.repository;
 
 import com.ddudu.user.domain.User;
+import com.ddudu.user.dto.FollowingSearchType;
 import java.util.List;
 
 public interface UserRepositoryCustom {
 
-  List<User> findFolloweesOfUser(User follower);
+  List<User> findFromFollowingBySearchType(User follower, FollowingSearchType searchType);
 
 }

--- a/src/main/java/com/ddudu/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/ddudu/user/repository/UserRepositoryImpl.java
@@ -3,7 +3,9 @@ package com.ddudu.user.repository;
 import static com.ddudu.user.domain.QFollowing.following;
 
 import com.ddudu.user.domain.FollowingStatus;
+import com.ddudu.user.domain.QUser;
 import com.ddudu.user.domain.User;
+import com.ddudu.user.dto.FollowingSearchType;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
@@ -20,14 +22,21 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
   }
 
   @Override
-  public List<User> findFolloweesOfUser(User follower) {
+  public List<User> findFromFollowingBySearchType(User user, FollowingSearchType searchType) {
     BooleanBuilder whereClause = new BooleanBuilder();
+    QUser owner = following.follower;
+    QUser target = following.followee;
 
-    whereClause.and(following.follower.eq(follower))
+    if (FollowingSearchType.isSearchingFollower(searchType)) {
+      owner = following.followee;
+      target = following.follower;
+    }
+
+    whereClause.and(owner.eq(user))
         .and(following.status.eq(FollowingStatus.FOLLOWING));
 
     return jpaQueryFactory
-        .select(following.followee)
+        .select(target)
         .from(following)
         .where(whereClause)
         .fetch();

--- a/src/main/java/com/ddudu/user/service/UserService.java
+++ b/src/main/java/com/ddudu/user/service/UserService.java
@@ -65,6 +65,7 @@ public class UserService {
     return UserProfileResponse.from(user);
   }
 
+  @Transactional
   public UpdateEmailResponse updateEmail(Long userId, UpdateEmailRequest request) {
     User user = findUser(userId);
     String newEmail = request.email();
@@ -76,7 +77,7 @@ public class UserService {
     verifyUniqueEmail(newEmail);
     user.applyEmailUpdate(newEmail);
 
-    return new UpdateEmailResponse(newEmail.getAddress());
+    return new UpdateEmailResponse(user.getEmail());
   }
 
   @Transactional

--- a/src/main/java/com/ddudu/user/service/UserService.java
+++ b/src/main/java/com/ddudu/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.ddudu.common.exception.DataNotFoundException;
 import com.ddudu.common.exception.DuplicateResourceException;
 import com.ddudu.user.domain.Email;
 import com.ddudu.user.domain.User;
+import com.ddudu.user.dto.FollowingSearchType;
 import com.ddudu.user.dto.request.SignUpRequest;
 import com.ddudu.user.dto.request.UpdateEmailRequest;
 import com.ddudu.user.dto.request.UpdatePasswordRequest;
@@ -95,12 +96,12 @@ public class UserService {
     return UserProfileResponse.from(user);
   }
 
-  public UsersResponse findFollowees(Long id) {
+  public UsersResponse findFromFollowings(Long id, FollowingSearchType searchType) {
     User user = findUser(id);
 
-    List<User> followees = userRepository.findFolloweesOfUser(user);
+    List<User> users = userRepository.findFromFollowingBySearchType(user, searchType);
 
-    return UsersResponse.from(followees);
+    return UsersResponse.from(users);
   }
 
   @Transactional

--- a/src/test/java/com/ddudu/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/ddudu/auth/service/AuthServiceTest.java
@@ -57,8 +57,8 @@ class AuthServiceTest {
         .emailAddress();
     password = faker.internet()
         .password(8, 40, true, true, true);
-    nickname = faker.funnyName()
-        .name();
+    nickname = faker.internet()
+        .username();
   }
 
   @Nested
@@ -67,8 +67,6 @@ class AuthServiceTest {
     @Test
     void 로그인을_성공하고_JWT를_발급받는다() {
       // given
-      String nickname = faker.internet()
-          .username();
       User user = User.builder()
           .email(email)
           .password(password)
@@ -107,8 +105,6 @@ class AuthServiceTest {
     @Test
     void 비밀번호가_다를_시_로그인을_실패한다() {
       // given
-      String nickname = faker.internet()
-          .username();
       User user = User.builder()
           .email(email)
           .passwordEncoder(passwordEncoder)
@@ -138,8 +134,6 @@ class AuthServiceTest {
     @Test
     void 사용자_로딩을_성공한다() {
       // given
-      String email = faker.internet()
-          .emailAddress();
       User user = User.builder()
           .passwordEncoder(passwordEncoder)
           .email(email)

--- a/src/test/java/com/ddudu/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/ddudu/auth/service/AuthServiceTest.java
@@ -65,45 +65,6 @@ class AuthServiceTest {
   class 로그인_테스트 {
 
     @Test
-    void 존재하지_않는_이메일_로그인을_실패한다() {
-      // given
-      LoginRequest request = new LoginRequest(email, password);
-
-      // when
-      ThrowingCallable login = () -> authService.login(request);
-
-      // then
-      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(login)
-          .withMessage(AuthErrorCode.EMAIL_NOT_EXISTING.getMessage());
-    }
-
-    @Test
-    void 비밀번호가_다를_시_로그인을_실패한다() {
-      // given
-      String nickname = faker.funnyName()
-          .name();
-      User user = User.builder()
-          .email(email)
-          .passwordEncoder(passwordEncoder)
-          .password(password)
-          .nickname(nickname)
-          .build();
-
-      userRepository.save(user);
-
-      String newPassword = faker.internet()
-          .password();
-      LoginRequest request = new LoginRequest(email, newPassword);
-
-      // when
-      ThrowingCallable login = () -> authService.login(request);
-
-      // then
-      assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(login)
-          .withMessage(AuthErrorCode.BAD_CREDENTIALS.getMessage());
-    }
-
-    @Test
     void 로그인을_성공하고_JWT를_발급받는다() {
       // given
       String nickname = faker.internet()
@@ -130,24 +91,49 @@ class AuthServiceTest {
       assertThat(actualAuthority).isEqualTo(expected.getAuthority());
     }
 
+    @Test
+    void 존재하지_않는_이메일_로그인을_실패한다() {
+      // given
+      LoginRequest request = new LoginRequest(email, password);
+
+      // when
+      ThrowingCallable login = () -> authService.login(request);
+
+      // then
+      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(login)
+          .withMessage(AuthErrorCode.EMAIL_NOT_EXISTING.getMessage());
+    }
+
+    @Test
+    void 비밀번호가_다를_시_로그인을_실패한다() {
+      // given
+      String nickname = faker.internet()
+          .username();
+      User user = User.builder()
+          .email(email)
+          .passwordEncoder(passwordEncoder)
+          .password(password)
+          .nickname(nickname)
+          .build();
+
+      userRepository.save(user);
+
+      String newPassword = faker.internet()
+          .password();
+      LoginRequest request = new LoginRequest(email, newPassword);
+
+      // when
+      ThrowingCallable login = () -> authService.login(request);
+
+      // then
+      assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(login)
+          .withMessage(AuthErrorCode.BAD_CREDENTIALS.getMessage());
+    }
+
   }
 
   @Nested
   class 사용자_로딩_테스트 {
-
-    @Test
-    void 존재하지_않는_사용자_아이디_로딩을_실패한다() {
-      // given
-      long randomId = faker.random()
-          .nextLong();
-
-      // when
-      ThrowingCallable login = () -> authService.loadUser(randomId);
-
-      // then
-      assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(login)
-          .withMessage(AuthErrorCode.INVALID_AUTHENTICATION.getMessage());
-    }
 
     @Test
     void 사용자_로딩을_성공한다() {
@@ -167,6 +153,20 @@ class AuthServiceTest {
 
       // then
       assertThat(actual.id()).isEqualTo(expected.getId());
+    }
+
+    @Test
+    void 존재하지_않는_사용자_아이디_로딩을_실패한다() {
+      // given
+      long randomId = faker.random()
+          .nextLong();
+
+      // when
+      ThrowingCallable login = () -> authService.loadUser(randomId);
+
+      // then
+      assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(login)
+          .withMessage(AuthErrorCode.INVALID_AUTHENTICATION.getMessage());
     }
 
   }

--- a/src/test/java/com/ddudu/user/controller/UserControllerTest.java
+++ b/src/test/java/com/ddudu/user/controller/UserControllerTest.java
@@ -1,6 +1,5 @@
 package com.ddudu.user.controller;
 
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasValue;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,6 +22,7 @@ import com.ddudu.common.exception.DuplicateResourceException;
 import com.ddudu.common.exception.ForbiddenException;
 import com.ddudu.support.ControllerTestSupport;
 import com.ddudu.user.domain.FollowingStatus;
+import com.ddudu.user.dto.FollowingSearchType;
 import com.ddudu.user.dto.SimpleUserDto;
 import com.ddudu.user.dto.request.FollowRequest;
 import com.ddudu.user.dto.request.SignUpRequest;
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -625,9 +626,9 @@ class UserControllerTest extends ControllerTestSupport {
   }
 
   @Nested
-  class GET_팔로이_조회_API_테스트 {
+  class GET_팔로워_팔로이_조회_API_테스트 {
 
-    static final String PATH = "/api/users/{id}/followees";
+    static final String PATH = "/api/users/{id}/followings";
 
     Long loginId;
     String token;
@@ -639,39 +640,45 @@ class UserControllerTest extends ControllerTestSupport {
       token = createBearerToken(loginId);
     }
 
-    @Test
-    void 로그인_사용자의_팔로이_조회를_성공하고_200_OK를_반환한다() throws Exception {
+    @ParameterizedTest(name = "조회 대상: {0}")
+    @EnumSource(FollowingSearchType.class)
+    void 로그인_사용자의_팔로잉_정보_조회를_성공하고_200_OK를_반환한다(FollowingSearchType searchType)
+        throws Exception {
       // given
-      long followeeId = faker.random()
+      long targetId = faker.random()
           .nextLong(Long.MAX_VALUE);
       String anotherNickname = faker.funnyName()
           .name();
       UsersResponse response = new UsersResponse(
-          1, List.of(new SimpleUserDto(followeeId, anotherNickname)));
+          1, List.of(new SimpleUserDto(targetId, anotherNickname)));
 
-      given(userService.findFollowees(anyLong()))
+      given(userService.findFromFollowings(anyLong(), any(FollowingSearchType.class)))
           .willReturn(response);
 
       // when
       ResultActions actions = mockMvc.perform(get(PATH, loginId)
-          .header(AUTHORIZATION, token));
+          .header(AUTHORIZATION, token)
+          .param("searchType", searchType.name()));
 
       // then
       actions.andExpect(status().isOk())
           .andExpect(jsonPath("$.counts").value(1))
-          .andExpect(jsonPath("$.users").value(hasSize(1)))
-          .andExpect(jsonPath("$.users.[0]").value(hasValue(followeeId)));
+          .andExpect(jsonPath("$.users.length()").value(1))
+          .andExpect(jsonPath("$.users.[0]").value(hasValue(targetId)));
     }
 
-    @Test
-    void 로그인한_사용자와_요청의_사용자가_다르면_403_Forbidden을_반환한다() throws Exception {
+    @ParameterizedTest(name = "조회 대상: {0}")
+    @EnumSource(FollowingSearchType.class)
+    void 로그인한_사용자와_요청의_사용자가_다르면_403_Forbidden을_반환한다(FollowingSearchType searchType)
+        throws Exception {
       // given
       long invalidId = faker.random()
           .nextLong(Long.MAX_VALUE);
 
       // when
       ResultActions actions = mockMvc.perform(get(PATH, invalidId)
-          .header(AUTHORIZATION, token));
+          .header(AUTHORIZATION, token)
+          .param("searchType", searchType.name()));
 
       // then
       actions.andExpect(status().isForbidden())
@@ -679,15 +686,18 @@ class UserControllerTest extends ControllerTestSupport {
           .andExpect(jsonPath("$.message").value(UserErrorCode.INVALID_AUTHORITY.getMessage()));
     }
 
-    @Test
-    void 존재하지_않는_사용자일_경우_404_Not_Found를_반환한다() throws Exception {
+    @ParameterizedTest(name = "조회 대상: {0}")
+    @EnumSource(FollowingSearchType.class)
+    void 존재하지_않는_사용자일_경우_404_Not_Found를_반환한다(FollowingSearchType searchType)
+        throws Exception {
       // given
-      given(userService.findFollowees(anyLong()))
+      given(userService.findFromFollowings(anyLong(), any(FollowingSearchType.class)))
           .willThrow(new DataNotFoundException(UserErrorCode.ID_NOT_EXISTING));
 
       // when
       ResultActions actions = mockMvc.perform(get(PATH, loginId)
-          .header(AUTHORIZATION, token));
+          .header(AUTHORIZATION, token)
+          .param("searchType", searchType.name()));
 
       // then
       actions.andExpect(status().isNotFound())

--- a/src/test/java/com/ddudu/user/controller/UserControllerTest.java
+++ b/src/test/java/com/ddudu/user/controller/UserControllerTest.java
@@ -649,7 +649,7 @@ class UserControllerTest extends ControllerTestSupport {
       UsersResponse response = new UsersResponse(
           1, List.of(new SimpleUserDto(followeeId, anotherNickname)));
 
-      given(userService.findFollowees(anyLong(), anyLong()))
+      given(userService.findFollowees(anyLong()))
           .willReturn(response);
 
       // when
@@ -804,7 +804,7 @@ class UserControllerTest extends ControllerTestSupport {
       FollowingResponse response = new FollowingResponse(
           followingId, loginId, followeeId, FollowingStatus.FOLLOWING);
 
-      given(followingService.updateStatus(anyLong(), any(UpdateFollowingRequest.class)))
+      given(followingService.updateStatus(anyLong(), anyLong(), any(UpdateFollowingRequest.class)))
           .willReturn(response);
 
       // when
@@ -824,7 +824,7 @@ class UserControllerTest extends ControllerTestSupport {
       // given
       UpdateFollowingRequest request = new UpdateFollowingRequest(null);
 
-      given(followingService.updateStatus(anyLong(), any(UpdateFollowingRequest.class)))
+      given(followingService.updateStatus(anyLong(), anyLong(), any(UpdateFollowingRequest.class)))
           .willReturn(new FollowingResponse(followingId, null, null, null));
 
       // when
@@ -844,7 +844,7 @@ class UserControllerTest extends ControllerTestSupport {
       // given
       UpdateFollowingRequest request = new UpdateFollowingRequest(FollowingStatus.REQUESTED);
 
-      given(followingService.updateStatus(anyLong(), any(UpdateFollowingRequest.class)))
+      given(followingService.updateStatus(anyLong(), anyLong(), any(UpdateFollowingRequest.class)))
           .willThrow(new BadRequestException(FollowingErrorCode.REQUEST_UNAVAILABLE));
 
       // when
@@ -880,7 +880,7 @@ class UserControllerTest extends ControllerTestSupport {
       // given
       UpdateFollowingRequest request = new UpdateFollowingRequest(FollowingStatus.FOLLOWING);
 
-      given(followingService.updateStatus(anyLong(), any(UpdateFollowingRequest.class)))
+      given(followingService.updateStatus(anyLong(), anyLong(), any(UpdateFollowingRequest.class)))
           .willThrow(new ForbiddenException(FollowingErrorCode.WRONG_OWNER));
 
       // when
@@ -900,7 +900,7 @@ class UserControllerTest extends ControllerTestSupport {
       // given
       UpdateFollowingRequest request = new UpdateFollowingRequest(FollowingStatus.FOLLOWING);
 
-      given(followingService.updateStatus(anyLong(), any(UpdateFollowingRequest.class)))
+      given(followingService.updateStatus(anyLong(), anyLong(), any(UpdateFollowingRequest.class)))
           .willThrow(new DataNotFoundException(FollowingErrorCode.ID_NOT_EXISTING));
 
       // when
@@ -939,7 +939,7 @@ class UserControllerTest extends ControllerTestSupport {
     void 팔로잉_삭제를_성공하고_204_No_Content를_반환한다() throws Exception {
       // given
       willDoNothing().given(followingService)
-          .delete(anyLong());
+          .delete(anyLong(), anyLong());
 
       // when
       ResultActions actions = mockMvc.perform(delete(PATH, loginId, followingId)
@@ -953,7 +953,7 @@ class UserControllerTest extends ControllerTestSupport {
     void 로그인한_사용자가_없으면_401_Unauthorized를_반환한다() throws Exception {
       // given
       willDoNothing().given(followingService)
-          .delete(anyLong());
+          .delete(anyLong(), anyLong());
 
       // when
       ResultActions actions = mockMvc.perform(delete(PATH, loginId, followingId)
@@ -968,7 +968,7 @@ class UserControllerTest extends ControllerTestSupport {
     void 로그인한_사용자와_요청의_사용자가_다를_경우_403_Forbidden을_반환한다() throws Exception {
       // given
       willDoNothing().given(followingService)
-          .delete(anyLong());
+          .delete(anyLong(), anyLong());
 
       // when
       ResultActions actions = mockMvc.perform(delete(PATH, followingId, followingId)
@@ -985,7 +985,7 @@ class UserControllerTest extends ControllerTestSupport {
       // given
       willThrow(new ForbiddenException(FollowingErrorCode.WRONG_OWNER))
           .given(followingService)
-          .delete(anyLong());
+          .delete(anyLong(), anyLong());
 
       // when
       ResultActions actions = mockMvc.perform(delete(PATH, loginId, followingId)

--- a/src/test/java/com/ddudu/user/service/UserServiceTest.java
+++ b/src/test/java/com/ddudu/user/service/UserServiceTest.java
@@ -6,12 +6,12 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import com.ddudu.auth.jwt.converter.JwtConverter;
 import com.ddudu.common.exception.DataNotFoundException;
 import com.ddudu.common.exception.DuplicateResourceException;
-import com.ddudu.common.exception.ForbiddenException;
 import com.ddudu.user.domain.Following;
 import com.ddudu.user.domain.FollowingStatus;
 import com.ddudu.user.domain.Options;
 import com.ddudu.user.domain.User;
 import com.ddudu.user.domain.User.UserBuilder;
+import com.ddudu.user.dto.FollowingSearchType;
 import com.ddudu.user.dto.SimpleUserDto;
 import com.ddudu.user.dto.request.SignUpRequest;
 import com.ddudu.user.dto.request.UpdateEmailRequest;
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -401,26 +402,33 @@ class UserServiceTest {
   }
 
   @Nested
-  class 팔로이_조회_테스트 {
+  class 팔로워_팔로이_조회_테스트 {
 
-    @Test
-    void 팔로이_조회를_성공한다() {
+    @ParameterizedTest(name = "조회 대상: {0}")
+    @EnumSource(FollowingSearchType.class)
+    void 사용자의_팔로잉_정보_조회를_성공한다(FollowingSearchType searchType) {
       // given
       User user = createUser(null, null, null);
-      User followee = createUser(null, null, null);
-      createFollowing(user, followee, null);
+      User target = createUser(null, null, null);
+
+      if (FollowingSearchType.isSearchingFollower(searchType)) {
+        createFollowing(target, user, null);
+      } else {
+        createFollowing(user, target, null);
+      }
 
       // when
-      UsersResponse actual = userService.findFollowees(user.getId());
+      UsersResponse actual = userService.findFromFollowings(user.getId(), searchType);
 
       // then
-      SimpleUserDto expected = SimpleUserDto.from(followee);
+      SimpleUserDto expected = SimpleUserDto.from(target);
       assertThat(actual.counts()).isEqualTo(1);
       assertThat(actual.users()).containsOnly(expected);
     }
 
-    @Test
-    void 요청됨이나_무시_상태가_아닌_팔로잉만_조회한다() {
+    @ParameterizedTest(name = "조회 대상: {0}")
+    @EnumSource(FollowingSearchType.class)
+    void 요청됨이나_무시_상태가_아닌_팔로잉만_조회한다(FollowingSearchType searchType) {
       // given
       User user = createUser(null, null, null);
       User requestedFollowee = createUser(null, null, null);
@@ -429,20 +437,21 @@ class UserServiceTest {
       createFollowing(user, rejectedFollowee, FollowingStatus.IGNORED);
 
       // when
-      UsersResponse actual = userService.findFollowees(user.getId());
+      UsersResponse actual = userService.findFromFollowings(user.getId(), searchType);
 
       // then
       assertThat(actual.users()).isEmpty();
     }
 
-    @Test
-    void 사용자가_존재하지_않으면_조회를_실패한다() {
+    @ParameterizedTest(name = "조회 대상: {0}")
+    @EnumSource(FollowingSearchType.class)
+    void 사용자가_존재하지_않으면_조회를_실패한다(FollowingSearchType searchType) {
       // given
       long loginId = faker.random()
           .nextLong(Long.MAX_VALUE);
 
       // when
-      ThrowingCallable findFollowees = () -> userService.findFollowees(loginId);
+      ThrowingCallable findFollowees = () -> userService.findFromFollowings(loginId, searchType);
 
       // then
       assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(findFollowees)

--- a/src/test/java/com/ddudu/user/service/UserServiceTest.java
+++ b/src/test/java/com/ddudu/user/service/UserServiceTest.java
@@ -411,7 +411,7 @@ class UserServiceTest {
       createFollowing(user, followee, null);
 
       // when
-      UsersResponse actual = userService.findFollowees(user.getId(), user.getId());
+      UsersResponse actual = userService.findFollowees(user.getId());
 
       // then
       SimpleUserDto expected = SimpleUserDto.from(followee);
@@ -429,26 +429,10 @@ class UserServiceTest {
       createFollowing(user, rejectedFollowee, FollowingStatus.IGNORED);
 
       // when
-      UsersResponse actual = userService.findFollowees(user.getId(), user.getId());
+      UsersResponse actual = userService.findFollowees(user.getId());
 
       // then
       assertThat(actual.users()).isEmpty();
-    }
-
-    @Test
-    void 로그인_사용자와_요청의_사용자가_다르면_조회_실패한다() {
-      // given
-      long loginId = faker.random()
-          .nextLong(Long.MAX_VALUE);
-      long invalidId = faker.random()
-          .nextLong(Long.MAX_VALUE);
-
-      // when
-      ThrowingCallable findFollowees = () -> userService.findFollowees(loginId, invalidId);
-
-      // then
-      assertThatExceptionOfType(ForbiddenException.class).isThrownBy(findFollowees)
-          .withMessage(UserErrorCode.INVALID_AUTHORITY.getMessage());
     }
 
     @Test
@@ -458,7 +442,7 @@ class UserServiceTest {
           .nextLong(Long.MAX_VALUE);
 
       // when
-      ThrowingCallable findFollowees = () -> userService.findFollowees(loginId, loginId);
+      ThrowingCallable findFollowees = () -> userService.findFollowees(loginId);
 
       // then
       assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(findFollowees)


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
* Resolves #98 
## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
* GET /api/users/{id}/followings
* search type에 따른 로그인 사용자의 follower/followee 조회
* ParameterizedTest로 두 케이스 모두 테스트