### PR TITLE
팔로잉 요청 받은 사용자가 수락/무시 할 수 없던 버그 수정

### DIFF
--- a/src/main/java/com/ddudu/user/domain/Following.java
+++ b/src/main/java/com/ddudu/user/domain/Following.java
@@ -52,11 +52,12 @@ public class Following extends BaseEntity {
     this.status = Objects.requireNonNullElse(status, FollowingStatus.FOLLOWING);
   }
 
-  public boolean isOwnedBy(Long followerId) {
-    Long ownerId = this.follower
-        .getId();
+  public boolean isRequestedTo(User user) {
+    return  Objects.equals(followee, user);
+  }
 
-    return Objects.equals(followerId, ownerId);
+  public boolean isOwnedBy(User owner) {
+    return Objects.equals(follower, owner);
   }
 
   public void updateStatus(FollowingStatus status) {

--- a/src/main/java/com/ddudu/user/exception/FollowingErrorCode.java
+++ b/src/main/java/com/ddudu/user/exception/FollowingErrorCode.java
@@ -12,7 +12,8 @@ public enum FollowingErrorCode implements ErrorCode {
   NULL_STATUS_REQUESTED(6007, "요청할 팔로잉 상태는 필수값입니다."),
   ID_NOT_EXISTING(6008, "해당 아이디의 팔로잉이 존재하지 않습니다."),
   REQUEST_UNAVAILABLE(6009, "이미 생성된 팔로잉을 요청 상태로 변경할 수 없습니다."),
-  WRONG_OWNER(6010, "해당 사용자가 생성한 팔로잉이 아닙니다.");
+  WRONG_OWNER(6010, "해당 사용자가 생성한 팔로잉이 아닙니다."),
+  NOT_ENGAGED_USER(6011, "해당 사용자와 관련되지 않은 팔로잉 요청입니다.");
 
   private final int code;
   private final String message;

--- a/src/test/java/com/ddudu/user/controller/UserControllerTest.java
+++ b/src/test/java/com/ddudu/user/controller/UserControllerTest.java
@@ -876,12 +876,12 @@ class UserControllerTest extends ControllerTestSupport {
     }
 
     @Test
-    void 로그인한_사용자와_팔로잉의_주인이_다르면_403_Forbidden을_반환한다() throws Exception {
+    void 로그인한_사용자와_받은_팔로잉이_아니면_403_Forbidden을_반환한다() throws Exception {
       // given
       UpdateFollowingRequest request = new UpdateFollowingRequest(FollowingStatus.FOLLOWING);
 
       given(followingService.updateStatus(anyLong(), anyLong(), any(UpdateFollowingRequest.class)))
-          .willThrow(new ForbiddenException(FollowingErrorCode.WRONG_OWNER));
+          .willThrow(new ForbiddenException(FollowingErrorCode.NOT_ENGAGED_USER));
 
       // when
       ResultActions actions = mockMvc.perform(put(PATH, loginId, followingId)
@@ -891,8 +891,8 @@ class UserControllerTest extends ControllerTestSupport {
 
       // then
       actions.andExpect(status().isForbidden())
-          .andExpect(jsonPath("$.code", is(FollowingErrorCode.WRONG_OWNER.getCode())))
-          .andExpect(jsonPath("$.message", is(FollowingErrorCode.WRONG_OWNER.getMessage())));
+          .andExpect(jsonPath("$.code", is(FollowingErrorCode.NOT_ENGAGED_USER.getCode())))
+          .andExpect(jsonPath("$.message", is(FollowingErrorCode.NOT_ENGAGED_USER.getMessage())));
     }
 
     @Test

--- a/src/test/java/com/ddudu/user/service/FollowingServiceTest.java
+++ b/src/test/java/com/ddudu/user/service/FollowingServiceTest.java
@@ -222,7 +222,7 @@ class FollowingServiceTest {
     void 존재하지_않는_사용자면_실패한다() {
       // given
       long invalidId = faker.random()
-          .nextLong();
+          .nextLong(Long.MAX_VALUE);
       UpdateFollowingRequest request = new UpdateFollowingRequest(FollowingStatus.FOLLOWING);
 
       // when
@@ -239,7 +239,7 @@ class FollowingServiceTest {
       // given
       User follower = createUser();
       long invalidId = faker.random()
-          .nextLong();
+          .nextLong(Long.MAX_VALUE);
       UpdateFollowingRequest request = new UpdateFollowingRequest(FollowingStatus.FOLLOWING);
 
       // when

--- a/src/test/java/com/ddudu/user/service/FollowingServiceTest.java
+++ b/src/test/java/com/ddudu/user/service/FollowingServiceTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException
 import com.ddudu.common.exception.BadRequestException;
 import com.ddudu.common.exception.DataNotFoundException;
 import com.ddudu.common.exception.DuplicateResourceException;
+import com.ddudu.common.exception.ForbiddenException;
 import com.ddudu.user.domain.Following;
 import com.ddudu.user.domain.FollowingStatus;
 import com.ddudu.user.domain.Options;
@@ -15,6 +16,7 @@ import com.ddudu.user.dto.request.FollowRequest;
 import com.ddudu.user.dto.request.UpdateFollowingRequest;
 import com.ddudu.user.dto.response.FollowingResponse;
 import com.ddudu.user.exception.FollowingErrorCode;
+import com.ddudu.user.exception.UserErrorCode;
 import com.ddudu.user.repository.FollowingRepository;
 import com.ddudu.user.repository.UserRepository;
 import java.util.Objects;
@@ -190,7 +192,7 @@ class FollowingServiceTest {
 
       // when
       FollowingResponse response = followingService.updateStatus(
-          follower.getId(), following.getId(), request);
+          followee.getId(), following.getId(), request);
 
       // then
       assertThat(response).extracting("id", "followerId", "followeeId", "status")
@@ -208,7 +210,7 @@ class FollowingServiceTest {
 
       // when
       FollowingResponse response = followingService.updateStatus(
-          follower.getId(), following.getId(), request);
+          followee.getId(), following.getId(), request);
 
       // then
       assertThat(response).extracting("id", "followerId", "followeeId", "status")
@@ -217,7 +219,7 @@ class FollowingServiceTest {
     }
 
     @Test
-    void 존재하지_않는_아이디면_실패한다() {
+    void 존재하지_않는_사용자면_실패한다() {
       // given
       long invalidId = faker.random()
           .nextLong();
@@ -226,6 +228,23 @@ class FollowingServiceTest {
       // when
       ThrowingCallable updateStatus = () -> followingService.updateStatus(
           invalidId, invalidId, request);
+
+      // then
+      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(updateStatus)
+          .withMessage(UserErrorCode.ID_NOT_EXISTING.getMessage());
+    }
+
+    @Test
+    void 존재하지_않는_아이디면_실패한다() {
+      // given
+      User follower = createUser();
+      long invalidId = faker.random()
+          .nextLong();
+      UpdateFollowingRequest request = new UpdateFollowingRequest(FollowingStatus.FOLLOWING);
+
+      // when
+      ThrowingCallable updateStatus = () -> followingService.updateStatus(
+          follower.getId(), invalidId, request);
 
       // then
       assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(updateStatus)
@@ -242,11 +261,29 @@ class FollowingServiceTest {
 
       // when
       ThrowingCallable updateStatus = () -> followingService.updateStatus(
-          follower.getId(), following.getId(), request);
+          followee.getId(), following.getId(), request);
 
       // then
       assertThatExceptionOfType(BadRequestException.class).isThrownBy(updateStatus)
           .withMessage(FollowingErrorCode.REQUEST_UNAVAILABLE.getMessage());
+    }
+
+    @Test
+    void 팔로잉_요청_받은_사용자가_아니면_수정을_실패한다() {
+      // given
+      User follower = createUser();
+      User followee = createUser();
+      Following following = createFollowing(follower, followee, FollowingStatus.REQUESTED);
+      User invalidUser = createUser();
+      UpdateFollowingRequest request = new UpdateFollowingRequest(FollowingStatus.FOLLOWING);
+
+      // when
+      ThrowingCallable updateStatus = () -> followingService.updateStatus(
+          invalidUser.getId(), following.getId(), request);
+
+      // then
+      assertThatExceptionOfType(ForbiddenException.class).isThrownBy(updateStatus)
+          .withMessage(FollowingErrorCode.NOT_ENGAGED_USER.getMessage());
     }
 
   }
@@ -278,7 +315,7 @@ class FollowingServiceTest {
           .nextLong(Long.MAX_VALUE);
 
       // when
-      ThrowingCallable delete = () -> followingService.delete(invalidId, follower.getId());
+      ThrowingCallable delete = () -> followingService.delete(follower.getId(), invalidId);
 
       // then
       assertThatNoException().isThrownBy(delete);


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
* Resolves #112 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
* 팔로잉 상태 수정 시 요청 받은 사용자인지 확인
* 팔로잉 삭제 시 로그인 사용자가 존재하는지 확인
* 해당 서비스 테스트 수정