### PR TITLE
CD 파이프라인 작성

### DIFF
--- a/.aws/dev-task-definition.json
+++ b/.aws/dev-task-definition.json
@@ -28,6 +28,15 @@
         },
         "secretOptions": []
       },
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "curl -f http://localhost/actuator/health || exit 1"
+        ],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3
+      },
       "systemControls": []
     }
   ],

--- a/.aws/dev-task-definition.json
+++ b/.aws/dev-task-definition.json
@@ -31,7 +31,7 @@
       "healthCheck": {
         "command": [
           "CMD-SHELL",
-          "curl -f http://localhost/actuator/health || exit 1"
+          "curl -f http://localhost:8080/actuator/health || exit 1"
         ],
         "interval": 30,
         "timeout": 5,


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
* Resolves #124 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
* `/.github/workflows`에 있는 actions 파이프라인
* `/.aws`에 있는 task definition을 봐주십쇼
### 방식 설명
**ECS with EC2**
1. github actions에서 **빌드** (테스트 제외)
2. 빌드된 **jar파일**을 **도커 이미지**로 빌드
3. 빌드된 이미지를 AWS **Private Elastic Container Registry**(ECR)에 저장 (500MB짜리 이미지까지 무료)
4. 미리 작성된 task definition에 빌드된 **이미지 주소 삽입**
    - aws에서 컨테이너를 실행시킬 ECS가 존재, ECS는 등록된 Task Definition을 바탕으로 컨테이너 실행
5. 이미지까지 삽입돼서 작성된 task definition으로 **ecs 태스크 실행**

**배포 시 AWS에서 일어나고 있는 일들**
1. 1개의 EC2(t2.micro)에서 리소스 풀로 컨테이너 구동
2. 배포 파이프라인을 거쳐 ECS에 태스크 생성
3. **Auto Scaling Group**이 EC2 인스턴스 **1개 추가 생성**
4. 생성된 EC2 인스턴스를 태스크 돌릴 수 있는 **ECS 컨테이너 인스턴스**로 등록
5. 가용할 수 있는 컨테이너 인스턴스가 생기면 바로 **추가된 태스크 실행**
6. 성공 시 돌아가는 태스크는 두개 (기존 + 추가 배포)
7. 돌아가는 EC2 인스턴스도 두개 (기존 태스크 + 추가 배포 태스크)
8. 목표 태스크는 1개이니 1개가 불필요해짐 -> **기존 태스크 종료**
9. 용량 공급자의 Capacity Provider Reservation 메트릭이 50%로 감소
    - **100 * 필요한 태스크를 돌릴 EC2 인스턴스 수 / 현재 running EC2 인스턴스 수**
    - 기존 서비스만 돌아갈 때
        100 * 1 / 1 = 100%
    - 추가 태스크가 들어왔을 때
        100 * 2 / 1 = 200% => 목표 메트릭은 100% -> 인스턴스 추가
    - 오토 스케일링 그룹이 인스턴스 추가했을 때
        100 * 2 / 2 = 100%
    - 기존 태스크 종료 후
        100 * 1 / 2 = 50% => 100%로 올리기 위해 running하고 있는 인스턴스 중 작업이 없는 인스턴스 종료
    - ![image](https://github.com/DDu-Du-DDu-Du/back-end/assets/110002292/fb84d00f-2fa6-4a7b-ba21-9215def0bed9)
10. 작업이 없는 **인스턴스 종료** (종료까지 20분 걸림..;;)
11. 인스턴스 한개만 유지

**그럼 EC2 2개 돌리면 프리티어 빠듯하지 않나요?**
* 맞습니다. 그래서 1시부터 8시까진 일단 서버 종료 예정^^*
