### PR TITLE
뚜두 다른 날 반복하기 (다시하기) 구현

### DIFF
--- a/src/main/java/com/ddudu/application/domain/ddudu/domain/Ddudu.java
+++ b/src/main/java/com/ddudu/application/domain/ddudu/domain/Ddudu.java
@@ -77,6 +77,20 @@ public class Ddudu {
     return builder.build();
   }
 
+  public Ddudu reproduceOnDate(LocalDate scheduledOn) {
+    checkArgument(
+        !scheduledOn.isEqual(this.scheduledOn),
+        DduduErrorCode.UNABLE_TO_REPRODUCE_ON_SAME_DATE.getCodeName()
+    );
+
+    return getFullBuilder()
+        .id(null)
+        .isPostponed(false)
+        .status(DduduStatus.UNCOMPLETED)
+        .scheduledOn(scheduledOn)
+        .build();
+  }
+
   public Ddudu applyTodoUpdates(Goal goal, String name, LocalDateTime beginAt) {
     return getFullBuilder()
         .goal(goal)

--- a/src/main/java/com/ddudu/application/domain/ddudu/exception/DduduErrorCode.java
+++ b/src/main/java/com/ddudu/application/domain/ddudu/exception/DduduErrorCode.java
@@ -17,7 +17,8 @@ public enum DduduErrorCode implements ErrorCode {
   INVALID_AUTHORITY(2007, "해당 기능에 대한 사용자 권한이 없습니다."),
   LOGIN_USER_NOT_EXISTING(2008, "로그인 아이디가 존재하지 않습니다."),
   NULL_USER(2009, "사용자는 필수값입니다."),
-  UNABLE_TO_FINISH_BEFORE_BEGIN(2010, "종료 시간은 시작 시간보다 뒤여야 합니다.");
+  UNABLE_TO_FINISH_BEFORE_BEGIN(2010, "종료 시간은 시작 시간보다 뒤여야 합니다."),
+  UNABLE_TO_REPRODUCE_ON_SAME_DATE(2013, "다시 하기의 날짜는 기존과 달라야합니다.");
 
   private final int code;
   private final String message;

--- a/src/main/java/com/ddudu/application/port/in/ddudu/RepeatUseCase.java
+++ b/src/main/java/com/ddudu/application/port/in/ddudu/RepeatUseCase.java
@@ -1,0 +1,12 @@
+package com.ddudu.application.port.in.ddudu;
+
+import com.ddudu.application.domain.ddudu.dto.request.RepeatAnotherDayRequest;
+import com.ddudu.application.domain.ddudu.dto.response.RepeatAnotherDayResponse;
+
+public interface RepeatUseCase {
+
+  RepeatAnotherDayResponse repeatOnAnotherDay(
+      Long loginId, Long dduduId, RepeatAnotherDayRequest request
+  );
+
+}

--- a/src/main/java/com/ddudu/application/port/out/ddudu/RepeatDduduPort.java
+++ b/src/main/java/com/ddudu/application/port/out/ddudu/RepeatDduduPort.java
@@ -1,0 +1,11 @@
+package com.ddudu.application.port.out.ddudu;
+
+import com.ddudu.application.domain.ddudu.domain.Ddudu;
+
+public interface RepeatDduduPort {
+
+  Ddudu getDduduOrElseThrow(Long id, String message);
+
+  Ddudu save(Ddudu ddudu);
+
+}

--- a/src/main/java/com/ddudu/application/service/ddudu/RepeatService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/RepeatService.java
@@ -1,0 +1,35 @@
+package com.ddudu.application.service.ddudu;
+
+import com.ddudu.application.annotation.UseCase;
+import com.ddudu.application.domain.ddudu.domain.Ddudu;
+import com.ddudu.application.domain.ddudu.dto.request.RepeatAnotherDayRequest;
+import com.ddudu.application.domain.ddudu.dto.response.RepeatAnotherDayResponse;
+import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
+import com.ddudu.application.port.in.ddudu.RepeatUseCase;
+import com.ddudu.application.port.out.ddudu.RepeatDduduPort;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class RepeatService implements RepeatUseCase {
+
+  private final RepeatDduduPort repeatDduduPort;
+
+  @Override
+  public RepeatAnotherDayResponse repeatOnAnotherDay(
+      Long loginId, Long dduduId, RepeatAnotherDayRequest request
+  ) {
+    Ddudu ddudu = repeatDduduPort.getDduduOrElseThrow(
+        dduduId, DduduErrorCode.ID_NOT_EXISTING.getCodeName());
+
+    ddudu.checkAuthority(loginId);
+
+    Ddudu replica = ddudu.reproduceOnDate(request.repeatOn());
+    Ddudu repeatedDdudu = repeatDduduPort.save(replica);
+
+    return new RepeatAnotherDayResponse(repeatedDdudu.getId());
+  }
+
+}

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
@@ -3,6 +3,7 @@ package com.ddudu.infrastructure.persistence.adapter;
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.port.out.ddudu.DduduLoaderPort;
 import com.ddudu.application.port.out.ddudu.PeriodSetupPort;
+import com.ddudu.application.port.out.ddudu.RepeatDduduPort;
 import com.ddudu.application.port.out.ddudu.SaveDduduPort;
 import com.ddudu.infrastructure.annotation.DrivenAdapter;
 import com.ddudu.infrastructure.persistence.entity.DduduEntity;
@@ -13,7 +14,8 @@ import lombok.RequiredArgsConstructor;
 
 @DrivenAdapter
 @RequiredArgsConstructor
-public class DduduPersistenceAdapter implements DduduLoaderPort, PeriodSetupPort, SaveDduduPort {
+public class DduduPersistenceAdapter implements DduduLoaderPort, PeriodSetupPort, SaveDduduPort,
+    RepeatDduduPort {
 
   private final DduduRepository dduduRepository;
 

--- a/src/main/java/com/ddudu/infrastructure/persistence/entity/DduduEntity.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/entity/DduduEntity.java
@@ -101,6 +101,7 @@ public class DduduEntity extends BaseEntity {
         .name(name)
         .status(status)
         .isPostponed(isPostponed)
+        .scheduledOn(scheduledOn)
         .beginAt(beginAt)
         .endAt(endAt)
         .build();
@@ -110,6 +111,7 @@ public class DduduEntity extends BaseEntity {
     this.name = ddudu.getName();
     this.status = ddudu.getStatus();
     this.isPostponed = ddudu.isPostponed();
+    this.scheduledOn = ddudu.getScheduledOn();
     this.beginAt = ddudu.getBeginAt();
     this.endAt = ddudu.getEndAt();
   }

--- a/src/main/java/com/ddudu/presentation/api/controller/DduduController.java
+++ b/src/main/java/com/ddudu/presentation/api/controller/DduduController.java
@@ -3,7 +3,9 @@ package com.ddudu.presentation.api.controller;
 import com.ddudu.application.domain.ddudu.dto.request.MoveDateRequest;
 import com.ddudu.application.domain.ddudu.dto.request.PeriodSetupRequest;
 import com.ddudu.application.domain.ddudu.dto.request.RepeatAnotherDayRequest;
+import com.ddudu.application.domain.ddudu.dto.response.RepeatAnotherDayResponse;
 import com.ddudu.application.port.in.ddudu.PeriodSetupUseCase;
+import com.ddudu.application.port.in.ddudu.RepeatUseCase;
 import com.ddudu.old.todo.dto.request.CreateTodoRequest;
 import com.ddudu.old.todo.dto.request.UpdateTodoRequest;
 import com.ddudu.old.todo.dto.response.TodoCompletionResponse;
@@ -34,11 +36,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/todos")
+@RequestMapping("/api/ddudus")
 @RequiredArgsConstructor
 public class DduduController implements DduduControllerDoc {
 
   private final PeriodSetupUseCase periodSetupUseCase;
+  private final RepeatUseCase repeatUseCase;
   private final TodoService todoService;
 
   @PostMapping
@@ -203,7 +206,7 @@ public class DduduController implements DduduControllerDoc {
   }
 
   @PostMapping("/{id}/repeat")
-  public ResponseEntity<Void> repeatOnAnotherDay(
+  public ResponseEntity<RepeatAnotherDayResponse> repeatOnAnotherDay(
       @Login
       Long loginId,
       @PathVariable
@@ -211,7 +214,12 @@ public class DduduController implements DduduControllerDoc {
       @RequestBody
       RepeatAnotherDayRequest request
   ) {
-    return null;
+    RepeatAnotherDayResponse response = repeatUseCase.repeatOnAnotherDay(
+        loginId, id, request);
+    URI uri = URI.create("/api/ddudus/" + response.id());
+
+    return ResponseEntity.created(uri)
+        .body(response);
   }
 
 }

--- a/src/main/java/com/ddudu/presentation/api/doc/DduduControllerDoc.java
+++ b/src/main/java/com/ddudu/presentation/api/doc/DduduControllerDoc.java
@@ -3,6 +3,7 @@ package com.ddudu.presentation.api.doc;
 import com.ddudu.application.domain.ddudu.dto.request.MoveDateRequest;
 import com.ddudu.application.domain.ddudu.dto.request.PeriodSetupRequest;
 import com.ddudu.application.domain.ddudu.dto.request.RepeatAnotherDayRequest;
+import com.ddudu.application.domain.ddudu.dto.response.RepeatAnotherDayResponse;
 import com.ddudu.old.todo.dto.request.CreateTodoRequest;
 import com.ddudu.old.todo.dto.request.UpdateTodoRequest;
 import com.ddudu.old.todo.dto.response.TodoCompletionResponse;
@@ -99,11 +100,7 @@ public interface DduduControllerDoc {
   @ApiResponse(responseCode = "204")
   ResponseEntity<Void> moveDate(Long loginId, Long id, MoveDateRequest request);
 
-  // TODO: 구현 후 설명 수정
-  @Operation(
-      summary = "뚜두 다른 날 반복하기. Not Yet Implemented",
-      description = "아직 구현되지 않은 기능입니다."
-  )
+  @Operation(summary = "뚜두 다른 날 반복하기")
   @ApiResponse(
       responseCode = "201",
       content = @Content(
@@ -111,6 +108,8 @@ public interface DduduControllerDoc {
           schema = @Schema(implementation = RepeatAnotherDayRequest.class)
       )
   )
-  ResponseEntity<Void> repeatOnAnotherDay(Long loginId, Long id, RepeatAnotherDayRequest request);
+  ResponseEntity<RepeatAnotherDayResponse> repeatOnAnotherDay(
+      Long loginId, Long id, RepeatAnotherDayRequest request
+  );
 
 }

--- a/src/test/java/com/ddudu/application/domain/ddudu/domain/DduduTest.java
+++ b/src/test/java/com/ddudu/application/domain/ddudu/domain/DduduTest.java
@@ -263,4 +263,55 @@ class DduduTest {
 
   }
 
+  @Nested
+  class 복제_테스트 {
+
+    Long userId;
+    Long goalId;
+    Ddudu ddudu;
+
+    @BeforeEach
+    void setUp() {
+      userId = DduduFixture.getRandomId();
+      goalId = DduduFixture.getRandomId();
+      ddudu = DduduFixture.createRandomDduduWithReference(goalId, userId);
+    }
+
+    @Test
+    void 뚜두_복제를_성공한다() {
+      // given
+      LocalDate tomorrow = LocalDate.now()
+          .plusDays(1);
+
+      // when
+      Ddudu replica = ddudu.reproduceOnDate(tomorrow);
+
+      // then
+      assertThat(replica).isNotEqualTo(ddudu);
+      assertThat(replica)
+          .hasFieldOrPropertyWithValue("goalId", ddudu.getGoalId())
+          .hasFieldOrPropertyWithValue("userId", ddudu.getUserId())
+          .hasFieldOrPropertyWithValue("name", ddudu.getName())
+          .hasFieldOrPropertyWithValue("status", DduduStatus.UNCOMPLETED)
+          .hasFieldOrPropertyWithValue("isPostponed", false)
+          .hasFieldOrPropertyWithValue("scheduledOn", tomorrow)
+          .hasFieldOrPropertyWithValue("beginAt", ddudu.getBeginAt())
+          .hasFieldOrPropertyWithValue("endAt", ddudu.getEndAt());
+    }
+
+    @Test
+    void 같은_날로_복제를_시도하면_실패한다() {
+      // given
+      LocalDate newDate = ddudu.getScheduledOn();
+
+      // when
+      ThrowingCallable reproduce = () -> ddudu.reproduceOnDate(newDate);
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(reproduce)
+          .withMessage(DduduErrorCode.UNABLE_TO_REPRODUCE_ON_SAME_DATE.getCodeName());
+    }
+
+  }
+
 }

--- a/src/test/java/com/ddudu/application/service/ddudu/RepeatServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/ddudu/RepeatServiceTest.java
@@ -1,0 +1,96 @@
+package com.ddudu.application.service.ddudu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.ddudu.application.domain.ddudu.domain.Ddudu;
+import com.ddudu.application.domain.ddudu.dto.request.RepeatAnotherDayRequest;
+import com.ddudu.application.domain.ddudu.dto.response.RepeatAnotherDayResponse;
+import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
+import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.port.out.auth.SignUpPort;
+import com.ddudu.application.port.out.ddudu.DduduLoaderPort;
+import com.ddudu.application.port.out.ddudu.SaveDduduPort;
+import com.ddudu.application.port.out.goal.SaveGoalPort;
+import com.ddudu.fixture.DduduFixture;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.UserFixture;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.MissingResourceException;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class RepeatServiceTest {
+
+  @Autowired
+  RepeatService repeatService;
+
+  @Autowired
+  SignUpPort signUpPort;
+
+  @Autowired
+  SaveGoalPort saveGoalPort;
+
+  @Autowired
+  SaveDduduPort saveDduduPort;
+
+  @Autowired
+  DduduLoaderPort dduduLoaderPort;
+
+  User user;
+  Goal goal;
+  Ddudu ddudu;
+
+  @BeforeEach
+  void setUp() {
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user));
+    ddudu = saveDduduPort.save(DduduFixture.createRandomDduduWithGoal(goal));
+  }
+
+  @Test
+  void 뚜두_다른_날_반복하기를_성공한다() {
+    // given
+    LocalDate tomorrow = LocalDate.now()
+        .plusDays(1);
+    RepeatAnotherDayRequest request = new RepeatAnotherDayRequest(tomorrow);
+
+    // when
+    RepeatAnotherDayResponse response = repeatService.repeatOnAnotherDay(
+        user.getId(), ddudu.getId(), request);
+
+    // then
+    Ddudu actual = dduduLoaderPort.getDduduOrElseThrow(response.id(), "not found");
+
+    assertThat(actual.getScheduledOn()).isEqualTo(tomorrow);
+    assertThat(actual).isNotEqualTo(ddudu);
+  }
+
+  @Test
+  void 뚜두가_없으면_다른_날_반복하기를_실패한다() {
+    // given
+    long invalidId = DduduFixture.getRandomId();
+    LocalDate tomorrow = LocalDate.now()
+        .plusDays(1);
+    RepeatAnotherDayRequest request = new RepeatAnotherDayRequest(tomorrow);
+
+    // when
+    ThrowingCallable repeat = () -> repeatService.repeatOnAnotherDay(
+        user.getId(), invalidId, request);
+
+    // then
+    assertThatExceptionOfType(MissingResourceException.class).isThrownBy(repeat)
+        .withMessage(DduduErrorCode.ID_NOT_EXISTING.getCodeName());
+  }
+
+}


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
* Resolves #159 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
* 뚜두 다른 날 반복하기 서비스 구현
* API 구현 및 문서 수정
* Outgoing 포트를 해당 유스케이스 용으로 이렇게 한 번 해봤습니다. 보시고 코멘트 주세요!!
* 유스케이스 별 통합테스트는 참 유용한 것 같습니다.