### PR TITLE
뚜두 목록 조회 구현

### DIFF
--- a/src/main/java/com/ddudu/application/dto/ddudu/DduduCursorDto.java
+++ b/src/main/java/com/ddudu/application/dto/ddudu/DduduCursorDto.java
@@ -1,5 +1,0 @@
-package com.ddudu.application.dto.ddudu;
-
-public record DduduCursorDto(String cursor, SimpleDduduSearchDto ddudu) {
-
-}

--- a/src/main/java/com/ddudu/application/dto/ddudu/request/DduduSearchRequest.java
+++ b/src/main/java/com/ddudu/application/dto/ddudu/request/DduduSearchRequest.java
@@ -9,17 +9,29 @@ public final class DduduSearchRequest {
 
   private final ScrollRequest scroll;
 
-  @Parameter(name = "query", description = "검색어", example = "알고리즘")
+  @Parameter(
+      name = "query",
+      description = "검색어",
+      example = "알고리즘"
+  )
   private final String query;
 
-  @Parameter(name = "isMine", description = "검색 대상이 본인인지. Not Yet Implemented.", example = "true")
+  @Parameter(
+      name = "isMine",
+      description = "검색 대상이 본인인지. Not Yet Implemented.",
+      example = "true"
+  )
   private final Boolean isMine;
 
   // TODO: 일반 검색 대상 추가
-  public DduduSearchRequest(String orderType, String cursor, int size, String query) {
-    this.scroll = new ScrollRequest(orderType, cursor, size);
+  public DduduSearchRequest(String order, String cursor, Integer size, String query) {
+    this.scroll = new ScrollRequest(order, cursor, size);
     this.query = query;
     this.isMine = true;
+  }
+
+  public int getSize() {
+    return scroll.getSize();
   }
 
 }

--- a/src/main/java/com/ddudu/application/dto/scroll/OrderType.java
+++ b/src/main/java/com/ddudu/application/dto/scroll/OrderType.java
@@ -1,16 +1,25 @@
 package com.ddudu.application.dto.scroll;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public enum OrderType {
-    LATEST;
+  LATEST;
 
-    public static OrderType from(String value) {
-        String upperValue = value.toUpperCase();
-
-        return Arrays.stream(OrderType.values())
-                .filter(type -> upperValue.equals(type.name()))
-                .findFirst()
-                .orElse(LATEST);
+  public static OrderType from(String value) {
+    if (Objects.isNull(value)) {
+      return LATEST;
     }
+    
+    String upperValue = value.toUpperCase();
+
+    return Arrays.stream(OrderType.values())
+        .filter(type -> upperValue.equals(type.name()))
+        .findFirst()
+        .orElse(LATEST);
+  }
+
+  public boolean isLatest() {
+    return this == LATEST;
+  }
 }

--- a/src/main/java/com/ddudu/application/dto/scroll/request/ScrollRequest.java
+++ b/src/main/java/com/ddudu/application/dto/scroll/request/ScrollRequest.java
@@ -10,13 +10,25 @@ public final class ScrollRequest {
 
   private static final int DEFAULT_SIZE = 10;
 
-  @Parameter(name = "order", description = "정렬 순서 타입. 소문자 가능", example = "latest")
+  @Parameter(
+      name = "order",
+      description = "정렬 순서 타입. 소문자 가능. 기본 최신순.",
+      example = "latest"
+  )
   private final OrderType order;
 
-  @Parameter(name = "cursor", description = "커서. 이 커서의 다음 순서부터 조회.", example = "1")
+  @Parameter(
+      name = "cursor",
+      description = "커서. 이 커서의 다음 순서부터 조회.",
+      example = "0"
+  )
   private final String cursor;
 
-  @Parameter(name = "size", description = "컨텐츠 사이즈. 기본 10.", example = "10")
+  @Parameter(
+      name = "size",
+      description = "컨텐츠 사이즈. 기본 10.",
+      example = "10"
+  )
   private final int size;
 
   public ScrollRequest(

--- a/src/main/java/com/ddudu/application/port/in/ddudu/DduduSearchUseCase.java
+++ b/src/main/java/com/ddudu/application/port/in/ddudu/DduduSearchUseCase.java
@@ -1,0 +1,11 @@
+package com.ddudu.application.port.in.ddudu;
+
+import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
+import com.ddudu.application.dto.ddudu.request.DduduSearchRequest;
+import com.ddudu.application.dto.scroll.response.ScrollResponse;
+
+public interface DduduSearchUseCase {
+
+  ScrollResponse<SimpleDduduSearchDto> search(Long loginId, DduduSearchRequest request);
+
+}

--- a/src/main/java/com/ddudu/application/port/out/ddudu/DduduSearchPort.java
+++ b/src/main/java/com/ddudu/application/port/out/ddudu/DduduSearchPort.java
@@ -1,0 +1,15 @@
+package com.ddudu.application.port.out.ddudu;
+
+import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
+import com.ddudu.application.dto.scroll.request.ScrollRequest;
+import com.ddudu.application.dto.scroll.response.ScrollResponse;
+
+;
+
+public interface DduduSearchPort {
+
+  ScrollResponse<SimpleDduduSearchDto> search(
+      Long userId, ScrollRequest request, String query, Boolean isMine
+  );
+
+}

--- a/src/main/java/com/ddudu/application/port/out/ddudu/DduduSearchPort.java
+++ b/src/main/java/com/ddudu/application/port/out/ddudu/DduduSearchPort.java
@@ -4,8 +4,6 @@ import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
 import com.ddudu.application.dto.scroll.request.ScrollRequest;
 import com.ddudu.application.dto.scroll.response.ScrollResponse;
 
-;
-
 public interface DduduSearchPort {
 
   ScrollResponse<SimpleDduduSearchDto> search(

--- a/src/main/java/com/ddudu/application/port/out/ddudu/SaveDduduPort.java
+++ b/src/main/java/com/ddudu/application/port/out/ddudu/SaveDduduPort.java
@@ -1,9 +1,12 @@
 package com.ddudu.application.port.out.ddudu;
 
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
+import java.util.List;
 
 public interface SaveDduduPort {
 
   Ddudu save(Ddudu ddudu);
+
+  List<Ddudu> saveAll(List<Ddudu> dduduList);
 
 }

--- a/src/main/java/com/ddudu/application/port/out/user/UserLoaderPort.java
+++ b/src/main/java/com/ddudu/application/port/out/user/UserLoaderPort.java
@@ -12,4 +12,6 @@ public interface UserLoaderPort {
 
   Optional<User> loadMinimalUser(Long id);
 
+  User loadMinimalUserOrElseThrow(Long id, String message);
+
 }

--- a/src/main/java/com/ddudu/application/service/ddudu/DduduSearchService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/DduduSearchService.java
@@ -1,0 +1,32 @@
+package com.ddudu.application.service.ddudu;
+
+import com.ddudu.application.annotation.UseCase;
+import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
+import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
+import com.ddudu.application.dto.ddudu.request.DduduSearchRequest;
+import com.ddudu.application.dto.scroll.response.ScrollResponse;
+import com.ddudu.application.port.in.ddudu.DduduSearchUseCase;
+import com.ddudu.application.port.out.ddudu.DduduSearchPort;
+import com.ddudu.application.port.out.user.UserLoaderPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DduduSearchService implements DduduSearchUseCase {
+
+  private final UserLoaderPort userLoaderPort;
+  private final DduduSearchPort dduduSearchPort;
+
+  @Override
+  public ScrollResponse<SimpleDduduSearchDto> search(Long loginId, DduduSearchRequest request) {
+    User user = userLoaderPort.loadMinimalUserOrElseThrow(
+        loginId, DduduErrorCode.USER_NOT_EXISTING.getCodeName());
+
+    return dduduSearchPort.search(
+        user.getId(), request.getScroll(), request.getQuery(), request.getIsMine());
+  }
+
+}

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
@@ -68,7 +68,7 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
   public ScrollResponse<SimpleDduduSearchDto> search(
       Long userId, ScrollRequest request, String query, Boolean isMine
   ) {
-    List<DduduCursorDto> ddudusWithCursor = dduduRepository.findScrollMyDdudus(
+    List<DduduCursorDto> ddudusWithCursor = dduduRepository.findScrollDdudus(
         userId, request, query, isMine, false);
 
     return getScrollResponse(ddudusWithCursor, request.getSize());

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
@@ -1,21 +1,27 @@
 package com.ddudu.infrastructure.persistence.adapter;
 
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
+import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
+import com.ddudu.application.dto.scroll.request.ScrollRequest;
+import com.ddudu.application.dto.scroll.response.ScrollResponse;
 import com.ddudu.application.port.out.ddudu.DduduLoaderPort;
+import com.ddudu.application.port.out.ddudu.DduduSearchPort;
 import com.ddudu.application.port.out.ddudu.DduduUpdatePort;
 import com.ddudu.application.port.out.ddudu.RepeatDduduPort;
 import com.ddudu.application.port.out.ddudu.SaveDduduPort;
 import com.ddudu.infrastructure.annotation.DrivenAdapter;
+import com.ddudu.infrastructure.persistence.dto.DduduCursorDto;
 import com.ddudu.infrastructure.persistence.entity.DduduEntity;
 import com.ddudu.infrastructure.persistence.repository.ddudu.DduduRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
 import java.util.MissingResourceException;
 import lombok.RequiredArgsConstructor;
 
 @DrivenAdapter
 @RequiredArgsConstructor
 public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort, SaveDduduPort,
-    RepeatDduduPort {
+    RepeatDduduPort, DduduSearchPort {
 
   private final DduduRepository dduduRepository;
 
@@ -44,6 +50,49 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
   public Ddudu save(Ddudu ddudu) {
     return dduduRepository.save(DduduEntity.from(ddudu))
         .toDomain();
+  }
+
+  @Override
+  public List<Ddudu> saveAll(List<Ddudu> ddudus) {
+    List<DduduEntity> dduduEntities = ddudus.stream()
+        .map(DduduEntity::from)
+        .toList();
+
+    return dduduRepository.saveAll(dduduEntities)
+        .stream()
+        .map(DduduEntity::toDomain)
+        .toList();
+  }
+
+  @Override
+  public ScrollResponse<SimpleDduduSearchDto> search(
+      Long userId, ScrollRequest request, String query, Boolean isMine
+  ) {
+    List<DduduCursorDto> ddudusWithCursor = dduduRepository.findScrollMyDdudus(
+        userId, request, query, isMine, false);
+
+    return getScrollResponse(ddudusWithCursor, request.getSize());
+  }
+
+  private ScrollResponse<SimpleDduduSearchDto> getScrollResponse(
+      List<DduduCursorDto> ddudusWithCursor, int size
+  ) {
+    List<SimpleDduduSearchDto> simpleDdudus = ddudusWithCursor.stream()
+        .limit(size)
+        .map(DduduCursorDto::ddudu)
+        .toList();
+    String nextCursor = getNextCursor(ddudusWithCursor, size);
+
+    return ScrollResponse.from(simpleDdudus, nextCursor);
+  }
+
+  private String getNextCursor(List<DduduCursorDto> ddudusWithCursor, int size) {
+    if (ddudusWithCursor.size() > size) {
+      return ddudusWithCursor.get(size - 1)
+          .cursor();
+    }
+
+    return null;
   }
 
 }

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/UserPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/UserPersistenceAdapter.java
@@ -11,6 +11,7 @@ import com.ddudu.infrastructure.persistence.entity.UserEntity;
 import com.ddudu.infrastructure.persistence.repository.auth.AuthProviderRepository;
 import com.ddudu.infrastructure.persistence.repository.user.UserRepository;
 import java.util.List;
+import java.util.MissingResourceException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
@@ -59,6 +60,16 @@ public class UserPersistenceAdapter implements UserLoaderPort, SignUpPort {
   public Optional<User> loadMinimalUser(Long id) {
     return userRepository.findById(id)
         .map(UserEntity::toDomain);
+  }
+
+  @Override
+  public User loadMinimalUserOrElseThrow(Long id, String message) {
+    return loadMinimalUser(id)
+        .orElseThrow(() -> new MissingResourceException(
+            message,
+            User.class.getName(),
+            id.toString()
+        ));
   }
 
   private AuthProvider saveAuthProvider(AuthProvider authProvider, UserEntity user) {

--- a/src/main/java/com/ddudu/infrastructure/persistence/dto/DduduCursorDto.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/dto/DduduCursorDto.java
@@ -1,0 +1,7 @@
+package com.ddudu.infrastructure.persistence.dto;
+
+import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
+
+public record DduduCursorDto(String cursor, SimpleDduduSearchDto ddudu) {
+
+}

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
@@ -1,6 +1,8 @@
 package com.ddudu.infrastructure.persistence.repository.ddudu;
 
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
+import com.ddudu.application.dto.scroll.request.ScrollRequest;
+import com.ddudu.infrastructure.persistence.dto.DduduCursorDto;
 import com.ddudu.infrastructure.persistence.entity.DduduEntity;
 import com.ddudu.infrastructure.persistence.entity.GoalEntity;
 import com.ddudu.infrastructure.persistence.entity.UserEntity;
@@ -20,5 +22,9 @@ public interface DduduQueryRepository {
   );
 
   void deleteAllByGoal(GoalEntity goal);
+
+  List<DduduCursorDto> findScrollMyDdudus(
+      Long userId, ScrollRequest request, String query, Boolean isMine, Boolean isFollower
+  );
 
 }

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
@@ -23,7 +23,7 @@ public interface DduduQueryRepository {
 
   void deleteAllByGoal(GoalEntity goal);
 
-  List<DduduCursorDto> findScrollMyDdudus(
+  List<DduduCursorDto> findScrollDdudus(
       Long userId, ScrollRequest request, String query, Boolean isMine, Boolean isFollower
   );
 

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepositoryImpl.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepositoryImpl.java
@@ -121,7 +121,7 @@ public class DduduQueryRepositoryImpl implements DduduQueryRepository {
   }
 
   @Override
-  public List<DduduCursorDto> findScrollMyDdudus(
+  public List<DduduCursorDto> findScrollDdudus(
       Long userId, ScrollRequest request, String query, Boolean isMine, Boolean isFollower
   ) {
     BooleanExpression cursorFilter = getCursorFilter(request.getOrder(), request.getCursor());

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepositoryImpl.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepositoryImpl.java
@@ -4,20 +4,36 @@ import static com.ddudu.infrastructure.persistence.entity.QDduduEntity.dduduEnti
 
 import com.ddudu.application.domain.ddudu.domain.enums.DduduStatus;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
+import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
+import com.ddudu.application.dto.scroll.OrderType;
+import com.ddudu.application.dto.scroll.request.ScrollRequest;
+import com.ddudu.infrastructure.persistence.dto.DduduCursorDto;
 import com.ddudu.infrastructure.persistence.entity.DduduEntity;
 import com.ddudu.infrastructure.persistence.entity.GoalEntity;
 import com.ddudu.infrastructure.persistence.entity.UserEntity;
 import com.ddudu.old.todo.dto.response.TodoCompletionResponse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.DateTemplate;
+import com.querydsl.core.types.dsl.EnumPath;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -102,6 +118,86 @@ public class DduduQueryRepositoryImpl implements DduduQueryRepository {
         .execute();
 
     entityManager.clear();
+  }
+
+  @Override
+  public List<DduduCursorDto> findScrollMyDdudus(
+      Long userId, ScrollRequest request, String query, Boolean isMine, Boolean isFollower
+  ) {
+    BooleanExpression cursorFilter = getCursorFilter(request.getOrder(), request.getCursor());
+    Predicate openness = getOpenness(isMine, isFollower);
+    BooleanBuilder condition = new BooleanBuilder(cursorFilter)
+        .and(dduduEntity.user.id.eq(userId))
+        .and(openness);
+
+    if (StringUtils.isNotBlank(query)) {
+      condition.and(dduduEntity.name.containsIgnoreCase(query));
+    }
+
+    OrderSpecifier<?> order = decideOrder(request.getOrder());
+
+    return jpaQueryFactory.select(projectDduduCursor(request.getOrder()))
+        .from(dduduEntity)
+        .where(condition)
+        .orderBy(order, dduduEntity.id.desc())
+        .limit(request.getSize() + 1)
+        .fetch();
+  }
+
+  private Predicate getOpenness(boolean isMine, boolean isFollower) {
+    EnumPath<PrivacyType> privacyType = dduduEntity.goal.privacyType;
+
+    if (isMine) {
+      return null;
+    }
+
+    if (isFollower) {
+      return privacyType.in(PrivacyType.FOLLOWER, PrivacyType.PRIVATE);
+    }
+
+    return privacyType.in(PrivacyType.PUBLIC);
+  }
+
+  private BooleanExpression getCursorFilter(OrderType orderType, String cursor) {
+    if (StringUtils.isBlank(cursor)) {
+      return null;
+    }
+
+    validateOrderType(orderType);
+
+    long idCursor = Long.parseLong(cursor);
+
+    return idCursor > 0 ? dduduEntity.id.lt(idCursor) : null;
+  }
+
+  private OrderSpecifier<?> decideOrder(OrderType orderType) {
+    validateOrderType(orderType);
+
+    return new OrderSpecifier<>(Order.ASC, Expressions.nullExpression());
+  }
+
+  private ConstructorExpression<DduduCursorDto> projectDduduCursor(OrderType orderType) {
+    StringExpression cursor = getCursor(orderType);
+
+    return Projections.constructor(
+        DduduCursorDto.class, cursor, projectSimpleDdudu());
+  }
+
+  private ConstructorExpression<SimpleDduduSearchDto> projectSimpleDdudu() {
+    return Projections.constructor(
+        SimpleDduduSearchDto.class, dduduEntity.id, dduduEntity.name, dduduEntity.scheduledOn);
+  }
+
+  private StringExpression getCursor(OrderType orderType) {
+    validateOrderType(orderType);
+
+    return dduduEntity.id.stringValue();
+  }
+
+  private void validateOrderType(OrderType orderType) {
+    if (Objects.isNull(orderType) || !orderType.isLatest()) {
+      throw new NotImplementedException("아직 구현되지 않은 검색 결과 순서입니다.");
+    }
   }
 
 }

--- a/src/main/java/com/ddudu/presentation/api/controller/DduduController.java
+++ b/src/main/java/com/ddudu/presentation/api/controller/DduduController.java
@@ -7,6 +7,7 @@ import com.ddudu.application.domain.ddudu.dto.response.RepeatAnotherDayResponse;
 import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
 import com.ddudu.application.dto.ddudu.request.DduduSearchRequest;
 import com.ddudu.application.dto.scroll.response.ScrollResponse;
+import com.ddudu.application.port.in.ddudu.DduduSearchUseCase;
 import com.ddudu.application.port.in.ddudu.MoveDateUseCase;
 import com.ddudu.application.port.in.ddudu.PeriodSetupUseCase;
 import com.ddudu.application.port.in.ddudu.RepeatUseCase;
@@ -48,6 +49,7 @@ public class DduduController implements DduduControllerDoc {
   private final PeriodSetupUseCase periodSetupUseCase;
   private final MoveDateUseCase moveDateUseCase;
   private final RepeatUseCase repeatUseCase;
+  private final DduduSearchUseCase dduduSearchUseCase;
   private final TodoService todoService;
 
   @PostMapping
@@ -67,12 +69,14 @@ public class DduduController implements DduduControllerDoc {
   }
 
   @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<ScrollResponse<SimpleDduduSearchDto>> searchMine(
+  public ResponseEntity<ScrollResponse<SimpleDduduSearchDto>> getList(
       @Login
       Long loginId,
       DduduSearchRequest request
   ) {
-    return null;
+    ScrollResponse<SimpleDduduSearchDto> response = dduduSearchUseCase.search(loginId, request);
+
+    return ResponseEntity.ok(response);
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/ddudu/presentation/api/doc/DduduControllerDoc.java
+++ b/src/main/java/com/ddudu/presentation/api/doc/DduduControllerDoc.java
@@ -114,7 +114,7 @@ public interface DduduControllerDoc {
 
   @Operation(summary = "뚜두 조회. Not Yet Implemented")
   @ApiResponse(responseCode = "200")
-  ResponseEntity<ScrollResponse<SimpleDduduSearchDto>> searchMine(
+  ResponseEntity<ScrollResponse<SimpleDduduSearchDto>> getList(
       Long loginId,
       @ParameterObject
       DduduSearchRequest request

--- a/src/test/java/com/ddudu/application/service/ddudu/DduduSearchServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/ddudu/DduduSearchServiceTest.java
@@ -1,0 +1,166 @@
+package com.ddudu.application.service.ddudu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.ddudu.application.domain.ddudu.domain.Ddudu;
+import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
+import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
+import com.ddudu.application.dto.ddudu.request.DduduSearchRequest;
+import com.ddudu.application.dto.scroll.response.ScrollResponse;
+import com.ddudu.application.port.out.auth.SignUpPort;
+import com.ddudu.application.port.out.ddudu.DduduLoaderPort;
+import com.ddudu.application.port.out.ddudu.SaveDduduPort;
+import com.ddudu.application.port.out.goal.SaveGoalPort;
+import com.ddudu.fixture.DduduFixture;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.UserFixture;
+import java.util.List;
+import java.util.MissingResourceException;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DduduSearchServiceTest {
+
+  @Autowired
+  DduduSearchService dduduSearchService;
+
+  @Autowired
+  SignUpPort signUpPort;
+
+  @Autowired
+  SaveGoalPort saveGoalPort;
+
+  @Autowired
+  SaveDduduPort saveDduduPort;
+
+  @Autowired
+  DduduLoaderPort dduduLoaderPort;
+
+  User user;
+  int size;
+  List<Ddudu> ddudus;
+  Long latestId;
+
+  @BeforeEach
+  void setUp() {
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    Goal goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user));
+    size = DduduFixture.getRandomInt(10, 100);
+    ddudus = saveDduduPort.saveAll(DduduFixture.createMultipleDdudusWithGoal(goal, size + 1));
+    latestId = ddudus.get(size)
+        .getId();
+  }
+
+  @Test
+  void 뚜두_최신순_목록_조회를_성공한다() {
+    // given
+    DduduSearchRequest request = new DduduSearchRequest(null, null, size, null);
+
+    // when
+    ScrollResponse<SimpleDduduSearchDto> response = dduduSearchService.search(
+        user.getId(), request);
+
+    // then
+    long expectedNextCursor = latestId - size + 1;
+
+    assertThat(response.isEmpty()).isFalse();
+    assertThat(response.contents()).hasSize(size);
+    assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+  }
+
+  @Test
+  void 기본_10개의_뚜두_목록_조회를_성공한다() {
+    // given
+    DduduSearchRequest request = new DduduSearchRequest(null, null, null, null);
+    int defaultSize = 10;
+
+    // when
+    ScrollResponse<SimpleDduduSearchDto> response = dduduSearchService.search(
+        user.getId(), request);
+
+    // then
+    long expectedNextCursor = latestId - defaultSize + 1;
+
+    assertThat(response.isEmpty()).isFalse();
+    assertThat(response.contents()).hasSize(defaultSize);
+    assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+  }
+
+  @Test
+  void 다음_커서_기반으로_뚜두_최신순_목록_조회를_성공한다() {
+    // given
+    int expectedSize = 5;
+    String nextCursor = String.valueOf(latestId - expectedSize + 1);
+    DduduSearchRequest request = new DduduSearchRequest(null, nextCursor, expectedSize, null);
+
+    // when
+    ScrollResponse<SimpleDduduSearchDto> response = dduduSearchService.search(
+        user.getId(), request);
+
+    // then
+    int expectedNextCursor = Integer.parseInt(nextCursor) - expectedSize;
+
+    assertThat(response.isEmpty()).isFalse();
+    assertThat(response.contents()).hasSize(expectedSize);
+    assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+  }
+
+  @Test
+  void 찾는_대상이_없으면_빈_조회_결과를_반환한다() {
+    // given
+    String cursor = String.valueOf(latestId - size - 1);
+    DduduSearchRequest request = new DduduSearchRequest(null, cursor, size, null);
+
+    // when
+    ScrollResponse<SimpleDduduSearchDto> response = dduduSearchService.search(
+        user.getId(), request);
+
+    // then
+    assertThat(response.isEmpty()).isTrue();
+    assertThat(response.contents()).isEmpty();
+    assertThat(response.nextCursor()).isNull();
+  }
+
+  @Test
+  void 검색어_조회를_성공한다() {
+    // given
+    Ddudu firstDdudu = ddudus.get(0);
+    DduduSearchRequest request = new DduduSearchRequest(null, null, size, firstDdudu.getName());
+
+    // when
+    ScrollResponse<SimpleDduduSearchDto> response = dduduSearchService.search(
+        user.getId(), request);
+
+    // then
+    assertThat(response.isEmpty()).isFalse();
+    assertThat(response.contents()).hasSize(1);
+    assertThat(response.nextCursor()).isNull();
+  }
+
+  @Test
+  void 사용자가_없으면_조회를_실패한다() {
+    // given
+    long invalidId = DduduFixture.getRandomId();
+    DduduSearchRequest request = new DduduSearchRequest(null, null, size, null);
+
+    // when
+    ThrowingCallable search = () -> dduduSearchService.search(invalidId, request);
+
+    // then
+    assertThatExceptionOfType(MissingResourceException.class).isThrownBy(search)
+        .withMessage(DduduErrorCode.USER_NOT_EXISTING.getCodeName());
+  }
+
+}

--- a/src/test/java/com/ddudu/fixture/DduduFixture.java
+++ b/src/test/java/com/ddudu/fixture/DduduFixture.java
@@ -3,13 +3,30 @@ package com.ddudu.fixture;
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.ddudu.domain.enums.DduduStatus;
 import com.ddudu.application.domain.goal.domain.Goal;
+import com.google.common.collect.Lists;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DduduFixture extends BaseFixture {
+
+  public static List<Ddudu> createMultipleDdudusWithGoal(Goal goal, int size) {
+    List<Ddudu> ddudus = Lists.newArrayList();
+
+    for (int i = 0; i < size; i++) {
+      Ddudu ddudu = createDdudu(
+          (long) (i + 1), goal.getId(), goal.getUserId(), getRandomSentenceWithMax(50), null, null,
+          null, null, null, null
+      );
+
+      ddudus.add(ddudu);
+    }
+
+    return ddudus;
+  }
 
   public static Ddudu createRandomDduduWithGoal(Goal goal) {
     return createRandomDduduWithReference(goal.getId(), goal.getUserId(), false, null);

--- a/src/test/java/com/ddudu/fixture/DduduFixture.java
+++ b/src/test/java/com/ddudu/fixture/DduduFixture.java
@@ -17,12 +17,7 @@ public class DduduFixture extends BaseFixture {
     List<Ddudu> ddudus = Lists.newArrayList();
 
     for (int i = 0; i < size; i++) {
-      Ddudu ddudu = createDdudu(
-          (long) (i + 1), goal.getId(), goal.getUserId(), getRandomSentenceWithMax(50), null, null,
-          null, null, null, null
-      );
-
-      ddudus.add(ddudu);
+      ddudus.add(createRandomDduduWithGoal(goal));
     }
 
     return ddudus;


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
* Resolves #166 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
* 뚜두 목록 조회 무한 스크롤 구현
* 아직까진 본인의 뚜두만 조회할 수 있도록 구현했습니다
* 약간 보시기 힘들 수도 있는데 쿼리가 핵심이고 persistence에서는 크게 두 부분으로 나눌 수 있습니다
  * select query 수행
    * 커서 확인: 최신순 - id / 필터 종류별 커서 추가 가능
    * 공개여부 확인: 본인 - 전부 / 팔로워 - 팔로워 + 퍼블릭 / 이외 - 퍼블릭
    * 조건 설정: 커서 + 공개여부 + 조회 대상 사용자 아이디
    * 쿼리: 조회 사이즈 + 1개만큼
  * 쿼리 결과 DTO 매핑
    * 스크롤 응답: `isEmpty`, `contents`, `nextCursor`
    * 다음 커서: `쿼리 결과 사이즈 > 조회 요청 사이즈`일 시 다음 컨텐츠 존재 -> `다음 커서 = 현재 마지막 아이템의 커서` -> 다음 조회 시 커서 의 다음 아이템부터 조회
* 사용자 개별조회를 추가했는데 지금 생각해보니 겹치네요. 나중에 지우겠습니다!
* 테스트 시 saveAll이 필요해서 추가했습니다. 계속 생각하는건데 유스케이스 별 인터페이스 하나만 확장하는게 엔티티가 엮이면 어렵고, 어댑터를 아예 통짜로 하나만 가져가기도 힘들고, 어댑터를 유스케이스 별로 만들기도 너무 복잡하고 중복이 많을 것 같고, 포트를 Repository처럼 엔티티 별로 만들고 어댑터를 그냥 JPARepository의 확장 느낌으로 도메인으로 변환만 해줘야 하나 싶기도 하고..어렵네요ㅠㅠ 좀 더 고민해보겠습니다
* 헷갈리시면 슬랙 바로 주셔도 좋습니다!!