### PR TITLE
뚜두 삭제 기능

### DIFF
--- a/src/main/java/com/ddudu/application/port/in/ddudu/DeleteDduduUseCase.java
+++ b/src/main/java/com/ddudu/application/port/in/ddudu/DeleteDduduUseCase.java
@@ -1,0 +1,7 @@
+package com.ddudu.application.port.in.ddudu;
+
+public interface DeleteDduduUseCase {
+
+  void delete(Long loginId, Long dduduId);
+
+}

--- a/src/main/java/com/ddudu/application/port/out/ddudu/DduduLoaderPort.java
+++ b/src/main/java/com/ddudu/application/port/out/ddudu/DduduLoaderPort.java
@@ -7,10 +7,13 @@ import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.TimeGroupedDdudus;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface DduduLoaderPort {
 
   Ddudu getDduduOrElseThrow(Long id, String message);
+
+  Optional<Ddudu> getOptionalDdudu(Long id);
 
   List<Ddudu> getDailyDdudusOfUserUnderGoals(LocalDate date, User user, List<Goal> goals);
 

--- a/src/main/java/com/ddudu/application/port/out/ddudu/DeleteDduduPort.java
+++ b/src/main/java/com/ddudu/application/port/out/ddudu/DeleteDduduPort.java
@@ -1,0 +1,9 @@
+package com.ddudu.application.port.out.ddudu;
+
+import com.ddudu.application.domain.ddudu.domain.Ddudu;
+
+public interface DeleteDduduPort {
+
+  void delete(Ddudu ddudu);
+
+}

--- a/src/main/java/com/ddudu/application/port/out/goal/GoalLoaderPort.java
+++ b/src/main/java/com/ddudu/application/port/out/goal/GoalLoaderPort.java
@@ -10,7 +10,7 @@ public interface GoalLoaderPort {
 
   Goal getGoalOrElseThrow(Long id, String message);
 
-  Optional<Goal> findById(Long id);
+  Optional<Goal> getOptionalGoal(Long id);
 
   List<Goal> findAllByUser(User user);
 

--- a/src/main/java/com/ddudu/application/service/ddudu/DeleteDduduService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/DeleteDduduService.java
@@ -1,0 +1,27 @@
+package com.ddudu.application.service.ddudu;
+
+import com.ddudu.application.annotation.UseCase;
+import com.ddudu.application.port.in.ddudu.DeleteDduduUseCase;
+import com.ddudu.application.port.out.ddudu.DduduLoaderPort;
+import com.ddudu.application.port.out.ddudu.DeleteDduduPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class DeleteDduduService implements DeleteDduduUseCase {
+
+  private final DduduLoaderPort dduduLoaderPort;
+  private final DeleteDduduPort deleteDduduPort;
+
+  @Override
+  public void delete(Long loginId, Long dduduId) {
+    dduduLoaderPort.getOptionalDdudu(dduduId)
+        .ifPresent(ddudu -> {
+          ddudu.validateDduduCreator(loginId);
+          deleteDduduPort.delete(ddudu);
+        });
+  }
+
+}

--- a/src/main/java/com/ddudu/application/service/goal/DeleteGoalService.java
+++ b/src/main/java/com/ddudu/application/service/goal/DeleteGoalService.java
@@ -1,8 +1,6 @@
 package com.ddudu.application.service.goal;
 
 import com.ddudu.application.annotation.UseCase;
-import com.ddudu.application.domain.goal.domain.Goal;
-import com.ddudu.application.domain.goal.exception.GoalErrorCode;
 import com.ddudu.application.port.in.goal.DeleteGoalUseCase;
 import com.ddudu.application.port.out.goal.DeleteGoalPort;
 import com.ddudu.application.port.out.goal.GoalLoaderPort;
@@ -18,11 +16,12 @@ public class DeleteGoalService implements DeleteGoalUseCase {
   private final DeleteGoalPort deleteGoalPort;
 
   @Override
-  public void delete(Long userId, Long id) {
-    Goal goal = goalLoaderPort.getGoalOrElseThrow(id, GoalErrorCode.ID_NOT_EXISTING.getCodeName());
-
-    goal.validateGoalCreator(userId);
-    deleteGoalPort.deleteWithDdudus(goal);
+  public void delete(Long userId, Long goalId) {
+    goalLoaderPort.getOptionalGoal(goalId)
+        .ifPresent(goal -> {
+          goal.validateGoalCreator(userId);
+          deleteGoalPort.deleteWithDdudus(goal);
+        });
   }
 
 }

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
@@ -11,6 +11,7 @@ import com.ddudu.application.dto.scroll.response.ScrollResponse;
 import com.ddudu.application.port.out.ddudu.DduduLoaderPort;
 import com.ddudu.application.port.out.ddudu.DduduSearchPort;
 import com.ddudu.application.port.out.ddudu.DduduUpdatePort;
+import com.ddudu.application.port.out.ddudu.DeleteDduduPort;
 import com.ddudu.application.port.out.ddudu.RepeatDduduPort;
 import com.ddudu.application.port.out.ddudu.SaveDduduPort;
 import com.ddudu.infrastructure.annotation.DrivenAdapter;
@@ -23,12 +24,13 @@ import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.MissingResourceException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @DrivenAdapter
 @RequiredArgsConstructor
 public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort, SaveDduduPort,
-    RepeatDduduPort, DduduSearchPort {
+    RepeatDduduPort, DduduSearchPort, DeleteDduduPort {
 
   private final DduduRepository dduduRepository;
 
@@ -135,6 +137,11 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
         userId, request, query, isMine, false);
 
     return getScrollResponse(ddudusWithCursor, request.getSize());
+  }
+
+  @Override
+  public void delete(Ddudu ddudu) {
+    dduduRepository.deleteById(ddudu.getId());
   }
 
   private ScrollResponse<SimpleDduduSearchDto> getScrollResponse(

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
@@ -141,7 +141,7 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
 
   @Override
   public void delete(Ddudu ddudu) {
-    dduduRepository.deleteById(ddudu.getId());
+    dduduRepository.delete(DduduEntity.from(ddudu));
   }
 
   private ScrollResponse<SimpleDduduSearchDto> getScrollResponse(

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
@@ -44,6 +44,12 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
   }
 
   @Override
+  public Optional<Ddudu> getOptionalDdudu(Long id) {
+    return dduduRepository.findById(id)
+        .map(DduduEntity::toDomain);
+  }
+
+  @Override
   public List<Ddudu> getDailyDdudusOfUserUnderGoals(LocalDate date, User user, List<Goal> goals) {
     return dduduRepository.findDdudusByDateAndUserAndGoals(
             date,

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/GoalPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/GoalPersistenceAdapter.java
@@ -38,7 +38,7 @@ public class GoalPersistenceAdapter implements SaveGoalPort, GoalLoaderPort, Upd
     List<GoalEntity> goalEntities = defaultGoals.stream()
         .map(GoalEntity::from)
         .toList();
-    
+
     return goalRepository.saveAll(goalEntities)
         .stream()
         .map(GoalEntity::toDomain)
@@ -57,7 +57,7 @@ public class GoalPersistenceAdapter implements SaveGoalPort, GoalLoaderPort, Upd
   }
 
   @Override
-  public Optional<Goal> findById(Long id) {
+  public Optional<Goal> getOptionalGoal(Long id) {
     return goalRepository.findById(id)
         .map(GoalEntity::toDomain);
   }

--- a/src/main/java/com/ddudu/presentation/api/controller/DduduController.java
+++ b/src/main/java/com/ddudu/presentation/api/controller/DduduController.java
@@ -17,6 +17,7 @@ import com.ddudu.application.dto.scroll.response.ScrollResponse;
 import com.ddudu.application.port.in.ddudu.ChangeNameUseCase;
 import com.ddudu.application.port.in.ddudu.CreateDduduUseCase;
 import com.ddudu.application.port.in.ddudu.DduduSearchUseCase;
+import com.ddudu.application.port.in.ddudu.DeleteDduduUseCase;
 import com.ddudu.application.port.in.ddudu.GetDailyDdudusByGoalUseCase;
 import com.ddudu.application.port.in.ddudu.GetTimetableUseCase;
 import com.ddudu.application.port.in.ddudu.MoveDateUseCase;
@@ -64,6 +65,7 @@ public class DduduController implements DduduControllerDoc {
   private final DduduSearchUseCase dduduSearchUseCase;
   private final SwitchStatusUseCase switchStatusUseCase;
   private final ChangeNameUseCase changeNameUseCase;
+  private final DeleteDduduUseCase deleteDduduUseCase;
   private final TodoService todoService;
 
   @PostMapping
@@ -212,14 +214,13 @@ public class DduduController implements DduduControllerDoc {
   }
 
   @DeleteMapping("/{id}")
-  @Deprecated
   public ResponseEntity<Void> delete(
       @Login
       Long loginId,
       @PathVariable
       Long id
   ) {
-    todoService.delete(loginId, id);
+    deleteDduduUseCase.delete(loginId, id);
 
     return ResponseEntity.noContent()
         .build();

--- a/src/main/java/com/ddudu/presentation/api/doc/DduduControllerDoc.java
+++ b/src/main/java/com/ddudu/presentation/api/doc/DduduControllerDoc.java
@@ -127,18 +127,21 @@ public interface DduduControllerDoc {
           schema = @Schema(implementation = IdResponse.class)
       )
   )
+  @Parameter(name = "id", description = "변경할 뚜두 식별자", in = ParameterIn.PATH)
   ResponseEntity<IdResponse> changeName(Long loginId, Long id, ChangeNameRequest request);
 
   @Operation(summary = "뚜두 상태 변경")
   @ApiResponse(
       responseCode = "204"
   )
+  @Parameter(name = "id", description = "변경할 뚜두 식별자", in = ParameterIn.PATH)
   ResponseEntity<Void> updateStatus(Long loginId, Long id);
 
   @Operation(summary = "뚜두 삭제")
   @ApiResponse(
       responseCode = "204"
   )
+  @Parameter(name = "id", description = "삭제할 뚜두 식별자", in = ParameterIn.PATH)
   ResponseEntity<Void> delete(Long loginId, Long id);
 
   @Operation(summary = "뚜두 시작/종료시간 설정")

--- a/src/test/java/com/ddudu/application/service/ddudu/DeleteDduduServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/ddudu/DeleteDduduServiceTest.java
@@ -1,0 +1,97 @@
+package com.ddudu.application.service.ddudu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.ddudu.application.domain.ddudu.domain.Ddudu;
+import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
+import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.port.out.auth.SignUpPort;
+import com.ddudu.application.port.out.ddudu.DduduLoaderPort;
+import com.ddudu.application.port.out.ddudu.SaveDduduPort;
+import com.ddudu.application.port.out.goal.GoalLoaderPort;
+import com.ddudu.application.port.out.goal.SaveGoalPort;
+import com.ddudu.application.port.out.user.UserLoaderPort;
+import com.ddudu.fixture.DduduFixture;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.UserFixture;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DeleteDduduServiceTest {
+
+  @Autowired
+  DeleteDduduService deleteDduduService;
+
+  @Autowired
+  UserLoaderPort userLoaderPort;
+
+  @Autowired
+  GoalLoaderPort goalLoaderPort;
+
+  @Autowired
+  SignUpPort signUpPort;
+
+  @Autowired
+  SaveGoalPort saveGoalPort;
+
+  @Autowired
+  DduduLoaderPort dduduLoaderPort;
+
+  @Autowired
+  SaveDduduPort saveDduduPort;
+
+  User user;
+  Ddudu ddudu;
+
+  @BeforeEach
+  void setUp() {
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    Goal goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user));
+    ddudu = saveDduduPort.save(DduduFixture.createRandomDduduWithGoal(goal));
+  }
+
+  @Test
+  void 뚜두를_삭제_할_수_있다() {
+    // when
+    deleteDduduService.delete(user.getId(), ddudu.getId());
+
+    // then
+    assertThat(dduduLoaderPort.getOptionalDdudu(ddudu.getId())).isEmpty();
+  }
+
+  @Test
+  void 뚜두가_존재하지_않는_경우_예외가_발생하지_않는다() {
+    // given
+    Long invalidId = DduduFixture.getRandomId();
+
+    // when / then
+    assertDoesNotThrow(() -> deleteDduduService.delete(user.getId(), invalidId));
+  }
+
+  @Test
+  void 로그인_사용자가_권한이_없는_경우_삭제에_실패한다() {
+    // given
+    User anotherUser = signUpPort.save(UserFixture.createRandomUserWithId());
+
+    // when
+    ThrowingCallable delete = () -> deleteDduduService.delete(anotherUser.getId(), ddudu.getId());
+
+    // then
+    assertThatExceptionOfType(SecurityException.class).isThrownBy(delete)
+        .withMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
+  }
+
+
+}

--- a/src/test/java/com/ddudu/application/service/goal/ChangeGoalStatusServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/goal/ChangeGoalStatusServiceTest.java
@@ -64,7 +64,7 @@ class ChangeGoalStatusServiceTest {
     changeGoalStatusService.changeStatus(userId, goal.getId(), request);
 
     // then
-    Goal actual = goalLoaderPort.findById(goal.getId())
+    Goal actual = goalLoaderPort.getOptionalGoal(goal.getId())
         .get();
     assertThat(actual.getStatus()).isEqualTo(newStatus);
   }

--- a/src/test/java/com/ddudu/application/service/goal/CreateGoalServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/goal/CreateGoalServiceTest.java
@@ -75,7 +75,7 @@ class CreateGoalServiceTest {
     GoalIdResponse expected = createGoalService.create(userId, request);
 
     // then
-    Optional<Goal> actual = goalLoaderPort.findById(expected.id());
+    Optional<Goal> actual = goalLoaderPort.getOptionalGoal(expected.id());
     assertThat(actual.get()).extracting("name", "color", "privacyType")
         .containsExactly(name, color, privacyType);
   }
@@ -86,7 +86,7 @@ class CreateGoalServiceTest {
     GoalIdResponse expected = createGoalService.create(userId, request);
 
     // then
-    Optional<Goal> actual = goalLoaderPort.findById(expected.id());
+    Optional<Goal> actual = goalLoaderPort.getOptionalGoal(expected.id());
     assertThat(actual.get()
         .getId()).isNotNull();
   }
@@ -97,7 +97,7 @@ class CreateGoalServiceTest {
     GoalIdResponse expected = createGoalService.create(userId, request);
 
     // then
-    Optional<Goal> actual = goalLoaderPort.findById(expected.id());
+    Optional<Goal> actual = goalLoaderPort.getOptionalGoal(expected.id());
     assertThat(actual.get()
         .getStatus()).isEqualTo(GoalStatus.IN_PROGRESS);
   }
@@ -115,7 +115,7 @@ class CreateGoalServiceTest {
     GoalIdResponse expected = createGoalService.create(userId, request);
 
     // then
-    Optional<Goal> actual = goalLoaderPort.findById(expected.id());
+    Optional<Goal> actual = goalLoaderPort.getOptionalGoal(expected.id());
     assertThat(actual.get()
         .getColor()).isEqualTo(defaultColor);
   }
@@ -130,7 +130,7 @@ class CreateGoalServiceTest {
     GoalIdResponse expected = createGoalService.create(userId, request);
 
     // then
-    Optional<Goal> actual = goalLoaderPort.findById(expected.id());
+    Optional<Goal> actual = goalLoaderPort.getOptionalGoal(expected.id());
     assertThat(actual.get()
         .getPrivacyType()).isEqualTo(defaultPrivacyType);
   }

--- a/src/test/java/com/ddudu/application/service/goal/DeleteGoalServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/goal/DeleteGoalServiceTest.java
@@ -2,12 +2,15 @@ package com.ddudu.application.service.goal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.domain.goal.exception.GoalErrorCode;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.port.out.auth.SignUpPort;
+import com.ddudu.application.port.out.ddudu.DduduLoaderPort;
+import com.ddudu.application.port.out.ddudu.SaveDduduPort;
 import com.ddudu.application.port.out.goal.DeleteGoalPort;
 import com.ddudu.application.port.out.goal.GoalLoaderPort;
 import com.ddudu.application.port.out.goal.SaveGoalPort;
@@ -15,10 +18,7 @@ import com.ddudu.application.port.out.user.UserLoaderPort;
 import com.ddudu.fixture.DduduFixture;
 import com.ddudu.fixture.GoalFixture;
 import com.ddudu.fixture.UserFixture;
-import com.ddudu.infrastructure.persistence.entity.DduduEntity;
-import com.ddudu.infrastructure.persistence.repository.ddudu.DduduRepository;
 import jakarta.transaction.Transactional;
-import java.util.MissingResourceException;
 import java.util.Optional;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,18 +51,21 @@ class DeleteGoalServiceTest {
   @Autowired
   DeleteGoalPort deleteGoalPort;
 
-  // TODO: 포트로 변경
   @Autowired
-  DduduRepository dduduRepository;
+  DduduLoaderPort dduduLoaderPort;
+
+  @Autowired
+  SaveDduduPort saveDduduPort;
+
 
   Long userId;
   Goal goal;
 
   @BeforeEach
   void setUp() {
-    User user = createAndSaveUser();
+    User user = signUpPort.save(UserFixture.createRandomUserWithId());
     userId = user.getId();
-    goal = createAndSaveGoal(user);
+    goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user));
   }
 
   @Test
@@ -71,7 +74,7 @@ class DeleteGoalServiceTest {
     deleteGoalService.delete(userId, goal.getId());
 
     // then
-    Optional<Goal> foundAfterDeleted = goalLoaderPort.findById(goal.getId());
+    Optional<Goal> foundAfterDeleted = goalLoaderPort.getOptionalGoal(goal.getId());
     assertThat(foundAfterDeleted).isEmpty();
   }
 
@@ -79,33 +82,28 @@ class DeleteGoalServiceTest {
   void 목표_삭제_시_해당_목표의_뚜두도_삭제된다() {
     //given
     Ddudu ddudu = DduduFixture.createRandomDduduWithGoal(goal);
-    ddudu = dduduRepository.save(DduduEntity.from(ddudu))
-        .toDomain();
+    ddudu = saveDduduPort.save(ddudu);
 
     //when
     deleteGoalService.delete(userId, goal.getId());
 
     //then
-    assertThat(dduduRepository.findById(ddudu.getId())).isEmpty();
+    assertThat(dduduLoaderPort.getOptionalDdudu(ddudu.getId())).isEmpty();
   }
 
   @Test
-  void 목표가_존재하지_않는_경우_예외가_발생한다() {
+  void 목표가_존재하지_않는_경우_예외가_발생하지_않는다() {
     // given
     Long invalidId = GoalFixture.getRandomId();
 
-    // when
-    ThrowingCallable delete = () -> deleteGoalService.delete(userId, invalidId);
-
-    // then
-    assertThatExceptionOfType(MissingResourceException.class).isThrownBy(delete)
-        .withMessage(GoalErrorCode.ID_NOT_EXISTING.getCodeName());
+    // when / then
+    assertDoesNotThrow(() -> deleteGoalService.delete(userId, invalidId));
   }
 
   @Test
   void 로그인_사용자가_권한이_없는_경우_삭제에_실패한다() {
     // given
-    User anotherUser = createAndSaveUser();
+    User anotherUser = signUpPort.save(UserFixture.createRandomUserWithId());
 
     // when
     ThrowingCallable delete = () -> deleteGoalService.delete(anotherUser.getId(), goal.getId());
@@ -115,14 +113,5 @@ class DeleteGoalServiceTest {
         .withMessage(GoalErrorCode.INVALID_AUTHORITY.getCodeName());
   }
 
-  private User createAndSaveUser() {
-    User user = UserFixture.createRandomUserWithId();
-    return signUpPort.save(user);
-  }
-
-  private Goal createAndSaveGoal(User user) {
-    Goal goal = GoalFixture.createRandomGoalWithUser(user);
-    return saveGoalPort.save(goal);
-  }
 
 }

--- a/src/test/java/com/ddudu/application/service/goal/UpdateGoalServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/goal/UpdateGoalServiceTest.java
@@ -68,7 +68,7 @@ class UpdateGoalServiceTest {
     updateGoalService.update(userId, goal.getId(), request);
 
     // then
-    Goal actual = goalLoaderPort.findById(goal.getId())
+    Goal actual = goalLoaderPort.getOptionalGoal(goal.getId())
         .get();
     assertThat(actual).extracting("name", "color", "privacyType")
         .containsExactly(newName, newColor, newPrivacyType);


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #176 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 생각해보니 저희 뚜두가 존재하지 않는 경우에 삭제를 하면, 에러없이 OK 응답하기로 했던 것 같아서, 이렇게 구현하고 이전 Goal 삭제부분도 수정했습니다!
