### PR TITLE
반복 뚜두 생성 테스트 코드 작성

### DIFF
--- a/src/main/java/com/ddudu/application/domain/repeat_ddudu/domain/MonthlyRepeatPattern.java
+++ b/src/main/java/com/ddudu/application/domain/repeat_ddudu/domain/MonthlyRepeatPattern.java
@@ -1,7 +1,10 @@
 package com.ddudu.application.domain.repeat_ddudu.domain;
 
 import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.nonNull;
 
+import com.ddudu.application.domain.repeat_ddudu.exception.RepeatDduduErrorCode;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.beans.ConstructorProperties;
 import java.time.LocalDate;
@@ -10,7 +13,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
-import lombok.Builder;
 
 public class MonthlyRepeatPattern implements RepeatPattern {
 
@@ -19,15 +21,32 @@ public class MonthlyRepeatPattern implements RepeatPattern {
   @JsonProperty
   private final Boolean lastDay;
 
-  @Builder
   @ConstructorProperties({"repeatDaysOfMonth", "lastDay"})
   public MonthlyRepeatPattern(
       List<Integer> repeatDaysOfMonth,
       Boolean lastDay
   ) {
-
     this.repeatDaysOfMonth = repeatDaysOfMonth;
     this.lastDay = lastDay;
+  }
+
+  public static MonthlyRepeatPattern withValidation(
+      List<Integer> repeatDaysOfMonth, Boolean lastDay
+  ) {
+    validate(repeatDaysOfMonth, lastDay);
+    return new MonthlyRepeatPattern(repeatDaysOfMonth, lastDay);
+  }
+
+  private static void validate(List<Integer> repeatDaysOfMonth, Boolean lastDay) {
+    checkArgument(
+        nonNull(repeatDaysOfMonth) && !repeatDaysOfMonth.isEmpty(),
+        RepeatDduduErrorCode.NULL_OR_EMPTY_REPEAT_DATES_OF_MONTH.getCodeName()
+    );
+
+    checkArgument(
+        nonNull(lastDay),
+        RepeatDduduErrorCode.NULL_LAST_DAY.getCodeName()
+    );
   }
 
   @Override

--- a/src/main/java/com/ddudu/application/domain/repeat_ddudu/domain/RepeatDdudu.java
+++ b/src/main/java/com/ddudu/application/domain/repeat_ddudu/domain/RepeatDdudu.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class RepeatDdudu {
+public final class RepeatDdudu {
 
   private static final int MAX_NAME_LENGTH = 50;
 

--- a/src/main/java/com/ddudu/application/domain/repeat_ddudu/domain/RepeatDdudu.java
+++ b/src/main/java/com/ddudu/application/domain/repeat_ddudu/domain/RepeatDdudu.java
@@ -1,6 +1,7 @@
 package com.ddudu.application.domain.repeat_ddudu.domain;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 import com.ddudu.application.domain.repeat_ddudu.domain.enums.RepeatType;
@@ -9,7 +10,6 @@ import io.micrometer.common.util.StringUtils;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Objects;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -33,16 +33,21 @@ public final class RepeatDdudu {
 
   @Builder
   public RepeatDdudu(
-      Long id, Long goalId, String name, RepeatType repeatType, RepeatPattern repeatPattern,
+      Long id, Long goalId, String name, RepeatType repeatType, List<String> repeatDaysOfWeek,
+      List<Integer> repeatDaysOfMonth, Boolean lastDayOfMonth, RepeatPattern repeatPattern,
       LocalDate startDate, LocalDate endDate, LocalTime beginAt, LocalTime endAt
   ) {
-    validate(goalId, name, startDate, endDate, beginAt, endAt);
+    validate(
+        goalId, name, repeatType, startDate, endDate, beginAt, endAt
+    );
 
     this.id = id;
     this.goalId = goalId;
     this.name = name;
     this.repeatType = repeatType;
-    this.repeatPattern = repeatPattern;
+    this.repeatPattern = isNull(repeatPattern) ?
+        RepeatPattern.create(repeatType, repeatDaysOfWeek, repeatDaysOfMonth, lastDayOfMonth)
+        : repeatPattern;
     this.startDate = startDate;
     this.endDate = endDate;
     this.beginAt = beginAt;
@@ -54,10 +59,11 @@ public final class RepeatDdudu {
   }
 
   private void validate(
-      Long goalId, String name, LocalDate startDate, LocalDate endDate, LocalTime beginAt,
-      LocalTime endAt
+      Long goalId, String name, RepeatType repeatType, LocalDate startDate, LocalDate endDate,
+      LocalTime beginAt, LocalTime endAt
   ) {
     checkArgument(nonNull(goalId), RepeatDduduErrorCode.NULL_GOAL_VALUE.getCodeName());
+    checkArgument(nonNull(repeatType), RepeatDduduErrorCode.NULL_REPEAT_TYPE.getCodeName());
     validateName(name);
     validatePeriodOfRepeat(startDate, endDate);
     validatePeriodOfTime(beginAt, endAt);
@@ -81,7 +87,7 @@ public final class RepeatDdudu {
   }
 
   private void validatePeriodOfTime(LocalTime beginAt, LocalTime endAt) {
-    if (Objects.isNull(beginAt) && Objects.isNull(endAt)) {
+    if (isNull(beginAt) && isNull(endAt)) {
       return;
     }
 

--- a/src/main/java/com/ddudu/application/domain/repeat_ddudu/domain/RepeatPattern.java
+++ b/src/main/java/com/ddudu/application/domain/repeat_ddudu/domain/RepeatPattern.java
@@ -27,8 +27,8 @@ public interface RepeatPattern {
   ) {
     return switch (repeatType) {
       case DAILY -> new DailyRepeatPattern();
-      case WEEKLY -> new WeeklyRepeatPattern(repeatDays);
-      case MONTHLY -> new MonthlyRepeatPattern(repeatDates, lastDayOfMonth);
+      case WEEKLY -> WeeklyRepeatPattern.withValidation(repeatDays);
+      case MONTHLY -> MonthlyRepeatPattern.withValidation(repeatDates, lastDayOfMonth);
     };
   }
 

--- a/src/main/java/com/ddudu/application/domain/repeat_ddudu/domain/WeeklyRepeatPattern.java
+++ b/src/main/java/com/ddudu/application/domain/repeat_ddudu/domain/WeeklyRepeatPattern.java
@@ -1,7 +1,10 @@
 package com.ddudu.application.domain.repeat_ddudu.domain;
 
 import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.nonNull;
 
+import com.ddudu.application.domain.repeat_ddudu.exception.RepeatDduduErrorCode;
 import com.ddudu.application.domain.repeat_ddudu.util.DayOfWeekUtil;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.beans.ConstructorProperties;
@@ -9,19 +12,29 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Stream;
-import lombok.Builder;
 
 public class WeeklyRepeatPattern implements RepeatPattern {
 
   private final List<DayOfWeek> repeatDaysOfWeek;
 
-  @Builder
   @ConstructorProperties({"repeatDaysOfWeek"})
   public WeeklyRepeatPattern(
       @JsonProperty(access = READ_ONLY)
       List<String> repeatDaysOfWeek
   ) {
     this.repeatDaysOfWeek = DayOfWeekUtil.toDaysOfWeek(repeatDaysOfWeek);
+  }
+
+  public static WeeklyRepeatPattern withValidation(List<String> repeatDaysOfWeek) {
+    validate(repeatDaysOfWeek);
+    return new WeeklyRepeatPattern(repeatDaysOfWeek);
+  }
+
+  private static void validate(List<String> repeatDaysOfWeek) {
+    checkArgument(
+        nonNull(repeatDaysOfWeek) && !repeatDaysOfWeek.isEmpty(),
+        RepeatDduduErrorCode.NULL_OR_EMPTY_REPEAT_DAYS_OF_WEEK.getCodeName()
+    );
   }
 
   @Override

--- a/src/main/java/com/ddudu/application/domain/repeat_ddudu/exception/RepeatDduduErrorCode.java
+++ b/src/main/java/com/ddudu/application/domain/repeat_ddudu/exception/RepeatDduduErrorCode.java
@@ -17,8 +17,9 @@ public enum RepeatDduduErrorCode implements ErrorCode {
   UNABLE_TO_FINISH_BEFORE_BEGIN(6008, "종료 시간은 시작 시간보다 뒤여야 합니다."),
   INVALID_REPEAT_TYPE(6009, "유효하지 않은 반복 유형입니다."),
   INVALID_DAY_OF_WEEK(6010, "유효하지 않은 요일입니다."),
-  EMPTY_REPEAT_DATES_OF_MONTH(6011, "반복되는 날짜가 없습니다."),
-  EMPTY_REPEAT_DAYS_OF_WEEK(6012, "반복되는 요일이 없습니다.");
+  NULL_OR_EMPTY_REPEAT_DATES_OF_MONTH(6011, "반복되는 날짜가 없습니다."),
+  NULL_OR_EMPTY_REPEAT_DAYS_OF_WEEK(6012, "반복되는 요일이 없습니다."),
+  NULL_LAST_DAY(6013, "마지막 날 반복 여부는 필수값입니다.");
 
   private final int code;
   private final String message;

--- a/src/main/java/com/ddudu/application/domain/repeat_ddudu/service/RepeatDduduDomainService.java
+++ b/src/main/java/com/ddudu/application/domain/repeat_ddudu/service/RepeatDduduDomainService.java
@@ -3,11 +3,9 @@ package com.ddudu.application.domain.repeat_ddudu.service;
 import com.ddudu.application.annotation.DomainService;
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
-import com.ddudu.application.domain.repeat_ddudu.domain.RepeatPattern;
 import com.ddudu.application.domain.repeat_ddudu.domain.enums.RepeatType;
 import com.ddudu.application.dto.repeat_ddudu.requset.CreateRepeatDduduRequest;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
@@ -21,7 +19,9 @@ public class RepeatDduduDomainService {
         .startDate(request.startDate())
         .endDate(request.endDate())
         .repeatType(RepeatType.from(request.repeatType()))
-        .repeatPattern(createRepeatPattern(request))
+        .repeatDaysOfWeek(request.repeatDaysOfWeek())
+        .repeatDaysOfMonth(request.repeatDaysOfMonth())
+        .lastDayOfMonth(request.lastDayOfMonth())
         .beginAt(request.beginAt())
         .endAt(request.endAt())
         .build();
@@ -41,15 +41,6 @@ public class RepeatDduduDomainService {
             .build()
         )
         .toList();
-  }
-
-  private RepeatPattern createRepeatPattern(CreateRepeatDduduRequest request) {
-    return RepeatPattern.create(
-        Objects.requireNonNull(RepeatType.from(request.repeatType())),
-        request.repeatDaysOfWeek(),
-        request.repeatDaysOfMonth(),
-        request.lastDayOfMonth()
-    );
   }
 
 }

--- a/src/main/java/com/ddudu/application/port/out/ddudu/DduduLoaderPort.java
+++ b/src/main/java/com/ddudu/application/port/out/ddudu/DduduLoaderPort.java
@@ -2,6 +2,7 @@ package com.ddudu.application.port.out.ddudu;
 
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.TimeGroupedDdudus;
@@ -28,5 +29,7 @@ public interface DduduLoaderPort {
   List<TimeGroupedDdudus> getDailyDdudusOfUserGroupingByTime(
       LocalDate date, User user, List<Goal> goals
   );
+
+  List<Ddudu> getRepeatedDdudus(RepeatDdudu repeatDdudu);
 
 }

--- a/src/main/java/com/ddudu/application/port/out/repeat_ddudu/RepeatDduduLoaderPort.java
+++ b/src/main/java/com/ddudu/application/port/out/repeat_ddudu/RepeatDduduLoaderPort.java
@@ -1,0 +1,10 @@
+package com.ddudu.application.port.out.repeat_ddudu;
+
+import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
+import java.util.Optional;
+
+public interface RepeatDduduLoaderPort {
+
+  Optional<RepeatDdudu> getOptionalRepeatDdudu(Long id);
+
+}

--- a/src/main/java/com/ddudu/application/service/repeat_ddudu/CreateRepeatDduduService.java
+++ b/src/main/java/com/ddudu/application/service/repeat_ddudu/CreateRepeatDduduService.java
@@ -1,9 +1,9 @@
 package com.ddudu.application.service.repeat_ddudu;
 
 import com.ddudu.application.annotation.UseCase;
-import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
 import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
+import com.ddudu.application.domain.repeat_ddudu.exception.RepeatDduduErrorCode;
 import com.ddudu.application.domain.repeat_ddudu.service.RepeatDduduDomainService;
 import com.ddudu.application.dto.repeat_ddudu.requset.CreateRepeatDduduRequest;
 import com.ddudu.application.port.in.repeat_ddudu.CreateRepeatDduduUseCase;
@@ -26,7 +26,7 @@ public class CreateRepeatDduduService implements CreateRepeatDduduUseCase {
   @Override
   public Long create(Long loginId, CreateRepeatDduduRequest request) {
     Goal goal = goalLoaderPort.getGoalOrElseThrow(
-        request.goalId(), DduduErrorCode.GOAL_NOT_EXISTING.getCodeName());
+        request.goalId(), RepeatDduduErrorCode.NULL_GOAL_VALUE.getCodeName());
 
     goal.validateGoalCreator(loginId);
 

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
@@ -2,6 +2,7 @@ package com.ddudu.infrastructure.persistence.adapter;
 
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
@@ -18,6 +19,7 @@ import com.ddudu.infrastructure.annotation.DrivenAdapter;
 import com.ddudu.infrastructure.persistence.dto.DduduCursorDto;
 import com.ddudu.infrastructure.persistence.entity.DduduEntity;
 import com.ddudu.infrastructure.persistence.entity.GoalEntity;
+import com.ddudu.infrastructure.persistence.entity.RepeatDduduEntity;
 import com.ddudu.infrastructure.persistence.entity.UserEntity;
 import com.ddudu.infrastructure.persistence.repository.ddudu.DduduRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -99,6 +101,14 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
             .map(GoalEntity::from)
             .toList()
     );
+  }
+
+  @Override
+  public List<Ddudu> getRepeatedDdudus(RepeatDdudu repeatDdudu) {
+    return dduduRepository.findAllByRepeatDdudu(RepeatDduduEntity.from(repeatDdudu))
+        .stream()
+        .map(DduduEntity::toDomain)
+        .toList();
   }
 
   @Override

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/RepeatDduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/RepeatDduduPersistenceAdapter.java
@@ -1,15 +1,17 @@
 package com.ddudu.infrastructure.persistence.adapter;
 
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
+import com.ddudu.application.port.out.repeat_ddudu.RepeatDduduLoaderPort;
 import com.ddudu.application.port.out.repeat_ddudu.SaveRepeatDduduPort;
 import com.ddudu.infrastructure.annotation.DrivenAdapter;
 import com.ddudu.infrastructure.persistence.entity.RepeatDduduEntity;
 import com.ddudu.infrastructure.persistence.repository.repeat_ddudu.RepeatDduduRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @DrivenAdapter
 @RequiredArgsConstructor
-public class RepeatDduduAdapter implements SaveRepeatDduduPort {
+public class RepeatDduduPersistenceAdapter implements SaveRepeatDduduPort, RepeatDduduLoaderPort {
 
   private final RepeatDduduRepository repeatDduduRepository;
 
@@ -17,6 +19,13 @@ public class RepeatDduduAdapter implements SaveRepeatDduduPort {
   public RepeatDdudu save(RepeatDdudu repeatDdudu) {
     return repeatDduduRepository.save(RepeatDduduEntity.from(repeatDdudu))
         .toDomain();
+  }
+
+
+  @Override
+  public Optional<RepeatDdudu> getOptionalRepeatDdudu(Long id) {
+    return repeatDduduRepository.findById(id)
+        .map(RepeatDduduEntity::toDomain);
   }
 
 }

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduRepository.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduRepository.java
@@ -2,11 +2,14 @@ package com.ddudu.infrastructure.persistence.repository.ddudu;
 
 import com.ddudu.infrastructure.persistence.entity.DduduEntity;
 import com.ddudu.infrastructure.persistence.entity.GoalEntity;
+import com.ddudu.infrastructure.persistence.entity.RepeatDduduEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DduduRepository extends JpaRepository<DduduEntity, Long>, DduduQueryRepository {
 
   List<DduduEntity> findAllByGoal(GoalEntity goalEntity);
+
+  List<DduduEntity> findAllByRepeatDdudu(RepeatDduduEntity repeatDduduEntity);
 
 }

--- a/src/test/java/com/ddudu/application/domain/repeat_ddudu/domain/RepeatDduduTest.java
+++ b/src/test/java/com/ddudu/application/domain/repeat_ddudu/domain/RepeatDduduTest.java
@@ -1,0 +1,373 @@
+package com.ddudu.application.domain.repeat_ddudu.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu.RepeatDduduBuilder;
+import com.ddudu.application.domain.repeat_ddudu.domain.enums.RepeatType;
+import com.ddudu.application.domain.repeat_ddudu.exception.RepeatDduduErrorCode;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.RepeatDduduFixture;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class RepeatDduduTest {
+
+  Long goalId;
+
+  @BeforeEach
+  void setUp() {
+    goalId = GoalFixture.getRandomId();
+  }
+
+  @Nested
+  class 생성_테스트 {
+
+    String name;
+    LocalDate startDate;
+    LocalDate endDate;
+    RepeatType repeatType;
+    RepeatPattern repeatPattern;
+
+    @BeforeEach
+    void setUp() {
+      name = RepeatDduduFixture.getRandomSentenceWithMax(50);
+      startDate = LocalDate.now();
+      endDate = LocalDate.now()
+          .plusMonths(1);
+      repeatType = RepeatDduduFixture.getRandomRepeatType();
+      repeatPattern = RepeatDduduFixture.createRandomRepeatPattern(repeatType);
+    }
+
+    @Test
+    void 반복_뚜두_생성을_성공한다() {
+      // when
+      RepeatDdudu repeatDdudu = RepeatDdudu.builder()
+          .goalId(goalId)
+          .name(name)
+          .repeatType(repeatType)
+          .repeatPattern(repeatPattern)
+          .startDate(startDate)
+          .endDate(endDate)
+          .build();
+
+      // then
+      assertThat(repeatDdudu).isNotNull();
+      assertThat(repeatDdudu)
+          .hasFieldOrPropertyWithValue("goalId", goalId)
+          .hasFieldOrPropertyWithValue("name", name)
+          .hasFieldOrPropertyWithValue("repeatType", repeatType)
+          .hasFieldOrPropertyWithValue("startDate", startDate)
+          .hasFieldOrPropertyWithValue("endDate", endDate);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = " ")
+    void 이름이_빈_값이면_생성을_실패한다(String blankName) {
+      // given
+      RepeatDduduBuilder builder = RepeatDdudu.builder()
+          .goalId(goalId)
+          .name(blankName)
+          .repeatType(repeatType)
+          .repeatPattern(repeatPattern)
+          .startDate(startDate)
+          .endDate(endDate);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(RepeatDduduErrorCode.BLANK_NAME.getCodeName());
+    }
+
+    @Test
+    void 이름이_50자를_넘으면_생성을_실패한다() {
+      // given
+      String over50 = RepeatDduduFixture.getRandomSentence(51, 100);
+      RepeatDduduBuilder builder = RepeatDdudu.builder()
+          .goalId(goalId)
+          .name(over50)
+          .repeatType(repeatType)
+          .repeatPattern(repeatPattern)
+          .startDate(startDate)
+          .endDate(endDate);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(RepeatDduduErrorCode.EXCESSIVE_NAME_LENGTH.getCodeName());
+    }
+
+    @Test
+    void 목표가_없으면_생성을_실패한다() {
+      // given
+      RepeatDduduBuilder builder = RepeatDdudu.builder()
+          .name(name)
+          .repeatType(repeatType)
+          .repeatPattern(repeatPattern)
+          .startDate(startDate)
+          .endDate(endDate);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(RepeatDduduErrorCode.NULL_GOAL_VALUE.getCodeName());
+    }
+
+    @Test
+    void 반복_유형이_없으면_생성을_실패한다() {
+      // given
+      RepeatDduduBuilder builder = RepeatDdudu.builder()
+          .goalId(goalId)
+          .name(name)
+          .repeatPattern(repeatPattern)
+          .startDate(startDate)
+          .endDate(endDate);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(RepeatDduduErrorCode.NULL_REPEAT_TYPE.getCodeName());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void 위클리_반복_뚜두의_경우_반복_요일이_없으면_생성을_실패한다(List<String> repeatDaysOfWeek) {
+      // given
+      RepeatDduduBuilder builder = RepeatDdudu.builder()
+          .goalId(goalId)
+          .name(name)
+          .repeatType(RepeatType.WEEKLY)
+          .repeatDaysOfWeek(repeatDaysOfWeek)
+          .startDate(startDate)
+          .endDate(endDate);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(RepeatDduduErrorCode.NULL_OR_EMPTY_REPEAT_DAYS_OF_WEEK.getCodeName());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void 먼슬리_반복_뚜두의_경우_반복_날짜가_없으면_생성을_실패한다(List<Integer> repeatDaysOfMonth) {
+      // given
+      RepeatDduduBuilder builder = RepeatDdudu.builder()
+          .goalId(goalId)
+          .name(name)
+          .repeatType(RepeatType.MONTHLY)
+          .repeatDaysOfMonth(repeatDaysOfMonth)
+          .lastDayOfMonth(false)
+          .startDate(startDate)
+          .endDate(endDate);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(RepeatDduduErrorCode.NULL_OR_EMPTY_REPEAT_DATES_OF_MONTH.getCodeName());
+    }
+
+    @Test
+    void 먼슬리_반복_뚜두의_경우_마지막_날_반복_여부가_없으면_생성을_실패한다() {
+      // given
+      RepeatDduduBuilder builder = RepeatDdudu.builder()
+          .goalId(goalId)
+          .name(name)
+          .repeatType(RepeatType.MONTHLY)
+          .repeatDaysOfMonth(RepeatDduduFixture.getRandomRepeatDaysOfMonth(1))
+          .lastDayOfMonth(null)
+          .startDate(startDate)
+          .endDate(endDate);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(RepeatDduduErrorCode.NULL_LAST_DAY.getCodeName());
+    }
+
+    @Test
+    void 시작_날짜가_없으면_생성을_실패한다() {
+      // given
+      RepeatDduduBuilder builder = RepeatDdudu.builder()
+          .goalId(goalId)
+          .name(name)
+          .repeatType(repeatType)
+          .repeatPattern(repeatPattern)
+          .endDate(endDate);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(RepeatDduduErrorCode.NULL_START_DATE.getCodeName());
+    }
+
+    @Test
+    void 종료_날짜가_없으면_생성을_실패한다() {
+      // given
+      RepeatDduduBuilder builder = RepeatDdudu.builder()
+          .goalId(goalId)
+          .name(name)
+          .repeatType(repeatType)
+          .repeatPattern(repeatPattern)
+          .startDate(startDate);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(RepeatDduduErrorCode.NULL_END_DATE.getCodeName());
+    }
+
+    @Test
+    void 시작_날짜가_종료_날짜보다_뒤면_생성을_실패한다() {
+      // given
+      RepeatDduduBuilder builder = RepeatDdudu.builder()
+          .goalId(goalId)
+          .name(name)
+          .repeatType(repeatType)
+          .repeatPattern(repeatPattern)
+          .startDate(startDate)
+          .endDate(startDate.minusMonths(1));
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(RepeatDduduErrorCode.UNABLE_TO_END_BEFORE_START.getCodeName());
+    }
+
+    @Test
+    void 시작_시간이_종료_시간보다_뒤면_생성을_실패한다() {
+      // given
+      RepeatDduduBuilder builder = RepeatDdudu.builder()
+          .goalId(goalId)
+          .name(name)
+          .repeatType(repeatType)
+          .repeatPattern(repeatPattern)
+          .startDate(startDate)
+          .endDate(endDate)
+          .beginAt(LocalTime.now()
+              .plusMinutes(1))
+          .endAt(LocalTime.now());
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(RepeatDduduErrorCode.UNABLE_TO_FINISH_BEFORE_BEGIN.getCodeName());
+    }
+
+  }
+
+  @Nested
+  class 반복_날짜_테스트 {
+
+    LocalDate startDate;
+    LocalDate endDate;
+
+    @BeforeEach
+    void setUp() {
+      startDate = LocalDate.now();
+      endDate = LocalDate.now()
+          .plusMonths(1);
+    }
+
+    @Test
+    void 데일리_반복_뚜두의_반복_날짜_리스트_조회에_성공한다() {
+      // given
+      RepeatPattern dailyPattern = RepeatDduduFixture.createDailyRepeatPattern();
+      RepeatDdudu repeatDdudu = RepeatDduduFixture.createRepeatDdudu(
+          RepeatType.DAILY,
+          dailyPattern,
+          startDate,
+          endDate
+      );
+
+      // when
+      List<LocalDate> repeatDates = repeatDdudu.getRepeatDates();
+
+      // then
+      assertThat(repeatDates).hasSize(startDate.until(endDate)
+          .getDays() + 1);
+    }
+
+    @Test
+    void 위클리_반복_뚜두의_반복_날짜_리스트_조회에_성공한다() {
+      // given
+      List<String> repeatDaysOfWeek = RepeatDduduFixture.getRandomRepeatDaysOfWeek(1);
+      RepeatPattern weeklyPattern = RepeatDduduFixture.createWeeklyRepeatPattern(
+          repeatDaysOfWeek);
+      RepeatDdudu repeatDdudu = RepeatDduduFixture.createRepeatDdudu(
+          RepeatType.WEEKLY,
+          weeklyPattern,
+          startDate,
+          endDate
+      );
+
+      // when
+      List<LocalDate> repeatDates = repeatDdudu.getRepeatDates();
+
+      // then
+      repeatDates.stream()
+          .map(LocalDate::getDayOfWeek)
+          .forEach(dayOfWeek -> assertThat(repeatDaysOfWeek)
+              .contains(dayOfWeek.toString()));
+    }
+
+    @Test
+    void 먼슬리_반복_뚜두의_반복_날짜_리스트_조회에_성공한() {
+      // given
+      int repeatDay = RepeatDduduFixture.getRandomInt(1, 25);
+      RepeatPattern monthlyPattern = RepeatDduduFixture.createMonthlyRepeatPattern(
+          List.of(repeatDay), true);
+      RepeatDdudu repeatDdudu = RepeatDduduFixture.createRepeatDdudu(
+          RepeatType.MONTHLY,
+          monthlyPattern,
+          startDate,
+          endDate
+      );
+
+      // when
+      List<LocalDate> repeatDates = repeatDdudu.getRepeatDates();
+
+      // then
+      assertThat(repeatDates).hasSize(2);
+      repeatDates.stream()
+          .map(LocalDate::getDayOfMonth)
+          .forEach(dayOfMonth ->
+              assertThat(dayOfMonth).isIn(repeatDay, startDate.lengthOfMonth()));
+    }
+
+  }
+
+}

--- a/src/test/java/com/ddudu/application/domain/repeat_ddudu/service/RepeatDduduDomainServiceTest.java
+++ b/src/test/java/com/ddudu/application/domain/repeat_ddudu/service/RepeatDduduDomainServiceTest.java
@@ -1,0 +1,204 @@
+package com.ddudu.application.domain.repeat_ddudu.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddudu.application.domain.ddudu.domain.Ddudu;
+import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
+import com.ddudu.application.domain.repeat_ddudu.domain.enums.RepeatType;
+import com.ddudu.application.dto.repeat_ddudu.requset.CreateRepeatDduduRequest;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.RepeatDduduFixture;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(RepeatDduduDomainService.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class RepeatDduduDomainServiceTest {
+
+  @Autowired
+  RepeatDduduDomainService repeatDduduDomainService;
+
+  @Nested
+  class 반복_뚜두_생성_테스트 {
+
+    String name;
+    Long goalId;
+    LocalDate startDate;
+    LocalDate endDate;
+
+    @BeforeEach
+    void setUp() {
+      name = RepeatDduduFixture.getRandomSentenceWithMax(50);
+      goalId = GoalFixture.getRandomId();
+      startDate = LocalDate.now();
+      endDate = LocalDate.now()
+          .plusMonths(1);
+    }
+
+    @Test
+    void 데일리_반복_뚜두를_생성한다() {
+      // given
+      CreateRepeatDduduRequest request = new CreateRepeatDduduRequest(
+          name,
+          goalId,
+          RepeatType.DAILY.name(),
+          null,
+          null,
+          null,
+          startDate,
+          endDate,
+          null,
+          null
+      );
+
+      // when
+      RepeatDdudu actual = repeatDduduDomainService.create(request);
+
+      // then
+      assertThat(actual).extracting("name", "goalId", "repeatType", "startDate", "endDate")
+          .containsExactly(name, goalId, RepeatType.DAILY, startDate, endDate);
+    }
+
+    @Test
+    void 위클리_반복_뚜두를_생성한다() {
+      // given
+      CreateRepeatDduduRequest request = new CreateRepeatDduduRequest(
+          name,
+          goalId,
+          RepeatType.WEEKLY.name(),
+          RepeatDduduFixture.getRandomRepeatDaysOfWeek(),
+          null,
+          null,
+          startDate,
+          endDate,
+          null,
+          null
+      );
+
+      // when
+      RepeatDdudu actual = repeatDduduDomainService.create(request);
+
+      // then
+      assertThat(actual).extracting("name", "goalId", "repeatType", "startDate", "endDate")
+          .containsExactly(name, goalId, RepeatType.WEEKLY, startDate, endDate);
+    }
+
+    @Test
+    void 먼슬리_반복_뚜두를_생성한다() {
+      // given
+      CreateRepeatDduduRequest request = new CreateRepeatDduduRequest(
+          name,
+          goalId,
+          RepeatType.MONTHLY.name(),
+          null,
+          RepeatDduduFixture.getRandomRepeatDaysOfMonth(1),
+          true,
+          startDate,
+          endDate,
+          null,
+          null
+      );
+
+      // when
+      RepeatDdudu actual = repeatDduduDomainService.create(request);
+
+      // then
+      assertThat(actual).extracting("name", "goalId", "repeatType", "startDate", "endDate")
+          .containsExactly(name, goalId, RepeatType.MONTHLY, startDate, endDate);
+    }
+
+  }
+
+  @Nested
+  class 뚜두_생성_테스트 {
+
+    Long userId;
+    String name;
+    Long goalId;
+    LocalDate startDate;
+    LocalDate endDate;
+
+    @BeforeEach
+    void setUp() {
+      userId = GoalFixture.getRandomId();
+      name = RepeatDduduFixture.getRandomSentenceWithMax(50);
+      goalId = GoalFixture.getRandomId();
+      startDate = LocalDate.now();
+      endDate = LocalDate.now()
+          .plusMonths(1);
+    }
+
+    @Test
+    void 데일리_반복_뚜두의_뚜두를_생성한다() {
+      // given
+      RepeatDdudu dailyRepeatDdudu = RepeatDduduFixture.createRepeatDdudu(
+          RepeatType.DAILY,
+          RepeatDduduFixture.createDailyRepeatPattern(),
+          startDate,
+          endDate
+      );
+
+      // when
+      List<Ddudu> ddudus = repeatDduduDomainService.createRepeatedDdudus(
+          userId, dailyRepeatDdudu);
+
+      // then
+      assertThat(ddudus).hasSize(startDate.until(endDate)
+          .getDays() + 1);
+      ddudus.stream()
+          .map(Ddudu::getScheduledOn)
+          .forEach(date -> assertThat(date).isBetween(startDate, endDate));
+    }
+
+    @Test
+    void 위클리_반복_뚜두의_뚜두를_생성한다() {
+      // given
+      List<String> repeatDayOfWeek = RepeatDduduFixture.getRandomRepeatDaysOfWeek(1);
+      RepeatDdudu weeklyRepeatDdudu = RepeatDduduFixture.createRepeatDdudu(
+          RepeatType.WEEKLY,
+          RepeatDduduFixture.createWeeklyRepeatPattern(repeatDayOfWeek),
+          startDate,
+          endDate
+      );
+
+      // when
+      List<Ddudu> ddudus = repeatDduduDomainService.createRepeatedDdudus(
+          userId, weeklyRepeatDdudu);
+
+      // then
+      ddudus.stream()
+          .map(Ddudu::getScheduledOn)
+          .forEach(date -> assertThat(date).isEqualTo(repeatDayOfWeek.get(0)));
+    }
+
+    @Test
+    void 먼슬리_반복_뚜두의_뚜두를_생성한다() {
+      // given
+      int repeatDayOfMonth = RepeatDduduFixture.getRandomInt(1, 31);
+      RepeatDdudu monthlyRepeatDdudu = RepeatDduduFixture.createRepeatDdudu(
+          RepeatType.MONTHLY,
+          RepeatDduduFixture.createMonthlyRepeatPattern(List.of(repeatDayOfMonth), true),
+          startDate,
+          endDate
+      );
+
+      // when
+      List<Ddudu> ddudus = repeatDduduDomainService.createRepeatedDdudus(
+          userId, monthlyRepeatDdudu);
+
+      // then
+      assertThat(ddudus).extracting(ddudu -> ddudu.getScheduledOn()
+              .getDayOfMonth())
+          .containsExactlyInAnyOrder(repeatDayOfMonth, startDate.lengthOfMonth());
+    }
+
+  }
+
+}

--- a/src/test/java/com/ddudu/application/service/repeat_ddudu/CreateRepeatDduduServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/repeat_ddudu/CreateRepeatDduduServiceTest.java
@@ -1,0 +1,152 @@
+package com.ddudu.application.service.repeat_ddudu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+import com.ddudu.application.domain.ddudu.domain.Ddudu;
+import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.goal.exception.GoalErrorCode;
+import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
+import com.ddudu.application.domain.repeat_ddudu.domain.enums.RepeatType;
+import com.ddudu.application.domain.repeat_ddudu.exception.RepeatDduduErrorCode;
+import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.dto.repeat_ddudu.requset.CreateRepeatDduduRequest;
+import com.ddudu.application.port.out.auth.SignUpPort;
+import com.ddudu.application.port.out.ddudu.DduduLoaderPort;
+import com.ddudu.application.port.out.goal.SaveGoalPort;
+import com.ddudu.application.port.out.repeat_ddudu.RepeatDduduLoaderPort;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.RepeatDduduFixture;
+import com.ddudu.fixture.UserFixture;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.MissingResourceException;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class CreateRepeatDduduServiceTest {
+
+  @Autowired
+  CreateRepeatDduduService createRepeatDduduService;
+  @Autowired
+  RepeatDduduLoaderPort repeatDduduLoaderPort;
+  @Autowired
+  DduduLoaderPort dduduLoaderPort;
+  @Autowired
+  SignUpPort signUpPort;
+  @Autowired
+  SaveGoalPort saveGoalPort;
+
+  User user;
+  Goal goal;
+  String name;
+  LocalDate startDate;
+  LocalDate endDate;
+  RepeatType repeatType;
+  List<String> repeatDaysOfWeek;
+  List<Integer> repeatDaysOfMonth;
+  Boolean lastDayOfMonth;
+  CreateRepeatDduduRequest request;
+
+  @BeforeEach
+  void setUp() {
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user));
+    name = RepeatDduduFixture.getRandomSentenceWithMax(50);
+    repeatType = RepeatDduduFixture.getRandomRepeatType();
+    repeatDaysOfWeek = RepeatDduduFixture.getRandomRepeatDaysOfWeek();
+    repeatDaysOfMonth = RepeatDduduFixture.getRandomRepeatDaysOfMonth();
+    lastDayOfMonth = false;
+    startDate = LocalDate.now();
+    endDate = LocalDate.now()
+        .plusMonths(1);
+    request = new CreateRepeatDduduRequest(
+        name,
+        goal.getId(),
+        repeatType.name(),
+        repeatDaysOfWeek,
+        repeatDaysOfMonth,
+        lastDayOfMonth,
+        startDate,
+        endDate,
+        null,
+        null
+    );
+  }
+
+  @Test
+  void 반복_뚜두_생성에_성공한다() {
+    // when
+    Long repeatDduduId = createRepeatDduduService.create(user.getId(), request);
+
+    // then
+    RepeatDdudu repeatDdudu = repeatDduduLoaderPort.getOptionalRepeatDdudu(repeatDduduId)
+        .get();
+    assertThat(repeatDdudu)
+        .hasFieldOrPropertyWithValue("name", name)
+        .hasFieldOrPropertyWithValue("goalId", goal.getId())
+        .hasFieldOrPropertyWithValue("repeatType", repeatType)
+        .hasFieldOrPropertyWithValue("startDate", startDate)
+        .hasFieldOrPropertyWithValue("endDate", endDate);
+  }
+
+  @Test
+  void 반복_뚜두_생성_시_뚜두도_함께_생성된다() {
+    // when
+    Long repeatDduduId = createRepeatDduduService.create(user.getId(), request);
+
+    // then
+    RepeatDdudu repeatDdudu = repeatDduduLoaderPort.getOptionalRepeatDdudu(repeatDduduId)
+        .get();
+    List<Ddudu> ddudus = dduduLoaderPort.getRepeatedDdudus(repeatDdudu);
+    assertThat(ddudus).isNotEmpty();
+  }
+
+  @Test
+  void 목표_아이디가_유효하지_않으면_예외가_발생한다() {
+    // given
+    Long invalidGoalId = GoalFixture.getRandomId();
+    CreateRepeatDduduRequest request = new CreateRepeatDduduRequest(
+        name,
+        invalidGoalId,
+        repeatType.name(),
+        repeatDaysOfWeek,
+        repeatDaysOfMonth,
+        lastDayOfMonth,
+        startDate,
+        endDate,
+        null,
+        null
+    );
+
+    // when
+    ThrowingCallable create = () -> createRepeatDduduService.create(user.getId(), request);
+
+    // then
+    assertThatExceptionOfType(MissingResourceException.class).isThrownBy(create)
+        .withMessage(RepeatDduduErrorCode.NULL_GOAL_VALUE.getCodeName());
+  }
+
+  @Test
+  void 본인의_목표가_아닌_경우_예외가_발생한다() {
+    // given
+    User anotherUser = signUpPort.save(UserFixture.createRandomUserWithId());
+
+    // when
+    ThrowingCallable create = () -> createRepeatDduduService.create(anotherUser.getId(), request);
+
+    // then
+    assertThatExceptionOfType(SecurityException.class).isThrownBy(create)
+        .withMessage(GoalErrorCode.INVALID_AUTHORITY.getCodeName());
+  }
+
+}

--- a/src/test/java/com/ddudu/fixture/RepeatDduduFixture.java
+++ b/src/test/java/com/ddudu/fixture/RepeatDduduFixture.java
@@ -1,0 +1,101 @@
+package com.ddudu.fixture;
+
+import com.ddudu.application.domain.repeat_ddudu.domain.DailyRepeatPattern;
+import com.ddudu.application.domain.repeat_ddudu.domain.MonthlyRepeatPattern;
+import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
+import com.ddudu.application.domain.repeat_ddudu.domain.RepeatPattern;
+import com.ddudu.application.domain.repeat_ddudu.domain.WeeklyRepeatPattern;
+import com.ddudu.application.domain.repeat_ddudu.domain.enums.RepeatType;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RepeatDduduFixture extends BaseFixture {
+
+  public static RepeatDdudu createRepeatDdudu(
+      RepeatType repeatType, RepeatPattern repeatPattern, LocalDate startDate, LocalDate endDate
+  ) {
+    return RepeatDdudu.builder()
+        .goalId(GoalFixture.getRandomId())
+        .name(getRandomSentenceWithMax(50))
+        .repeatType(repeatType)
+        .repeatPattern(repeatPattern)
+        .startDate(startDate)
+        .endDate(endDate)
+        .build();
+
+  }
+
+  public static RepeatType getRandomRepeatType() {
+    RepeatType[] types = RepeatType.values();
+    int index = getRandomInt(0, types.length - 1);
+
+    return types[index];
+  }
+
+  public static RepeatPattern createRandomRepeatPattern(RepeatType type) {
+    return switch (type) {
+      case DAILY -> createDailyRepeatPattern();
+      case WEEKLY -> createWeeklyRepeatPattern(getRandomRepeatDaysOfWeek());
+      case MONTHLY -> createMonthlyRepeatPattern(
+          getRandomRepeatDaysOfMonth(), false
+      );
+    };
+  }
+
+  public static RepeatPattern createDailyRepeatPattern() {
+    return new DailyRepeatPattern();
+  }
+
+  public static RepeatPattern createWeeklyRepeatPattern(List<String> repeatDaysOfWeek) {
+    return WeeklyRepeatPattern.withValidation(repeatDaysOfWeek);
+  }
+
+  public static RepeatPattern createMonthlyRepeatPattern(
+      List<Integer> repeatDaysOfMonth, boolean lastDayOfMonth
+  ) {
+    return MonthlyRepeatPattern.withValidation(repeatDaysOfMonth, lastDayOfMonth);
+  }
+
+  public static List<String> getRandomRepeatDaysOfWeek() {
+    int numberOfDaysToRepeat = getRandomInt(1, DayOfWeek.values().length);
+    return getRandomRepeatDaysOfWeek(numberOfDaysToRepeat);
+  }
+
+  public static List<String> getRandomRepeatDaysOfWeek(int numberOfDaysToRepeat) {
+    List<DayOfWeek> days = Arrays.stream(DayOfWeek.values())
+        .collect(Collectors.toList());
+
+    Collections.shuffle(days);
+
+    return days.stream()
+        .limit(numberOfDaysToRepeat)
+        .map(DayOfWeek::name)
+        .toList();
+  }
+
+  public static List<Integer> getRandomRepeatDaysOfMonth() {
+    int numberOfDaysToRepeat = getRandomInt(1, 31);
+    return getRandomRepeatDaysOfMonth(numberOfDaysToRepeat);
+  }
+
+  public static List<Integer> getRandomRepeatDaysOfMonth(int numberOfDaysToRepeat) {
+    List<Integer> days = IntStream.rangeClosed(1, 31)
+        .boxed()
+        .collect(Collectors.toList());
+
+    Collections.shuffle(days);
+
+    return days.stream()
+        .limit(numberOfDaysToRepeat)
+        .toList();
+  }
+
+}


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Closes #191 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 기존 코드 리팩토링
- [x] 반복 날짜에 대한 유효성 검사를 RepeatPattern 내부에서 수행하도록 변경
- [x] 반복 뚜두 생성 시 RepeatPattern를 생성해서 주입하지 않고, 생성자 내부에서 생성하도록 변경
- [x] 유효성 검사 추가 및 에러 수정
- 테스트 코드 작성
- [x] 도메인 테스트 코드 작성
- [x] 도메인 서비스 테스트 코드 작성
- [x] 애플리케이션 서비스 테스트 코드 작성

## 💬 코멘트
- `RepeatDdudu` 도메인 생성 및 테스트를 먼저 PR로 올렸어야 했는데, 생성 기능이랑 같이 작업하니 PR 단위가 너무 커졌습니다.. 죄송합니다😭
- 반복 날짜 확인에 대한 테스트 코드가 깔끔하지 못한 것 같은데.. 죄송합니다.. 조금 더 고민해서 리팩토링 때 가독성있게 수정하겠습니다..!!