### PR TITLE
주간 뚜두 완료도 조회

### DIFF
--- a/src/main/java/com/ddudu/application/domain/repeat_ddudu/util/DayOfWeekUtil.java
+++ b/src/main/java/com/ddudu/application/domain/repeat_ddudu/util/DayOfWeekUtil.java
@@ -1,10 +1,12 @@
 package com.ddudu.application.domain.repeat_ddudu.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 import com.ddudu.application.domain.repeat_ddudu.exception.RepeatDduduErrorCode;
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.format.TextStyle;
 import java.util.HashMap;
 import java.util.List;
@@ -13,6 +15,7 @@ import java.util.Map;
 
 public final class DayOfWeekUtil {
 
+  private static final DayOfWeek FIRST_DAY_OF_WEEK = DayOfWeek.MONDAY;
   private static final Map<String, DayOfWeek> dayOfWeekMap = new HashMap<>();
 
   static {
@@ -36,6 +39,11 @@ public final class DayOfWeekUtil {
     return daysOfWeek.stream()
         .map(DayOfWeekUtil::toDaysOfWeek)
         .toList();
+  }
+
+  public static LocalDate getFirstDayOfWeek(LocalDate date) {
+    return isNull(date) ? LocalDate.now()
+        .with(FIRST_DAY_OF_WEEK) : date.with(FIRST_DAY_OF_WEEK);
   }
 
 }

--- a/src/main/java/com/ddudu/application/dto/ddudu/response/DduduCompletionResponse.java
+++ b/src/main/java/com/ddudu/application/dto/ddudu/response/DduduCompletionResponse.java
@@ -1,17 +1,17 @@
-package com.ddudu.old.todo.dto.response;
+package com.ddudu.application.dto.ddudu.response;
 
 import java.time.LocalDate;
 import lombok.Builder;
 
 @Builder
-public record TodoCompletionResponse(
+public record DduduCompletionResponse(
     LocalDate date,
     int totalCount,
     int uncompletedCount
 ) {
 
-  public static TodoCompletionResponse createEmptyResponse(LocalDate date) {
-    return TodoCompletionResponse.builder()
+  public static DduduCompletionResponse createEmptyResponse(LocalDate date) {
+    return DduduCompletionResponse.builder()
         .date(date)
         .totalCount(0)
         .uncompletedCount(0)

--- a/src/main/java/com/ddudu/application/port/in/ddudu/CalculateWeeklyCompletionUseCase.java
+++ b/src/main/java/com/ddudu/application/port/in/ddudu/CalculateWeeklyCompletionUseCase.java
@@ -1,0 +1,11 @@
+package com.ddudu.application.port.in.ddudu;
+
+import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface CalculateWeeklyCompletionUseCase {
+
+  List<DduduCompletionResponse> calculate(Long loginId, Long userId, LocalDate date);
+
+}

--- a/src/main/java/com/ddudu/application/port/out/ddudu/DduduStatsPort.java
+++ b/src/main/java/com/ddudu/application/port/out/ddudu/DduduStatsPort.java
@@ -3,13 +3,13 @@ package com.ddudu.application.port.out.ddudu;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface DduduStatsPort {
 
   List<DduduCompletionResponse> calculateDdudusCompletion(
-      LocalDateTime startDate, LocalDateTime endDate, User user, List<PrivacyType> privacyTypes
+      LocalDate startDate, LocalDate endDate, User user, List<PrivacyType> privacyTypes
   );
 
 }

--- a/src/main/java/com/ddudu/application/port/out/ddudu/DduduStatsPort.java
+++ b/src/main/java/com/ddudu/application/port/out/ddudu/DduduStatsPort.java
@@ -1,0 +1,15 @@
+package com.ddudu.application.port.out.ddudu;
+
+import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
+import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface DduduStatsPort {
+
+  List<DduduCompletionResponse> calculateDdudusCompletion(
+      LocalDateTime startDate, LocalDateTime endDate, User user, List<PrivacyType> privacyTypes
+  );
+
+}

--- a/src/main/java/com/ddudu/application/service/ddudu/CalculateWeeklyCompletionService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/CalculateWeeklyCompletionService.java
@@ -1,0 +1,82 @@
+package com.ddudu.application.service.ddudu;
+
+import com.ddudu.application.annotation.UseCase;
+import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
+import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
+import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
+import com.ddudu.application.port.in.ddudu.CalculateWeeklyCompletionUseCase;
+import com.ddudu.application.port.out.ddudu.DduduStatsPort;
+import com.ddudu.application.port.out.user.UserLoaderPort;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalculateWeeklyCompletionService implements CalculateWeeklyCompletionUseCase {
+
+  private final UserLoaderPort userLoaderPort;
+  private final DduduStatsPort dduduStatsPort;
+
+  @Override
+  public List<DduduCompletionResponse> calculate(Long loginId, Long userId, LocalDate date) {
+    User loginUser = userLoaderPort.getUserOrElseThrow(
+        loginId, DduduErrorCode.USER_NOT_EXISTING.getCodeName());
+    User user = userLoaderPort.getUserOrElseThrow(
+        userId, DduduErrorCode.USER_NOT_EXISTING.getCodeName());
+
+    LocalDateTime startDate = date.atStartOfDay();
+    LocalDateTime endDate = startDate.plusDays(7);
+
+    return generateCompletions(startDate, endDate, loginUser, user);
+  }
+
+  private List<DduduCompletionResponse> generateCompletions(
+      LocalDateTime startDate, LocalDateTime endDate, User loginUser, User user
+  ) {
+    List<PrivacyType> privacyTypes = determinePrivacyTypes(loginUser, user);
+
+    Map<LocalDate, DduduCompletionResponse> completionByDate = dduduStatsPort.calculateDdudusCompletion(
+            startDate, endDate, user, privacyTypes)
+        .stream()
+        .collect(Collectors.toMap(DduduCompletionResponse::date, response -> response));
+
+    List<DduduCompletionResponse> completionList = new ArrayList<>();
+    for (LocalDateTime currentDate = startDate; currentDate.isBefore(endDate);
+        currentDate = currentDate.plusDays(1)) {
+      DduduCompletionResponse response = completionByDate.getOrDefault(
+          currentDate.toLocalDate(),
+          DduduCompletionResponse.createEmptyResponse(currentDate.toLocalDate())
+      );
+
+      completionList.add(response);
+    }
+
+    return completionList;
+  }
+
+  private List<PrivacyType> determinePrivacyTypes(User loginUser, User user) {
+    if (loginUser.equals(user)) {
+      return List.of(PrivacyType.PRIVATE, PrivacyType.FOLLOWER, PrivacyType.PUBLIC);
+    }
+
+    if (isFollowerOf(loginUser, user)) {
+      return List.of(PrivacyType.FOLLOWER, PrivacyType.PUBLIC);
+    }
+
+    return List.of(PrivacyType.PUBLIC);
+  }
+
+  private boolean isFollowerOf(User user, User targetUser) {
+    // TODO: 팔로잉 기능 추가 시 팔로잉 상태 확인
+    return false;
+  }
+
+}

--- a/src/main/java/com/ddudu/application/service/ddudu/CalculateWeeklyCompletionService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/CalculateWeeklyCompletionService.java
@@ -1,5 +1,7 @@
 package com.ddudu.application.service.ddudu;
 
+import static java.util.Objects.isNull;
+
 import com.ddudu.application.annotation.UseCase;
 import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
@@ -29,7 +31,7 @@ public class CalculateWeeklyCompletionService implements CalculateWeeklyCompleti
   public List<DduduCompletionResponse> calculate(Long loginId, Long userId, LocalDate date) {
     User loginUser = userLoaderPort.getUserOrElseThrow(
         loginId, DduduErrorCode.USER_NOT_EXISTING.getCodeName());
-    User user = userLoaderPort.getUserOrElseThrow(
+    User user = isNull(userId) ? loginUser : userLoaderPort.getUserOrElseThrow(
         userId, DduduErrorCode.USER_NOT_EXISTING.getCodeName());
 
     LocalDate firstDayOfWeek = DayOfWeekUtil.getFirstDayOfWeek(date);

--- a/src/main/java/com/ddudu/application/service/ddudu/CalculateWeeklyCompletionService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/CalculateWeeklyCompletionService.java
@@ -3,13 +3,13 @@ package com.ddudu.application.service.ddudu;
 import com.ddudu.application.annotation.UseCase;
 import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
+import com.ddudu.application.domain.repeat_ddudu.util.DayOfWeekUtil;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.application.port.in.ddudu.CalculateWeeklyCompletionUseCase;
 import com.ddudu.application.port.out.ddudu.DduduStatsPort;
 import com.ddudu.application.port.out.user.UserLoaderPort;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,14 +32,14 @@ public class CalculateWeeklyCompletionService implements CalculateWeeklyCompleti
     User user = userLoaderPort.getUserOrElseThrow(
         userId, DduduErrorCode.USER_NOT_EXISTING.getCodeName());
 
-    LocalDateTime startDate = date.atStartOfDay();
-    LocalDateTime endDate = startDate.plusDays(7);
+    LocalDate firstDayOfWeek = DayOfWeekUtil.getFirstDayOfWeek(date);
+    LocalDate lastDayOfWeek = firstDayOfWeek.plusDays(7);
 
-    return generateCompletions(startDate, endDate, loginUser, user);
+    return generateCompletions(firstDayOfWeek, lastDayOfWeek, loginUser, user);
   }
 
   private List<DduduCompletionResponse> generateCompletions(
-      LocalDateTime startDate, LocalDateTime endDate, User loginUser, User user
+      LocalDate startDate, LocalDate endDate, User loginUser, User user
   ) {
     List<PrivacyType> privacyTypes = determinePrivacyTypes(loginUser, user);
 
@@ -49,11 +49,11 @@ public class CalculateWeeklyCompletionService implements CalculateWeeklyCompleti
         .collect(Collectors.toMap(DduduCompletionResponse::date, response -> response));
 
     List<DduduCompletionResponse> completionList = new ArrayList<>();
-    for (LocalDateTime currentDate = startDate; currentDate.isBefore(endDate);
+    for (LocalDate currentDate = startDate; currentDate.isBefore(endDate);
         currentDate = currentDate.plusDays(1)) {
       DduduCompletionResponse response = completionByDate.getOrDefault(
-          currentDate.toLocalDate(),
-          DduduCompletionResponse.createEmptyResponse(currentDate.toLocalDate())
+          currentDate,
+          DduduCompletionResponse.createEmptyResponse(currentDate)
       );
 
       completionList.add(response);

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
@@ -27,7 +27,6 @@ import com.ddudu.infrastructure.persistence.entity.UserEntity;
 import com.ddudu.infrastructure.persistence.repository.ddudu.DduduRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.MissingResourceException;
 import java.util.Optional;
@@ -181,7 +180,7 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
 
   @Override
   public List<DduduCompletionResponse> calculateDdudusCompletion(
-      LocalDateTime startDate, LocalDateTime endDate, User user, List<PrivacyType> privacyTypes
+      LocalDate startDate, LocalDate endDate, User user, List<PrivacyType> privacyTypes
   ) {
     return dduduRepository.findDdudusCompletion(
         startDate, endDate, UserEntity.from(user), privacyTypes);

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
@@ -2,15 +2,18 @@ package com.ddudu.infrastructure.persistence.adapter;
 
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
 import com.ddudu.application.dto.ddudu.TimeGroupedDdudus;
+import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.application.dto.scroll.request.ScrollRequest;
 import com.ddudu.application.dto.scroll.response.ScrollResponse;
 import com.ddudu.application.port.out.ddudu.DduduLoaderPort;
 import com.ddudu.application.port.out.ddudu.DduduSearchPort;
+import com.ddudu.application.port.out.ddudu.DduduStatsPort;
 import com.ddudu.application.port.out.ddudu.DduduUpdatePort;
 import com.ddudu.application.port.out.ddudu.DeleteDduduPort;
 import com.ddudu.application.port.out.ddudu.RepeatDduduPort;
@@ -24,6 +27,7 @@ import com.ddudu.infrastructure.persistence.entity.UserEntity;
 import com.ddudu.infrastructure.persistence.repository.ddudu.DduduRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.MissingResourceException;
 import java.util.Optional;
@@ -32,7 +36,7 @@ import lombok.RequiredArgsConstructor;
 @DrivenAdapter
 @RequiredArgsConstructor
 public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort, SaveDduduPort,
-    RepeatDduduPort, DduduSearchPort, DeleteDduduPort {
+    RepeatDduduPort, DduduSearchPort, DeleteDduduPort, DduduStatsPort {
 
   private final DduduRepository dduduRepository;
 
@@ -173,6 +177,14 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
     }
 
     return null;
+  }
+
+  @Override
+  public List<DduduCompletionResponse> calculateDdudusCompletion(
+      LocalDateTime startDate, LocalDateTime endDate, User user, List<PrivacyType> privacyTypes
+  ) {
+    return dduduRepository.findDdudusCompletion(
+        startDate, endDate, UserEntity.from(user), privacyTypes);
   }
 
 }

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
@@ -3,12 +3,12 @@ package com.ddudu.infrastructure.persistence.repository.ddudu;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.TimeGroupedDdudus;
+import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.application.dto.scroll.request.ScrollRequest;
 import com.ddudu.infrastructure.persistence.dto.DduduCursorDto;
 import com.ddudu.infrastructure.persistence.entity.DduduEntity;
 import com.ddudu.infrastructure.persistence.entity.GoalEntity;
 import com.ddudu.infrastructure.persistence.entity.UserEntity;
-import com.ddudu.old.todo.dto.response.TodoCompletionResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,7 +23,7 @@ public interface DduduQueryRepository {
       LocalDate date, UserEntity user, List<GoalEntity> goals
   );
 
-  List<TodoCompletionResponse> findTodosCompletion(
+  List<DduduCompletionResponse> findDdudusCompletion(
       LocalDateTime startDate, LocalDateTime endDate, UserEntity user,
       List<PrivacyType> privacyTypes
   );

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
@@ -24,7 +24,7 @@ public interface DduduQueryRepository {
   );
 
   List<DduduCompletionResponse> findDdudusCompletion(
-      LocalDateTime startDate, LocalDateTime endDate, UserEntity user,
+      LocalDate startDate, LocalDate endDate, UserEntity user,
       List<PrivacyType> privacyTypes
   );
 

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepositoryImpl.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepositoryImpl.java
@@ -85,11 +85,11 @@ public class DduduQueryRepositoryImpl implements DduduQueryRepository {
 
   @Override
   public List<DduduCompletionResponse> findDdudusCompletion(
-      LocalDateTime startDate, LocalDateTime endDate, UserEntity user,
+      LocalDate startDate, LocalDate endDate, UserEntity user,
       List<PrivacyType> privacyTypes
   ) {
     DateTemplate<LocalDate> dateTemplate = Expressions.dateTemplate(
-        LocalDate.class, "{0}", dduduEntity.beginAt);
+        LocalDate.class, "{0}", dduduEntity.scheduledOn);
 
     NumberTemplate<Long> totalTodosTemplate = Expressions.numberTemplate(
         Long.class,
@@ -120,15 +120,14 @@ public class DduduQueryRepositoryImpl implements DduduQueryRepository {
             dduduEntity.goal.privacyType.in(privacyTypes)
         )
         .where(
-            dduduEntity.beginAt.goe(LocalTime.from(startDate)),
-            dduduEntity.beginAt.lt(LocalTime.from(endDate))
+            dduduEntity.scheduledOn.goe(LocalDate.from(startDate)),
+            dduduEntity.scheduledOn.lt(LocalDate.from(endDate))
         )
         .groupBy(dateTemplate)
         .fetch()
         .stream()
         .map(result -> DduduCompletionResponse.builder()
-            .date(Objects.requireNonNull(result.get(0, LocalDateTime.class))
-                .toLocalDate())
+            .date(Objects.requireNonNull(result.get(0, LocalDate.class)))
             .totalCount(Objects.requireNonNull(result.get(1, Long.class))
                 .intValue())
             .uncompletedCount(Objects.requireNonNull(result.get(2, Long.class))

--- a/src/main/java/com/ddudu/old/persistence/repository/TodoRepositoryImpl.java
+++ b/src/main/java/com/ddudu/old/persistence/repository/TodoRepositoryImpl.java
@@ -3,11 +3,11 @@ package com.ddudu.old.persistence.repository;
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.infrastructure.persistence.entity.DduduEntity;
 import com.ddudu.infrastructure.persistence.entity.UserEntity;
 import com.ddudu.infrastructure.persistence.repository.ddudu.DduduRepository;
 import com.ddudu.old.todo.domain.OldTodoRepository;
-import com.ddudu.old.todo.dto.response.TodoCompletionResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -43,10 +43,10 @@ public class TodoRepositoryImpl implements OldTodoRepository {
   }
 
   @Override
-  public List<TodoCompletionResponse> findTodosCompletion(
+  public List<DduduCompletionResponse> findTodosCompletion(
       LocalDateTime startDate, LocalDateTime endDate, User user, List<PrivacyType> privacyTypes
   ) {
-    return dduduRepository.findTodosCompletion(
+    return dduduRepository.findDdudusCompletion(
         startDate, endDate, UserEntity.from(user), privacyTypes);
   }
 

--- a/src/main/java/com/ddudu/old/persistence/repository/TodoRepositoryImpl.java
+++ b/src/main/java/com/ddudu/old/persistence/repository/TodoRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.ddudu.infrastructure.persistence.entity.DduduEntity;
 import com.ddudu.infrastructure.persistence.entity.UserEntity;
 import com.ddudu.infrastructure.persistence.repository.ddudu.DduduRepository;
 import com.ddudu.old.todo.domain.OldTodoRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -44,7 +45,7 @@ public class TodoRepositoryImpl implements OldTodoRepository {
 
   @Override
   public List<DduduCompletionResponse> findTodosCompletion(
-      LocalDateTime startDate, LocalDateTime endDate, User user, List<PrivacyType> privacyTypes
+      LocalDate startDate, LocalDate endDate, User user, List<PrivacyType> privacyTypes
   ) {
     return dduduRepository.findDdudusCompletion(
         startDate, endDate, UserEntity.from(user), privacyTypes);

--- a/src/main/java/com/ddudu/old/todo/domain/OldTodoRepository.java
+++ b/src/main/java/com/ddudu/old/todo/domain/OldTodoRepository.java
@@ -4,6 +4,7 @@ import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -19,7 +20,7 @@ public interface OldTodoRepository {
   List<Ddudu> findTodosByDate(LocalDateTime startDate, LocalDateTime endDate, User user);
 
   List<DduduCompletionResponse> findTodosCompletion(
-      LocalDateTime startDate, LocalDateTime endDate, User user, List<PrivacyType> privacyTypes
+      LocalDate startDate, LocalDate endDate, User user, List<PrivacyType> privacyTypes
   );
 
   void update(Ddudu ddudu);

--- a/src/main/java/com/ddudu/old/todo/domain/OldTodoRepository.java
+++ b/src/main/java/com/ddudu/old/todo/domain/OldTodoRepository.java
@@ -3,7 +3,7 @@ package com.ddudu.old.todo.domain;
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.user.domain.User;
-import com.ddudu.old.todo.dto.response.TodoCompletionResponse;
+import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -18,7 +18,7 @@ public interface OldTodoRepository {
 
   List<Ddudu> findTodosByDate(LocalDateTime startDate, LocalDateTime endDate, User user);
 
-  List<TodoCompletionResponse> findTodosCompletion(
+  List<DduduCompletionResponse> findTodosCompletion(
       LocalDateTime startDate, LocalDateTime endDate, User user, List<PrivacyType> privacyTypes
   );
 

--- a/src/main/java/com/ddudu/old/todo/service/TodoService.java
+++ b/src/main/java/com/ddudu/old/todo/service/TodoService.java
@@ -7,7 +7,6 @@ import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.response.BasicDduduResponse;
-import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.application.exception.ErrorCode;
 import com.ddudu.old.goal.domain.OldGoalRepository;
 import com.ddudu.old.like.domain.Like;
@@ -18,12 +17,8 @@ import com.ddudu.old.todo.dto.response.TodoResponse;
 import com.ddudu.old.user.domain.FollowingRepository;
 import com.ddudu.old.user.domain.UserRepository;
 import com.ddudu.presentation.api.exception.DataNotFoundException;
-import com.ddudu.presentation.api.exception.ForbiddenException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.YearMonth;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -77,31 +72,6 @@ public class TodoService {
         .toList();
   }
 
-  public List<DduduCompletionResponse> findWeeklyCompletions(
-      Long loginId, Long userId, LocalDate date
-  ) {
-    User loginUser = findUser(loginId, DduduErrorCode.LOGIN_USER_NOT_EXISTING);
-    User user = determineUser(loginId, userId, loginUser);
-
-    LocalDateTime startDate = date.atStartOfDay();
-    LocalDateTime endDate = startDate.plusDays(7);
-
-    return generateCompletions(startDate, endDate, loginUser, user);
-  }
-
-  public List<DduduCompletionResponse> findMonthlyCompletions(
-      Long loginId, Long userId, YearMonth yearMonth
-  ) {
-    User loginUser = findUser(loginId, DduduErrorCode.LOGIN_USER_NOT_EXISTING);
-    User user = determineUser(loginId, userId, loginUser);
-
-    LocalDateTime startDate = yearMonth.atDay(1)
-        .atStartOfDay();
-    LocalDateTime endDate = startDate.plusMonths(1);
-
-    return generateCompletions(startDate, endDate, loginUser, user);
-  }
-
   @Transactional
   public void updateStatus(Long loginId, Long id) {
     Ddudu ddudu = findTodo(id, DduduErrorCode.ID_NOT_EXISTING);
@@ -119,29 +89,6 @@ public class TodoService {
         });
   }
 
-  private List<DduduCompletionResponse> generateCompletions(
-      LocalDateTime startDate, LocalDateTime endDate, User loginUser, User user
-  ) {
-    List<PrivacyType> privacyTypes = determinePrivacyTypes(loginUser, user);
-
-    Map<LocalDate, DduduCompletionResponse> completionByDate = oldTodoRepository.findTodosCompletion(
-            startDate, endDate, user, privacyTypes)
-        .stream()
-        .collect(Collectors.toMap(DduduCompletionResponse::date, response -> response));
-
-    List<DduduCompletionResponse> completionList = new ArrayList<>();
-    for (LocalDateTime currentDate = startDate; currentDate.isBefore(endDate);
-        currentDate = currentDate.plusDays(1)) {
-      DduduCompletionResponse response = completionByDate.getOrDefault(
-          currentDate.toLocalDate(),
-          DduduCompletionResponse.createEmptyResponse(currentDate.toLocalDate())
-      );
-      completionList.add(response);
-    }
-
-    return completionList;
-  }
-
   private User determineUser(Long loginId, Long userId, User loginUser) {
     if (loginId.equals(userId)) {
       return loginUser;
@@ -155,20 +102,9 @@ public class TodoService {
         .orElseThrow(() -> new DataNotFoundException(errorCode));
   }
 
-  private Goal findGoal(Long goalId, ErrorCode errorCode) {
-    return oldGoalRepository.findById(goalId)
-        .orElseThrow(() -> new DataNotFoundException(errorCode));
-  }
-
   private Ddudu findTodo(Long todoId, ErrorCode errorCode) {
     return oldTodoRepository.findById(todoId)
         .orElseThrow(() -> new DataNotFoundException(errorCode));
-  }
-
-  private void checkGoalPermission(Long userId, Goal goal) {
-    if (!goal.isCreatedBy(userId)) {
-      throw new ForbiddenException(DduduErrorCode.INVALID_AUTHORITY);
-    }
   }
 
   private List<PrivacyType> determinePrivacyTypes(User loginUser, User user) {

--- a/src/main/java/com/ddudu/old/todo/service/TodoService.java
+++ b/src/main/java/com/ddudu/old/todo/service/TodoService.java
@@ -7,13 +7,13 @@ import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.response.BasicDduduResponse;
+import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.application.exception.ErrorCode;
 import com.ddudu.old.goal.domain.OldGoalRepository;
 import com.ddudu.old.like.domain.Like;
 import com.ddudu.old.like.domain.LikeRepository;
 import com.ddudu.old.todo.domain.OldTodoRepository;
 import com.ddudu.old.todo.dto.response.LikeInfo;
-import com.ddudu.old.todo.dto.response.TodoCompletionResponse;
 import com.ddudu.old.todo.dto.response.TodoResponse;
 import com.ddudu.old.user.domain.FollowingRepository;
 import com.ddudu.old.user.domain.UserRepository;
@@ -77,7 +77,7 @@ public class TodoService {
         .toList();
   }
 
-  public List<TodoCompletionResponse> findWeeklyCompletions(
+  public List<DduduCompletionResponse> findWeeklyCompletions(
       Long loginId, Long userId, LocalDate date
   ) {
     User loginUser = findUser(loginId, DduduErrorCode.LOGIN_USER_NOT_EXISTING);
@@ -89,7 +89,7 @@ public class TodoService {
     return generateCompletions(startDate, endDate, loginUser, user);
   }
 
-  public List<TodoCompletionResponse> findMonthlyCompletions(
+  public List<DduduCompletionResponse> findMonthlyCompletions(
       Long loginId, Long userId, YearMonth yearMonth
   ) {
     User loginUser = findUser(loginId, DduduErrorCode.LOGIN_USER_NOT_EXISTING);
@@ -119,22 +119,22 @@ public class TodoService {
         });
   }
 
-  private List<TodoCompletionResponse> generateCompletions(
+  private List<DduduCompletionResponse> generateCompletions(
       LocalDateTime startDate, LocalDateTime endDate, User loginUser, User user
   ) {
     List<PrivacyType> privacyTypes = determinePrivacyTypes(loginUser, user);
 
-    Map<LocalDate, TodoCompletionResponse> completionByDate = oldTodoRepository.findTodosCompletion(
+    Map<LocalDate, DduduCompletionResponse> completionByDate = oldTodoRepository.findTodosCompletion(
             startDate, endDate, user, privacyTypes)
         .stream()
-        .collect(Collectors.toMap(TodoCompletionResponse::date, response -> response));
+        .collect(Collectors.toMap(DduduCompletionResponse::date, response -> response));
 
-    List<TodoCompletionResponse> completionList = new ArrayList<>();
+    List<DduduCompletionResponse> completionList = new ArrayList<>();
     for (LocalDateTime currentDate = startDate; currentDate.isBefore(endDate);
         currentDate = currentDate.plusDays(1)) {
-      TodoCompletionResponse response = completionByDate.getOrDefault(
+      DduduCompletionResponse response = completionByDate.getOrDefault(
           currentDate.toLocalDate(),
-          TodoCompletionResponse.createEmptyResponse(currentDate.toLocalDate())
+          DduduCompletionResponse.createEmptyResponse(currentDate.toLocalDate())
       );
       completionList.add(response);
     }

--- a/src/main/java/com/ddudu/presentation/api/controller/DduduController.java
+++ b/src/main/java/com/ddudu/presentation/api/controller/DduduController.java
@@ -176,10 +176,9 @@ public class DduduController implements DduduControllerDoc {
   ) {
     userId = (userId == null) ? loginId : userId;
     yearMonth = (yearMonth == null) ? YearMonth.now() : yearMonth;
-    List<DduduCompletionResponse> completionList = todoService.findMonthlyCompletions(
-        loginId, userId, yearMonth);
 
-    return ResponseEntity.ok(completionList);
+    // TODO: Need to implement this method
+    return null;
   }
 
   @PutMapping("/{id}")

--- a/src/main/java/com/ddudu/presentation/api/controller/DduduController.java
+++ b/src/main/java/com/ddudu/presentation/api/controller/DduduController.java
@@ -11,9 +11,11 @@ import com.ddudu.application.dto.ddudu.request.MoveDateRequest;
 import com.ddudu.application.dto.ddudu.request.PeriodSetupRequest;
 import com.ddudu.application.dto.ddudu.request.RepeatAnotherDayRequest;
 import com.ddudu.application.dto.ddudu.response.BasicDduduResponse;
+import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.application.dto.ddudu.response.RepeatAnotherDayResponse;
 import com.ddudu.application.dto.ddudu.response.TimetableResponse;
 import com.ddudu.application.dto.scroll.response.ScrollResponse;
+import com.ddudu.application.port.in.ddudu.CalculateWeeklyCompletionUseCase;
 import com.ddudu.application.port.in.ddudu.ChangeNameUseCase;
 import com.ddudu.application.port.in.ddudu.CreateDduduUseCase;
 import com.ddudu.application.port.in.ddudu.DduduSearchUseCase;
@@ -24,7 +26,6 @@ import com.ddudu.application.port.in.ddudu.MoveDateUseCase;
 import com.ddudu.application.port.in.ddudu.PeriodSetupUseCase;
 import com.ddudu.application.port.in.ddudu.RepeatUseCase;
 import com.ddudu.application.port.in.ddudu.SwitchStatusUseCase;
-import com.ddudu.old.todo.dto.response.TodoCompletionResponse;
 import com.ddudu.old.todo.dto.response.TodoResponse;
 import com.ddudu.old.todo.service.TodoService;
 import com.ddudu.presentation.api.annotation.Login;
@@ -66,6 +67,7 @@ public class DduduController implements DduduControllerDoc {
   private final SwitchStatusUseCase switchStatusUseCase;
   private final ChangeNameUseCase changeNameUseCase;
   private final DeleteDduduUseCase deleteDduduUseCase;
+  private final CalculateWeeklyCompletionUseCase calculateWeeklyCompletionUseCase;
   private final TodoService todoService;
 
   @PostMapping
@@ -143,9 +145,8 @@ public class DduduController implements DduduControllerDoc {
     return ResponseEntity.ok(response);
   }
 
-  @GetMapping("/weekly")
-  @Deprecated
-  public ResponseEntity<List<TodoCompletionResponse>> getWeeklyCompletion(
+  @GetMapping("/completion/weekly")
+  public ResponseEntity<List<DduduCompletionResponse>> getWeeklyCompletion(
       @Login
       Long loginId,
       @RequestParam(required = false)
@@ -158,15 +159,16 @@ public class DduduController implements DduduControllerDoc {
     DayOfWeek weekStart = DayOfWeek.MONDAY;
     date = (date == null) ? LocalDate.now()
         .with(weekStart) : date.with(weekStart);
-    List<TodoCompletionResponse> completionList = todoService.findWeeklyCompletions(
+
+    List<DduduCompletionResponse> response = calculateWeeklyCompletionUseCase.calculate(
         loginId, userId, date);
 
-    return ResponseEntity.ok(completionList);
+    return ResponseEntity.ok(response);
   }
 
   @GetMapping("/monthly")
   @Deprecated
-  public ResponseEntity<List<TodoCompletionResponse>> getMonthlyCompletion(
+  public ResponseEntity<List<DduduCompletionResponse>> getMonthlyCompletion(
       @Login
       Long loginId,
       @RequestParam(required = false)
@@ -180,7 +182,7 @@ public class DduduController implements DduduControllerDoc {
   ) {
     userId = (userId == null) ? loginId : userId;
     yearMonth = (yearMonth == null) ? YearMonth.now() : yearMonth;
-    List<TodoCompletionResponse> completionList = todoService.findMonthlyCompletions(
+    List<DduduCompletionResponse> completionList = todoService.findMonthlyCompletions(
         loginId, userId, yearMonth);
 
     return ResponseEntity.ok(completionList);

--- a/src/main/java/com/ddudu/presentation/api/controller/DduduController.java
+++ b/src/main/java/com/ddudu/presentation/api/controller/DduduController.java
@@ -33,7 +33,6 @@ import com.ddudu.presentation.api.common.dto.response.IdResponse;
 import com.ddudu.presentation.api.doc.DduduControllerDoc;
 import jakarta.validation.Valid;
 import java.net.URI;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
@@ -155,11 +154,6 @@ public class DduduController implements DduduControllerDoc {
       @DateTimeFormat(pattern = "yyyy-MM-dd")
       LocalDate date
   ) {
-    userId = (userId == null) ? loginId : userId;
-    DayOfWeek weekStart = DayOfWeek.MONDAY;
-    date = (date == null) ? LocalDate.now()
-        .with(weekStart) : date.with(weekStart);
-
     List<DduduCompletionResponse> response = calculateWeeklyCompletionUseCase.calculate(
         loginId, userId, date);
 

--- a/src/main/java/com/ddudu/presentation/api/doc/DduduControllerDoc.java
+++ b/src/main/java/com/ddudu/presentation/api/doc/DduduControllerDoc.java
@@ -9,10 +9,10 @@ import com.ddudu.application.dto.ddudu.request.MoveDateRequest;
 import com.ddudu.application.dto.ddudu.request.PeriodSetupRequest;
 import com.ddudu.application.dto.ddudu.request.RepeatAnotherDayRequest;
 import com.ddudu.application.dto.ddudu.response.BasicDduduResponse;
+import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.application.dto.ddudu.response.RepeatAnotherDayResponse;
 import com.ddudu.application.dto.ddudu.response.TimetableResponse;
 import com.ddudu.application.dto.scroll.response.ScrollResponse;
-import com.ddudu.old.todo.dto.response.TodoCompletionResponse;
 import com.ddudu.old.todo.dto.response.TodoResponse;
 import com.ddudu.presentation.api.common.dto.response.IdResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -103,19 +103,37 @@ public interface DduduControllerDoc {
   ResponseEntity<TimetableResponse> getDailyTimetable(Long loginId, Long userId, LocalDate date);
 
 
-  @Operation(summary = "주간 뚜두 조회")
+  @Operation(summary = "주간 뚜두 완료도 조회")
   @ApiResponse(
-      responseCode = "200"
+      responseCode = "200",
+      content = @Content(
+          mediaType = MediaType.APPLICATION_JSON_VALUE,
+          array = @ArraySchema(schema = @Schema(implementation = DduduCompletionResponse.class))
+      )
   )
-  ResponseEntity<List<TodoCompletionResponse>> getWeeklyCompletion(
+  @Parameters(
+      {
+          @Parameter(
+              name = "userId",
+              description = "조회할 뚜두의 사용자 식별자 (기본값: 로그인한 사용자)",
+              in = ParameterIn.QUERY
+          ),
+          @Parameter(
+              name = "date",
+              description = "조회할 날짜 (기본값: 오늘)",
+              in = ParameterIn.QUERY
+          )
+      }
+  )
+  ResponseEntity<List<DduduCompletionResponse>> getWeeklyCompletion(
       Long loginId, Long userId, LocalDate date
   );
 
-  @Operation(summary = "월간 뚜두 조회")
+  @Operation(summary = "월간 뚜두 완료도 조회")
   @ApiResponse(
       responseCode = "200"
   )
-  ResponseEntity<List<TodoCompletionResponse>> getMonthlyCompletion(
+  ResponseEntity<List<DduduCompletionResponse>> getMonthlyCompletion(
       Long loginId, Long userId, YearMonth yearMonth
   );
 

--- a/src/test/java/com/ddudu/application/service/ddudu/CalculateWeeklyCompletionServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/ddudu/CalculateWeeklyCompletionServiceTest.java
@@ -26,9 +26,10 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
-//@Transactional
+@Transactional
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class CalculateWeeklyCompletionServiceTest {
 

--- a/src/test/java/com/ddudu/application/service/ddudu/CalculateWeeklyCompletionServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/ddudu/CalculateWeeklyCompletionServiceTest.java
@@ -1,0 +1,126 @@
+package com.ddudu.application.service.ddudu;
+
+import static com.ddudu.application.domain.goal.domain.enums.PrivacyType.PRIVATE;
+import static com.ddudu.application.domain.goal.domain.enums.PrivacyType.PUBLIC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+import com.ddudu.application.domain.ddudu.domain.Ddudu;
+import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
+import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
+import com.ddudu.application.port.out.auth.SignUpPort;
+import com.ddudu.application.port.out.ddudu.SaveDduduPort;
+import com.ddudu.application.port.out.goal.SaveGoalPort;
+import com.ddudu.fixture.DduduFixture;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.UserFixture;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.MissingResourceException;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+//@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class CalculateWeeklyCompletionServiceTest {
+
+  @Autowired
+  CalculateWeeklyCompletionService calculateWeeklyCompletionService;
+  @Autowired
+  SignUpPort signUpPort;
+  @Autowired
+  SaveGoalPort saveGoalPort;
+  @Autowired
+  SaveDduduPort saveDduduPort;
+
+  LocalDate today;
+  User user;
+  Goal privateGoal;
+  Goal publicGoal;
+  Ddudu privateDdudu;
+  Ddudu publicDdudu;
+
+  @BeforeEach
+  void setUp() {
+    today = LocalDate.now();
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    privateGoal = saveGoalPort.save(
+        GoalFixture.createRandomGoalWithUserAndPrivacyType(user, PRIVATE));
+    publicGoal = saveGoalPort.save(
+        GoalFixture.createRandomGoalWithUserAndPrivacyType(user, PUBLIC));
+    privateDdudu = saveDduduPort.save(DduduFixture.createRandomDduduWithGoal(privateGoal));
+    publicDdudu = saveDduduPort.save(DduduFixture.createRandomDduduWithGoal(publicGoal));
+  }
+
+  @Test
+  void 자신의_주간_할_일_달성률_조회를_성공한다() {
+    // given
+    int indexOfToday = today.getDayOfWeek()
+        .getValue() - 1;
+
+    // when
+    List<DduduCompletionResponse> responses = calculateWeeklyCompletionService.calculate(
+        user.getId(), user.getId(), today);
+
+    // then
+    assertThat(responses).hasSize(7);
+    assertThat(responses.get(indexOfToday))
+        .extracting("date", "totalCount", "uncompletedCount")
+        .containsExactly(today, 2, 2);
+  }
+
+  @Test
+  void 다른_사용자의_주간_할_일_달성률_조회를_성공한다() {
+    // given
+    User anotherUser = signUpPort.save(UserFixture.createRandomUserWithId());
+    int indexOfToday = today.getDayOfWeek()
+        .getValue() - 1;
+
+    // when
+    List<DduduCompletionResponse> responses = calculateWeeklyCompletionService.calculate(
+        anotherUser.getId(), user.getId(), today);
+
+    // then
+    assertThat(responses).hasSize(7);
+    assertThat(responses.get(indexOfToday)).extracting("date", "totalCount", "uncompletedCount")
+        .containsExactly(today, 1, 1);
+  }
+
+  @Test
+  void 로그인_아이디가_존재하지_않아_주간_할_일_달성률_조회를_실패한다() {
+    // given
+    Long invalidLoginId = UserFixture.getRandomId();
+
+    // when
+    ThrowingCallable findWeeklyCompletions = () -> calculateWeeklyCompletionService.calculate(
+        invalidLoginId, user.getId(), today);
+
+    // then
+    assertThatExceptionOfType(MissingResourceException.class).isThrownBy(findWeeklyCompletions)
+        .withMessage(DduduErrorCode.USER_NOT_EXISTING.getCodeName());
+  }
+
+  @Test
+  void 사용자_아이디가_존재하지_않아_주간_할_일_달성률_조회를_실패한다() {
+    // given
+    Long invalidUserId = UserFixture.getRandomId();
+    LocalDate date = LocalDate.now();
+
+    // when
+    ThrowingCallable findWeeklyCompletions = () -> calculateWeeklyCompletionService.calculate(
+        user.getId(), invalidUserId, date);
+
+    // then
+    assertThatExceptionOfType(MissingResourceException.class).isThrownBy(findWeeklyCompletions)
+        .withMessage(DduduErrorCode.USER_NOT_EXISTING.getCodeName());
+  }
+
+}

--- a/src/test/java/com/ddudu/old/todo/service/DduduServiceTest.java
+++ b/src/test/java/com/ddudu/old/todo/service/DduduServiceTest.java
@@ -8,23 +8,17 @@ import com.ddudu.application.domain.ddudu.domain.enums.DduduStatus;
 import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
 import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.domain.user.domain.User;
-import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.old.goal.domain.OldGoalRepository;
 import com.ddudu.old.like.domain.Like;
 import com.ddudu.old.like.domain.LikeRepository;
 import com.ddudu.old.todo.domain.OldTodoRepository;
 import com.ddudu.old.todo.dto.response.TodoResponse;
 import com.ddudu.old.user.domain.UserRepository;
-import com.ddudu.old.user.dto.request.FollowRequest;
 import com.ddudu.old.user.service.FollowingService;
 import com.ddudu.presentation.api.exception.DataNotFoundException;
 import com.ddudu.presentation.api.exception.ForbiddenException;
 import jakarta.persistence.EntityManager;
-import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.YearMonth;
-import java.util.List;
 import java.util.Optional;
 import net.datafaker.Faker;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -84,6 +78,52 @@ class DduduServiceTest {
         .word();
     goalName = faker.lorem()
         .word();
+  }
+
+  private Goal createGoal(String name, User user) {
+    Goal goal = Goal.builder()
+        .name(name)
+        .user(user)
+        .build();
+
+    return oldGoalRepository.save(goal);
+  }
+
+  private Ddudu createTodo(String name, Goal goal, User user) {
+    Ddudu ddudu = Ddudu.builder()
+        .name(name)
+        .goal(goal)
+        .user(user)
+        .build();
+
+    return oldTodoRepository.save(ddudu);
+  }
+
+  private User createUser() {
+    String email = faker.internet()
+        .emailAddress();
+    String password = faker.internet()
+        .password(8, 40, true, true, true);
+    String nickname = faker.oscarMovie()
+        .character();
+
+    User user = User.builder()
+        .build();
+
+    return userRepository.save(user);
+  }
+
+  private Like createLike(User user, Ddudu ddudu) {
+    Like like = Like.builder()
+        .user(user)
+        .ddudu(ddudu)
+        .build();
+    return likeRepository.save(like);
+  }
+
+  private void flushAndClearPersistence() {
+    entityManager.flush();
+    entityManager.clear();
   }
 
   @Nested
@@ -189,222 +229,6 @@ class DduduServiceTest {
   }
 
   @Nested
-  class 할_일_달성률_조회_테스트 {
-
-    @Test
-    void 자신의_주간_할_일_달성률_조회를_성공한다() {
-      // given
-      Goal goal1 = createGoal(goalName, user);
-      Goal goal2 = createGoal("book", user);
-      Ddudu ddudu1 = createTodo(name, goal1, user);
-      Ddudu ddudu2 = createTodo("JPA N+1 문제 해결", goal1, user);
-
-      LocalDate date = LocalDate.now();
-      LocalDate mondayDate = date.with(DayOfWeek.MONDAY);
-      DayOfWeek dayOfWeek = date.getDayOfWeek();
-      int dayIndex = dayOfWeek.getValue() - 1;
-
-      // when
-      List<DduduCompletionResponse> responses = todoService.findWeeklyCompletions(
-          user.getId(), user.getId(), mondayDate);
-
-      // then
-      assertThat(responses).hasSize(7);
-      assertThat(responses.get(dayIndex)).extracting("date", "totalCount", "uncompletedCount")
-          .containsExactly(date, 2, 2);
-    }
-
-    @Test
-    void 팔로워의_주간_할_일_달성률_조회를_성공한다() {
-      // given
-      Goal goal1 = createGoal(goalName, user);
-      Goal goal2 = createGoal("book", user);
-      Ddudu ddudu1 = createTodo(name, goal1, user);
-      Ddudu ddudu2 = createTodo("JPA N+1 문제 해결", goal1, user);
-
-      LocalDate date = LocalDate.now();
-      LocalDate mondayDate = date.with(DayOfWeek.MONDAY);
-      DayOfWeek dayOfWeek = date.getDayOfWeek();
-      int dayIndex = dayOfWeek.getValue() - 1;
-
-      FollowRequest request = new FollowRequest(user.getId());
-      followingService.create(loginUser.getId(), request);
-
-      // when
-      List<DduduCompletionResponse> responses = todoService.findWeeklyCompletions(
-          loginUser.getId(), user.getId(), mondayDate);
-
-      // then
-      assertThat(responses).hasSize(7);
-      assertThat(responses.get(dayIndex)).extracting("date", "totalCount", "uncompletedCount")
-          .containsExactly(date, 0, 0);
-    }
-
-    @Test
-    void 다른_사용자의_주간_할_일_달성률_조회를_성공한다() {
-      // given
-      Goal goal1 = createGoal(goalName, user);
-      Goal goal2 = createGoal("book", user);
-      Ddudu ddudu1 = createTodo(name, goal1, user);
-      Ddudu ddudu2 = createTodo("JPA N+1 문제 해결", goal1, user);
-
-      LocalDate date = LocalDate.now();
-      LocalDate mondayDate = date.with(DayOfWeek.MONDAY);
-      DayOfWeek dayOfWeek = date.getDayOfWeek();
-      int dayIndex = dayOfWeek.getValue() - 1;
-
-      // when
-      List<DduduCompletionResponse> responses = todoService.findWeeklyCompletions(
-          loginUser.getId(), user.getId(), mondayDate);
-
-      // then
-      assertThat(responses).hasSize(7);
-      assertThat(responses.get(dayIndex)).extracting("date", "totalCount", "uncompletedCount")
-          .containsExactly(date, 0, 0);
-    }
-
-    @Test
-    void 로그인_아이디가_존재하지_않아_주간_할_일_달성률_조회를_실패한다() {
-      // given
-      Long invalidLoginId = faker.random()
-          .nextLong(Long.MAX_VALUE);
-      LocalDate date = LocalDate.now();
-
-      // when
-      ThrowingCallable findWeeklyCompletions = () -> todoService.findWeeklyCompletions(
-          invalidLoginId, user.getId(), date);
-
-      // then
-      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(findWeeklyCompletions)
-          .withMessage(DduduErrorCode.LOGIN_USER_NOT_EXISTING.getMessage());
-    }
-
-    @Test
-    void 사용자_아이디가_존재하지_않아_주간_할_일_달성률_조회를_실패한다() {
-      // given
-      Long invalidUserId = faker.random()
-          .nextLong(Long.MAX_VALUE);
-      LocalDate date = LocalDate.now();
-
-      // when
-      ThrowingCallable findWeeklyCompletions = () -> todoService.findWeeklyCompletions(
-          loginUser.getId(), invalidUserId, date);
-
-      // then
-      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(findWeeklyCompletions)
-          .withMessage(DduduErrorCode.USER_NOT_EXISTING.getMessage());
-    }
-
-    @Test
-    void 자신의_월간_할_일_달성률_조회를_성공한다() {
-      // given
-      Goal goal1 = createGoal(goalName, user);
-      Goal goal2 = createGoal("book", user);
-      Ddudu ddudu1 = createTodo(name, goal1, user);
-      Ddudu ddudu2 = createTodo("JPA N+1 문제 해결", goal1, user);
-
-      LocalDate date = LocalDate.now();
-      YearMonth yearMonth = YearMonth.now();
-      int daysInMonth = yearMonth.lengthOfMonth();
-      int dayOfMonthIndex = date.getDayOfMonth() - 1;
-
-      // when
-      List<DduduCompletionResponse> responses = todoService.findMonthlyCompletions(
-          user.getId(), user.getId(), yearMonth);
-
-      // then
-      assertThat(responses).hasSize(daysInMonth);
-      assertThat(responses.get(dayOfMonthIndex)).extracting(
-              "date", "totalCount", "uncompletedCount")
-          .containsExactly(date, 2, 2);
-    }
-
-    @Test
-    void 팔로워의_월간_할_일_달성률_조회를_성공한다() {
-      // given
-      Goal goal1 = createGoal(goalName, user);
-      Goal goal2 = createGoal("book", user);
-      Ddudu ddudu1 = createTodo(name, goal1, user);
-      Ddudu ddudu2 = createTodo("JPA N+1 문제 해결", goal1, user);
-
-      LocalDate date = LocalDate.now();
-      YearMonth yearMonth = YearMonth.now();
-      int daysInMonth = yearMonth.lengthOfMonth();
-      int dayOfMonthIndex = date.getDayOfMonth() - 1;
-
-      FollowRequest request = new FollowRequest(user.getId());
-      followingService.create(loginUser.getId(), request);
-
-      // when
-      List<DduduCompletionResponse> responses = todoService.findMonthlyCompletions(
-          loginUser.getId(), user.getId(), yearMonth);
-
-      // then
-      assertThat(responses).hasSize(daysInMonth);
-      assertThat(responses.get(dayOfMonthIndex)).extracting(
-              "date", "totalCount", "uncompletedCount")
-          .containsExactly(date, 0, 0);
-    }
-
-    @Test
-    void 다른_사용자의_월간_할_일_달성률_조회를_성공한다() {
-      // given
-      Goal goal1 = createGoal(goalName, user);
-      Goal goal2 = createGoal("book", user);
-      Ddudu ddudu1 = createTodo(name, goal1, user);
-      Ddudu ddudu2 = createTodo("JPA N+1 문제 해결", goal1, user);
-
-      LocalDate date = LocalDate.now();
-      YearMonth yearMonth = YearMonth.now();
-      int daysInMonth = yearMonth.lengthOfMonth();
-      int dayOfMonthIndex = date.getDayOfMonth() - 1;
-
-      // when
-      List<DduduCompletionResponse> responses = todoService.findMonthlyCompletions(
-          loginUser.getId(), user.getId(), yearMonth);
-
-      // then
-      assertThat(responses).hasSize(daysInMonth);
-      assertThat(responses.get(dayOfMonthIndex)).extracting(
-              "date", "totalCount", "uncompletedCount")
-          .containsExactly(date, 0, 0);
-    }
-
-    @Test
-    void 로그인_아이디가_존재하지_않아_월간_할_일_달성률_조회를_실패한다() {
-      // given
-      Long invalidLoginId = faker.random()
-          .nextLong(Long.MAX_VALUE);
-      YearMonth yearMonth = YearMonth.now();
-
-      // when
-      ThrowingCallable findMonthlyCompletions = () -> todoService.findMonthlyCompletions(
-          invalidLoginId, user.getId(), yearMonth);
-
-      // then
-      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(findMonthlyCompletions)
-          .withMessage(DduduErrorCode.LOGIN_USER_NOT_EXISTING.getMessage());
-    }
-
-    @Test
-    void 사용자_아이디가_존재하지_않아_월간_할_일_달성률_조회를_실패한다() {
-      // given
-      Long invalidUserId = faker.random()
-          .nextLong(Long.MAX_VALUE);
-      YearMonth yearMonth = YearMonth.now();
-
-      // when
-      ThrowingCallable findMonthlyCompletions = () -> todoService.findMonthlyCompletions(
-          loginUser.getId(), invalidUserId, yearMonth);
-
-      // then
-      assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(findMonthlyCompletions)
-          .withMessage(DduduErrorCode.USER_NOT_EXISTING.getMessage());
-    }
-
-  }
-
-  @Nested
   class 할_일_삭제_테스트 {
 
     @Test
@@ -444,52 +268,6 @@ class DduduServiceTest {
           .withMessage(DduduErrorCode.INVALID_AUTHORITY.getMessage());
     }
 
-  }
-
-  private Goal createGoal(String name, User user) {
-    Goal goal = Goal.builder()
-        .name(name)
-        .user(user)
-        .build();
-
-    return oldGoalRepository.save(goal);
-  }
-
-  private Ddudu createTodo(String name, Goal goal, User user) {
-    Ddudu ddudu = Ddudu.builder()
-        .name(name)
-        .goal(goal)
-        .user(user)
-        .build();
-
-    return oldTodoRepository.save(ddudu);
-  }
-
-  private User createUser() {
-    String email = faker.internet()
-        .emailAddress();
-    String password = faker.internet()
-        .password(8, 40, true, true, true);
-    String nickname = faker.oscarMovie()
-        .character();
-
-    User user = User.builder()
-        .build();
-
-    return userRepository.save(user);
-  }
-
-  private Like createLike(User user, Ddudu ddudu) {
-    Like like = Like.builder()
-        .user(user)
-        .ddudu(ddudu)
-        .build();
-    return likeRepository.save(like);
-  }
-
-  private void flushAndClearPersistence() {
-    entityManager.flush();
-    entityManager.clear();
   }
 
 }

--- a/src/test/java/com/ddudu/old/todo/service/DduduServiceTest.java
+++ b/src/test/java/com/ddudu/old/todo/service/DduduServiceTest.java
@@ -8,11 +8,11 @@ import com.ddudu.application.domain.ddudu.domain.enums.DduduStatus;
 import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
 import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.old.goal.domain.OldGoalRepository;
 import com.ddudu.old.like.domain.Like;
 import com.ddudu.old.like.domain.LikeRepository;
 import com.ddudu.old.todo.domain.OldTodoRepository;
-import com.ddudu.old.todo.dto.response.TodoCompletionResponse;
 import com.ddudu.old.todo.dto.response.TodoResponse;
 import com.ddudu.old.user.domain.UserRepository;
 import com.ddudu.old.user.dto.request.FollowRequest;
@@ -205,7 +205,7 @@ class DduduServiceTest {
       int dayIndex = dayOfWeek.getValue() - 1;
 
       // when
-      List<TodoCompletionResponse> responses = todoService.findWeeklyCompletions(
+      List<DduduCompletionResponse> responses = todoService.findWeeklyCompletions(
           user.getId(), user.getId(), mondayDate);
 
       // then
@@ -231,7 +231,7 @@ class DduduServiceTest {
       followingService.create(loginUser.getId(), request);
 
       // when
-      List<TodoCompletionResponse> responses = todoService.findWeeklyCompletions(
+      List<DduduCompletionResponse> responses = todoService.findWeeklyCompletions(
           loginUser.getId(), user.getId(), mondayDate);
 
       // then
@@ -254,7 +254,7 @@ class DduduServiceTest {
       int dayIndex = dayOfWeek.getValue() - 1;
 
       // when
-      List<TodoCompletionResponse> responses = todoService.findWeeklyCompletions(
+      List<DduduCompletionResponse> responses = todoService.findWeeklyCompletions(
           loginUser.getId(), user.getId(), mondayDate);
 
       // then
@@ -309,7 +309,7 @@ class DduduServiceTest {
       int dayOfMonthIndex = date.getDayOfMonth() - 1;
 
       // when
-      List<TodoCompletionResponse> responses = todoService.findMonthlyCompletions(
+      List<DduduCompletionResponse> responses = todoService.findMonthlyCompletions(
           user.getId(), user.getId(), yearMonth);
 
       // then
@@ -336,7 +336,7 @@ class DduduServiceTest {
       followingService.create(loginUser.getId(), request);
 
       // when
-      List<TodoCompletionResponse> responses = todoService.findMonthlyCompletions(
+      List<DduduCompletionResponse> responses = todoService.findMonthlyCompletions(
           loginUser.getId(), user.getId(), yearMonth);
 
       // then
@@ -360,7 +360,7 @@ class DduduServiceTest {
       int dayOfMonthIndex = date.getDayOfMonth() - 1;
 
       // when
-      List<TodoCompletionResponse> responses = todoService.findMonthlyCompletions(
+      List<DduduCompletionResponse> responses = todoService.findMonthlyCompletions(
           loginUser.getId(), user.getId(), yearMonth);
 
       // then


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #206 

일단, 기존 코드(old) 부분만 마이그레이션 해봤습니다! 
(프론트에서 메인 페이지 작업 중이라 일단 API 열고, 추후 리팩토링해도 될 것 같아서요!)


## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 기존 Querydsl로 날아가던 쿼리 거의 유사하게 썼습니다! 
  - 데이터 타입 변경 `LocalDateTime(start_at)` → `LocalDate (scheduled_on)`
  - join이 where절 보다 먼저 실행되서, join 부분에서 먼저 거를 수 있는 부분은 거를 수 있도록 변경했습니다! (userId 확인 / 목표 타입 확인)
  - 아래와 같은 식으로 쿼리 날아갑니당~
<img width="529" alt="스크린샷 2024-07-08 17 44 38" src="https://github.com/DDu-Du-DDu-Du/back-end/assets/80446430/80c84596-514d-46b1-ae97-948e8d80f147">
