### PR TITLE
타임 테이블 뚜두 데이터 포맷 변경

### DIFF
--- a/src/main/java/com/ddudu/application/domain/ddudu/domain/Ddudu.java
+++ b/src/main/java/com/ddudu/application/domain/ddudu/domain/Ddudu.java
@@ -1,6 +1,8 @@
 package com.ddudu.application.domain.ddudu.domain;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 import com.ddudu.application.domain.ddudu.domain.enums.DduduStatus;
 import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
@@ -138,6 +140,18 @@ public class Ddudu {
         .build();
   }
 
+  public boolean hasStartTime() {
+    return nonNull(beginAt);
+  }
+
+  public int getBeginHour() {
+    if (isNull(beginAt)) {
+      return -1;
+    }
+
+    return beginAt.getHour();
+  }
+
   private DduduBuilder getFullBuilder() {
     return Ddudu.builder()
         .id(this.id)
@@ -168,7 +182,7 @@ public class Ddudu {
   }
 
   private void validatePeriod(LocalTime beginAt, LocalTime endAt) {
-    if (Objects.isNull(beginAt) || Objects.isNull(endAt)) {
+    if (isNull(beginAt) || isNull(endAt)) {
       return;
     }
 

--- a/src/main/java/com/ddudu/application/domain/ddudu/domain/DduduList.java
+++ b/src/main/java/com/ddudu/application/domain/ddudu/domain/DduduList.java
@@ -1,7 +1,8 @@
 package com.ddudu.application.domain.ddudu.domain;
 
+import static com.google.gson.internal.$Gson$Preconditions.checkArgument;
+import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.groupingBy;
-import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 
 import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
@@ -17,8 +18,7 @@ public class DduduList {
   private final List<Ddudu> ddudus;
 
   public DduduList(List<Ddudu> ddudus) {
-    assertNotNull(ddudus, "DduduList 생성 시 ddudus는 null일 수 없습니다.");
-
+    checkArgument(nonNull(ddudus));
     this.ddudus = ddudus;
   }
 

--- a/src/main/java/com/ddudu/application/domain/ddudu/domain/DduduList.java
+++ b/src/main/java/com/ddudu/application/domain/ddudu/domain/DduduList.java
@@ -1,0 +1,51 @@
+package com.ddudu.application.domain.ddudu.domain;
+
+import static java.util.stream.Collectors.groupingBy;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+
+import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
+import com.ddudu.application.dto.ddudu.response.BasicDduduResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class DduduList {
+
+  private final List<Ddudu> ddudus;
+
+  public DduduList(List<Ddudu> ddudus) {
+    assertNotNull(ddudus, "DduduList 생성 시 ddudus는 null일 수 없습니다.");
+
+    this.ddudus = ddudus;
+  }
+
+  public List<GoalGroupedDdudus> getDdudusWithGoal(List<Goal> goals) {
+    Map<Long, Goal> goalsById = mapGoalById(goals);
+    Map<Long, List<Ddudu>> ddudusByGoal = mapDdudusByGoal();
+
+    return goalsById.entrySet()
+        .stream()
+        .map(entry -> GoalGroupedDdudus.of(
+            entry.getValue(),
+            ddudusByGoal.getOrDefault(entry.getKey(), new ArrayList<>())
+                .stream()
+                .map(BasicDduduResponse::from)
+                .toList()
+        ))
+        .toList();
+  }
+
+  private Map<Long, Goal> mapGoalById(List<Goal> goals) {
+    return goals.stream()
+        .collect(Collectors.toMap(Goal::getId, Function.identity()));
+  }
+
+  private Map<Long, List<Ddudu>> mapDdudusByGoal() {
+    return ddudus.stream()
+        .collect(groupingBy(Ddudu::getGoalId));
+  }
+
+}

--- a/src/main/java/com/ddudu/application/domain/ddudu/domain/Timetable.java
+++ b/src/main/java/com/ddudu/application/domain/ddudu/domain/Timetable.java
@@ -7,7 +7,6 @@ import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.dto.ddudu.BasicDduduWithGoalIdAndTime;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.TimeGroupedDdudus;
-import com.ddudu.application.dto.ddudu.response.BasicDduduResponse;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +17,7 @@ import java.util.stream.Collectors;
 public class Timetable {
 
   private final Map<Integer, List<Ddudu>> timetable;
-  private final List<Ddudu> unassignedDdudus;
+  private final DduduList unassignedDdudus;
 
   public Timetable(List<Ddudu> ddudus) {
     assertNotNull(ddudus, "Timetable 생성 시 ddudus는 null일 수 없습니다.");
@@ -29,7 +28,7 @@ public class Timetable {
     List<Ddudu> assignedDdudus = split.getOrDefault(true, new ArrayList<>());
     timetable = assignedDdudus.stream()
         .collect(groupingBy(Ddudu::getBeginHour));
-    unassignedDdudus = split.getOrDefault(false, new ArrayList<>());
+    unassignedDdudus = new DduduList(split.getOrDefault(false, new ArrayList<>()));
   }
 
   private static Map<Long, Goal> mapGoalById(List<Goal> goals) {
@@ -53,24 +52,7 @@ public class Timetable {
   }
 
   public List<GoalGroupedDdudus> getUnassignedDdudusWithGoal(List<Goal> goals) {
-    Map<Long, Goal> goalsById = mapGoalById(goals);
-    Map<Long, List<Ddudu>> ddudusByGoal = mapUnssignedDdudusByGoal();
-
-    return goalsById.entrySet()
-        .stream()
-        .map(entry -> GoalGroupedDdudus.of(
-            entry.getValue(),
-            ddudusByGoal.getOrDefault(entry.getKey(), new ArrayList<>())
-                .stream()
-                .map(BasicDduduResponse::from)
-                .toList()
-        ))
-        .toList();
-  }
-
-  private Map<Long, List<Ddudu>> mapUnssignedDdudusByGoal() {
-    return unassignedDdudus.stream()
-        .collect(groupingBy(Ddudu::getGoalId));
+    return unassignedDdudus.getDdudusWithGoal(goals);
   }
 
 }

--- a/src/main/java/com/ddudu/application/domain/ddudu/domain/Timetable.java
+++ b/src/main/java/com/ddudu/application/domain/ddudu/domain/Timetable.java
@@ -12,8 +12,6 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class Timetable {
 
@@ -30,11 +28,6 @@ public class Timetable {
     timetable = assignedDdudus.stream()
         .collect(groupingBy(Ddudu::getBeginHour));
     unassignedDdudus = new DduduList(split.getOrDefault(false, new ArrayList<>()));
-  }
-
-  private static Map<Long, Goal> mapGoalById(List<Goal> goals) {
-    return goals.stream()
-        .collect(Collectors.toMap(Goal::getId, Function.identity()));
   }
 
   public List<TimeGroupedDdudus> getTimeGroupedDdudus() {

--- a/src/main/java/com/ddudu/application/domain/ddudu/domain/Timetable.java
+++ b/src/main/java/com/ddudu/application/domain/ddudu/domain/Timetable.java
@@ -1,0 +1,76 @@
+package com.ddudu.application.domain.ddudu.domain;
+
+import static java.util.stream.Collectors.groupingBy;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+
+import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.dto.ddudu.BasicDduduWithGoalIdAndTime;
+import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
+import com.ddudu.application.dto.ddudu.TimeGroupedDdudus;
+import com.ddudu.application.dto.ddudu.response.BasicDduduResponse;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class Timetable {
+
+  private final Map<Integer, List<Ddudu>> timetable;
+  private final List<Ddudu> unassignedDdudus;
+
+  public Timetable(List<Ddudu> ddudus) {
+    assertNotNull(ddudus, "Timetable 생성 시 ddudus는 null일 수 없습니다.");
+
+    Map<Boolean, List<Ddudu>> split = ddudus.stream()
+        .collect(groupingBy((Ddudu::hasStartTime)));
+
+    List<Ddudu> assignedDdudus = split.getOrDefault(true, new ArrayList<>());
+    timetable = assignedDdudus.stream()
+        .collect(groupingBy(Ddudu::getBeginHour));
+    unassignedDdudus = split.getOrDefault(false, new ArrayList<>());
+  }
+
+  private static Map<Long, Goal> mapGoalById(List<Goal> goals) {
+    return goals.stream()
+        .collect(Collectors.toMap(Goal::getId, Function.identity()));
+  }
+
+  public List<TimeGroupedDdudus> getTimeGroupedDdudus() {
+    return timetable.entrySet()
+        .stream()
+        .map(entry ->
+            TimeGroupedDdudus.of(
+                LocalTime.of(entry.getKey(), 0),
+                entry.getValue()
+                    .stream()
+                    .map(BasicDduduWithGoalIdAndTime::of)
+                    .toList()
+            )
+        )
+        .toList();
+  }
+
+  public List<GoalGroupedDdudus> getUnassignedDdudusWithGoal(List<Goal> goals) {
+    Map<Long, Goal> goalsById = mapGoalById(goals);
+    Map<Long, List<Ddudu>> ddudusByGoal = mapUnssignedDdudusByGoal();
+
+    return goalsById.entrySet()
+        .stream()
+        .map(entry -> GoalGroupedDdudus.of(
+            entry.getValue(),
+            ddudusByGoal.getOrDefault(entry.getKey(), new ArrayList<>())
+                .stream()
+                .map(BasicDduduResponse::from)
+                .toList()
+        ))
+        .toList();
+  }
+
+  private Map<Long, List<Ddudu>> mapUnssignedDdudusByGoal() {
+    return unassignedDdudus.stream()
+        .collect(groupingBy(Ddudu::getGoalId));
+  }
+
+}

--- a/src/main/java/com/ddudu/application/domain/ddudu/domain/Timetable.java
+++ b/src/main/java/com/ddudu/application/domain/ddudu/domain/Timetable.java
@@ -1,7 +1,8 @@
 package com.ddudu.application.domain.ddudu.domain;
 
+import static com.google.gson.internal.$Gson$Preconditions.checkArgument;
+import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.groupingBy;
-import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 
 import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.dto.ddudu.BasicDduduWithGoalIdAndTime;
@@ -20,7 +21,7 @@ public class Timetable {
   private final DduduList unassignedDdudus;
 
   public Timetable(List<Ddudu> ddudus) {
-    assertNotNull(ddudus, "Timetable 생성 시 ddudus는 null일 수 없습니다.");
+    checkArgument(nonNull(ddudus));
 
     Map<Boolean, List<Ddudu>> split = ddudus.stream()
         .collect(groupingBy((Ddudu::hasStartTime)));

--- a/src/main/java/com/ddudu/application/domain/goal/domain/enums/PrivacyType.java
+++ b/src/main/java/com/ddudu/application/domain/goal/domain/enums/PrivacyType.java
@@ -3,12 +3,20 @@ package com.ddudu.application.domain.goal.domain.enums;
 import static java.util.Objects.isNull;
 
 import com.ddudu.application.domain.goal.exception.GoalErrorCode;
+import com.ddudu.application.domain.user.domain.enums.Relationship;
 import java.util.Arrays;
+import java.util.List;
 
 public enum PrivacyType {
-  PRIVATE,
-  FOLLOWER,
-  PUBLIC;
+  PRIVATE(Relationship.ME),
+  FOLLOWER(Relationship.ME, Relationship.FOLLOWER),
+  PUBLIC(Relationship.ME, Relationship.FOLLOWER, Relationship.NONE);
+
+  private final List<Relationship> accessibleRelationships;
+
+  PrivacyType(Relationship... accessibleRelationships) {
+    this.accessibleRelationships = Arrays.asList(accessibleRelationships);
+  }
 
   public static PrivacyType from(String value) {
     if (isNull(value)) {
@@ -21,5 +29,15 @@ public enum PrivacyType {
         .findFirst()
         .orElseThrow(
             () -> new IllegalArgumentException(GoalErrorCode.INVALID_PRIVACY_TYPE.getCodeName()));
+  }
+
+  public static List<PrivacyType> getAccessibleTypesIn(Relationship relationship) {
+    return Arrays.stream(PrivacyType.values())
+        .filter(type -> type.isAccessible(relationship))
+        .toList();
+  }
+
+  private boolean isAccessible(Relationship relationship) {
+    return accessibleRelationships.contains(relationship);
   }
 }

--- a/src/main/java/com/ddudu/application/domain/user/domain/enums/Relationship.java
+++ b/src/main/java/com/ddudu/application/domain/user/domain/enums/Relationship.java
@@ -1,0 +1,43 @@
+package com.ddudu.application.domain.user.domain.enums;
+
+import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
+import com.ddudu.application.domain.user.domain.User;
+import java.util.Arrays;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public enum Relationship {
+  ME(List.of(PrivacyType.PRIVATE, PrivacyType.FOLLOWER, PrivacyType.PUBLIC)) {
+    boolean isSatisfied(User user, User targetUser) {
+      return user.equals(targetUser);
+    }
+  },
+  FOLLOWER(List.of(PrivacyType.FOLLOWER, PrivacyType.PUBLIC)) {
+    boolean isSatisfied(User user, User targetUser) {
+      // TODO : 팔로우 기능 구현 후 수정
+      return false;
+    }
+  },
+  NONE(List.of(PrivacyType.PUBLIC)) {
+    boolean isSatisfied(User user, User targetUser) {
+      return true;
+    }
+  };
+
+  private final List<PrivacyType> accessiblePrivacyTypes;
+
+  Relationship(List<PrivacyType> accessiblePrivacyTypes) {
+    this.accessiblePrivacyTypes = accessiblePrivacyTypes;
+  }
+
+  public static Relationship getRelationship(User user, User targetUser) {
+    return Arrays.stream(Relationship.values())
+        .filter(relationship -> relationship.isSatisfied(user, targetUser))
+        .findFirst()
+        .orElse(NONE);
+  }
+
+  abstract boolean isSatisfied(User user, User targetUser);
+
+}

--- a/src/main/java/com/ddudu/application/domain/user/domain/enums/Relationship.java
+++ b/src/main/java/com/ddudu/application/domain/user/domain/enums/Relationship.java
@@ -1,34 +1,20 @@
 package com.ddudu.application.domain.user.domain.enums;
 
-import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.user.domain.User;
 import java.util.Arrays;
-import java.util.List;
+import java.util.function.BiPredicate;
 import lombok.Getter;
 
 @Getter
 public enum Relationship {
-  ME(List.of(PrivacyType.PRIVATE, PrivacyType.FOLLOWER, PrivacyType.PUBLIC)) {
-    boolean isSatisfied(User user, User targetUser) {
-      return user.equals(targetUser);
-    }
-  },
-  FOLLOWER(List.of(PrivacyType.FOLLOWER, PrivacyType.PUBLIC)) {
-    boolean isSatisfied(User user, User targetUser) {
-      // TODO : 팔로우 기능 구현 후 수정
-      return false;
-    }
-  },
-  NONE(List.of(PrivacyType.PUBLIC)) {
-    boolean isSatisfied(User user, User targetUser) {
-      return true;
-    }
-  };
+  ME((user, targetUser) -> user.equals(targetUser)),
+  FOLLOWER((user, targetUser) -> false),
+  NONE((user, targetUser) -> true);
 
-  private final List<PrivacyType> accessiblePrivacyTypes;
+  private final BiPredicate<User, User> filter;
 
-  Relationship(List<PrivacyType> accessiblePrivacyTypes) {
-    this.accessiblePrivacyTypes = accessiblePrivacyTypes;
+  Relationship(BiPredicate<User, User> filter) {
+    this.filter = filter;
   }
 
   public static Relationship getRelationship(User user, User targetUser) {
@@ -38,6 +24,8 @@ public enum Relationship {
         .orElse(NONE);
   }
 
-  abstract boolean isSatisfied(User user, User targetUser);
+  public boolean isSatisfied(User user, User targetUser) {
+    return filter.test(user, targetUser);
+  }
 
 }

--- a/src/main/java/com/ddudu/application/dto/ddudu/BasicDduduWithGoalIdAndTime.java
+++ b/src/main/java/com/ddudu/application/dto/ddudu/BasicDduduWithGoalIdAndTime.java
@@ -2,22 +2,28 @@ package com.ddudu.application.dto.ddudu;
 
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.ddudu.domain.enums.DduduStatus;
+import java.time.LocalTime;
 import lombok.Builder;
 
 @Builder
-public record BasicDduduWithGoalId(
+public record BasicDduduWithGoalIdAndTime(
     Long id,
     String name,
     DduduStatus status,
-    Long goalId
+    Long goalId,
+    LocalTime beginAt,
+    LocalTime endAt
 ) {
 
-  public static BasicDduduWithGoalId of(Ddudu ddudu) {
-    return BasicDduduWithGoalId.builder()
+  public static BasicDduduWithGoalIdAndTime of(Ddudu ddudu) {
+
+    return BasicDduduWithGoalIdAndTime.builder()
         .id(ddudu.getId())
         .name(ddudu.getName())
         .status(ddudu.getStatus())
         .goalId(ddudu.getGoalId())
+        .beginAt(ddudu.getBeginAt())
+        .endAt(ddudu.getEndAt())
         .build();
   }
 

--- a/src/main/java/com/ddudu/application/dto/ddudu/TimeGroupedDdudus.java
+++ b/src/main/java/com/ddudu/application/dto/ddudu/TimeGroupedDdudus.java
@@ -11,10 +11,10 @@ public record TimeGroupedDdudus(
     @Schema(type = "string", pattern = "HH:mm", example = "14:00")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     LocalTime beginAt,
-    List<BasicDduduWithGoalId> ddudus
+    List<BasicDduduWithGoalIdAndTime> ddudus
 ) {
 
-  public static TimeGroupedDdudus of(LocalTime beginAt, List<BasicDduduWithGoalId> ddudus) {
+  public static TimeGroupedDdudus of(LocalTime beginAt, List<BasicDduduWithGoalIdAndTime> ddudus) {
     return TimeGroupedDdudus.builder()
         .beginAt(beginAt)
         .ddudus(ddudus)

--- a/src/main/java/com/ddudu/application/port/out/ddudu/DduduLoaderPort.java
+++ b/src/main/java/com/ddudu/application/port/out/ddudu/DduduLoaderPort.java
@@ -2,10 +2,10 @@ package com.ddudu.application.port.out.ddudu;
 
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
-import com.ddudu.application.dto.ddudu.TimeGroupedDdudus;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -16,20 +16,14 @@ public interface DduduLoaderPort {
 
   Optional<Ddudu> getOptionalDdudu(Long id);
 
-  List<Ddudu> getDailyDdudusOfUserUnderGoals(LocalDate date, User user, List<Goal> goals);
-
   List<GoalGroupedDdudus> getDailyDdudusOfUserGroupingByGoal(
       LocalDate date, User loginUser, List<Goal> goals
   );
 
-  List<GoalGroupedDdudus> getUnassignedDdudusOfUserGroupingByGoal(
-      LocalDate date, User user, List<Goal> goals
-  );
-
-  List<TimeGroupedDdudus> getDailyDdudusOfUserGroupingByTime(
-      LocalDate date, User user, List<Goal> goals
-  );
-
   List<Ddudu> getRepeatedDdudus(RepeatDdudu repeatDdudu);
+
+  List<Ddudu> getDailyDdudus(
+      LocalDate date, User user, List<PrivacyType> accessiblePrivacyTypes
+  );
 
 }

--- a/src/main/java/com/ddudu/application/port/out/ddudu/DduduLoaderPort.java
+++ b/src/main/java/com/ddudu/application/port/out/ddudu/DduduLoaderPort.java
@@ -1,11 +1,9 @@
 package com.ddudu.application.port.out.ddudu;
 
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
-import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 import com.ddudu.application.domain.user.domain.User;
-import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -15,10 +13,6 @@ public interface DduduLoaderPort {
   Ddudu getDduduOrElseThrow(Long id, String message);
 
   Optional<Ddudu> getOptionalDdudu(Long id);
-
-  List<GoalGroupedDdudus> getDailyDdudusOfUserGroupingByGoal(
-      LocalDate date, User loginUser, List<Goal> goals
-  );
 
   List<Ddudu> getRepeatedDdudus(RepeatDdudu repeatDdudu);
 

--- a/src/main/java/com/ddudu/application/port/out/goal/GoalLoaderPort.java
+++ b/src/main/java/com/ddudu/application/port/out/goal/GoalLoaderPort.java
@@ -12,9 +12,9 @@ public interface GoalLoaderPort {
 
   Optional<Goal> getOptionalGoal(Long id);
 
-  List<Goal> findAllByUser(User user);
+  List<Goal> findAllByUserAndPrivacyTypes(User user);
 
-  List<Goal> findAllByUser(User user, List<PrivacyType> privacyTypes);
+  List<Goal> findAllByUserAndPrivacyTypes(User user, List<PrivacyType> privacyTypes);
 
   List<Goal> findAccessibleGoals(User user, boolean isFollower);
 

--- a/src/main/java/com/ddudu/application/service/ddudu/GetDailyDdudusByGoalService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/GetDailyDdudusByGoalService.java
@@ -32,8 +32,8 @@ public class GetDailyDdudusByGoalService implements GetDailyDdudusByGoalUseCase 
     User user = userLoaderPort.getUserOrElseThrow(
         userId, DduduErrorCode.USER_NOT_EXISTING.getCodeName());
 
-    List<PrivacyType> accessiblePrivacyTypes = Relationship.getRelationship(loginUser, user)
-        .getAccessiblePrivacyTypes();
+    Relationship relationship = Relationship.getRelationship(loginUser, user);
+    List<PrivacyType> accessiblePrivacyTypes = PrivacyType.getAccessibleTypesIn(relationship);
     DduduList ddudus = new DduduList(
         dduduLoaderPort.getDailyDdudus(date, user, accessiblePrivacyTypes));
 

--- a/src/main/java/com/ddudu/application/service/ddudu/GetDailyDdudusByGoalService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/GetDailyDdudusByGoalService.java
@@ -30,7 +30,7 @@ public class GetDailyDdudusByGoalService implements GetDailyDdudusByGoalUseCase 
         loginId, DduduErrorCode.LOGIN_USER_NOT_EXISTING.getCodeName());
 
     if (Objects.equals(loginId, userId)) {
-      List<Goal> goals = goalLoaderPort.findAllByUser(loginUser);
+      List<Goal> goals = goalLoaderPort.findAllByUserAndPrivacyTypes(loginUser);
       return dduduLoaderPort.getDailyDdudusOfUserGroupingByGoal(date, loginUser, goals);
     }
 

--- a/src/main/java/com/ddudu/application/service/ddudu/GetTimetableService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/GetTimetableService.java
@@ -1,9 +1,11 @@
 package com.ddudu.application.service.ddudu;
 
 import com.ddudu.application.annotation.UseCase;
+import com.ddudu.application.domain.ddudu.domain.Timetable;
 import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
-import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.domain.user.domain.enums.Relationship;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.TimeGroupedDdudus;
 import com.ddudu.application.dto.ddudu.response.TimetableResponse;
@@ -13,7 +15,6 @@ import com.ddudu.application.port.out.goal.GoalLoaderPort;
 import com.ddudu.application.port.out.user.UserLoaderPort;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,43 +24,28 @@ import org.springframework.transaction.annotation.Transactional;
 public class GetTimetableService implements
     GetTimetableUseCase {
 
-  private final GoalLoaderPort goalLoaderPort;
   private final DduduLoaderPort dduduLoaderPort;
   private final UserLoaderPort userLoaderPort;
+  private final GoalLoaderPort goalLoaderPort;
 
   @Override
   public TimetableResponse get(Long loginId, Long userId, LocalDate date) {
     User loginUser = userLoaderPort.getUserOrElseThrow(
         loginId, DduduErrorCode.LOGIN_USER_NOT_EXISTING.getCodeName());
-
-    if (Objects.equals(loginId, userId)) {
-      List<Goal> goals = goalLoaderPort.findAllByUser(loginUser);
-
-      List<TimeGroupedDdudus> ddudusWithGoalIdByTime = dduduLoaderPort.getDailyDdudusOfUserGroupingByTime(
-          date, loginUser, goals);
-      List<GoalGroupedDdudus> unassignedDdudus = dduduLoaderPort.getUnassignedDdudusOfUserGroupingByGoal(
-          date, loginUser, goals);
-
-      return TimetableResponse.of(ddudusWithGoalIdByTime, unassignedDdudus);
-    }
-
     User user = userLoaderPort.getUserOrElseThrow(
         userId, DduduErrorCode.USER_NOT_EXISTING.getCodeName());
 
-    boolean isFollower = isFollowerOf(loginUser, user);
-    List<Goal> accessibleGoals = goalLoaderPort.findAccessibleGoals(user, isFollower);
+    List<PrivacyType> accessiblePrivacyTypes = Relationship.getRelationship(loginUser, user)
+        .getAccessiblePrivacyTypes();
+    Timetable timetable = new Timetable(
+        dduduLoaderPort.getDailyDdudus(date, user, accessiblePrivacyTypes));
 
-    List<TimeGroupedDdudus> ddudusWithGoalIdByTime = dduduLoaderPort.getDailyDdudusOfUserGroupingByTime(
-        date, user, accessibleGoals);
-    List<GoalGroupedDdudus> unassignedDdudus = dduduLoaderPort.getUnassignedDdudusOfUserGroupingByGoal(
-        date, user, accessibleGoals);
+    List<TimeGroupedDdudus> assignedDdudus = timetable.getTimeGroupedDdudus();
+    List<GoalGroupedDdudus> unassignedDdudus = timetable.getUnassignedDdudusWithGoal(
+        goalLoaderPort.findAllByUserAndPrivacyTypes(user, accessiblePrivacyTypes)
+    );
 
-    return TimetableResponse.of(ddudusWithGoalIdByTime, unassignedDdudus);
-  }
-
-  private boolean isFollowerOf(User user, User targetUser) {
-    // TODO: 팔로잉 기능 추가 시 팔로잉 상태 확인
-    return false;
+    return TimetableResponse.of(assignedDdudus, unassignedDdudus);
   }
 
 }

--- a/src/main/java/com/ddudu/application/service/ddudu/GetTimetableService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/GetTimetableService.java
@@ -35,8 +35,8 @@ public class GetTimetableService implements
     User user = userLoaderPort.getUserOrElseThrow(
         userId, DduduErrorCode.USER_NOT_EXISTING.getCodeName());
 
-    List<PrivacyType> accessiblePrivacyTypes = Relationship.getRelationship(loginUser, user)
-        .getAccessiblePrivacyTypes();
+    Relationship relationship = Relationship.getRelationship(loginUser, user);
+    List<PrivacyType> accessiblePrivacyTypes = PrivacyType.getAccessibleTypesIn(relationship);
     Timetable timetable = new Timetable(
         dduduLoaderPort.getDailyDdudus(date, user, accessiblePrivacyTypes));
 

--- a/src/main/java/com/ddudu/application/service/goal/RetrieveAllGoalsService.java
+++ b/src/main/java/com/ddudu/application/service/goal/RetrieveAllGoalsService.java
@@ -24,7 +24,7 @@ public class RetrieveAllGoalsService implements RetrieveAllGoalsUseCase {
     User user = userLoaderPort.getUserOrElseThrow(
         userId, GoalErrorCode.USER_NOT_EXISTING.getCodeName());
 
-    return goalLoaderPort.findAllByUser(user)
+    return goalLoaderPort.findAllByUserAndPrivacyTypes(user)
         .stream()
         .map(BasicGoalWithStatusResponse::from)
         .toList();

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
@@ -1,11 +1,9 @@
 package com.ddudu.infrastructure.persistence.adapter;
 
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
-import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 import com.ddudu.application.domain.user.domain.User;
-import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
 import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.application.dto.scroll.request.ScrollRequest;
@@ -20,7 +18,6 @@ import com.ddudu.application.port.out.ddudu.SaveDduduPort;
 import com.ddudu.infrastructure.annotation.DrivenAdapter;
 import com.ddudu.infrastructure.persistence.dto.DduduCursorDto;
 import com.ddudu.infrastructure.persistence.entity.DduduEntity;
-import com.ddudu.infrastructure.persistence.entity.GoalEntity;
 import com.ddudu.infrastructure.persistence.entity.RepeatDduduEntity;
 import com.ddudu.infrastructure.persistence.entity.UserEntity;
 import com.ddudu.infrastructure.persistence.repository.ddudu.DduduRepository;
@@ -53,18 +50,6 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
   public Optional<Ddudu> getOptionalDdudu(Long id) {
     return dduduRepository.findById(id)
         .map(DduduEntity::toDomain);
-  }
-
-  @Override
-  public List<GoalGroupedDdudus> getDailyDdudusOfUserGroupingByGoal(
-      LocalDate date, User loginUser, List<Goal> goals
-  ) {
-    List<GoalEntity> goalEntities = goals.stream()
-        .map(GoalEntity::from)
-        .toList();
-
-    return dduduRepository.findDailyDdudusByUserGroupByGoal(
-        date, UserEntity.from(loginUser), goalEntities);
   }
 
   @Override

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
@@ -7,7 +7,6 @@ import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
-import com.ddudu.application.dto.ddudu.TimeGroupedDdudus;
 import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.application.dto.scroll.request.ScrollRequest;
 import com.ddudu.application.dto.scroll.response.ScrollResponse;
@@ -57,20 +56,6 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
   }
 
   @Override
-  public List<Ddudu> getDailyDdudusOfUserUnderGoals(LocalDate date, User user, List<Goal> goals) {
-    return dduduRepository.findDdudusByDateAndUserAndGoals(
-            date,
-            UserEntity.from(user),
-            goals.stream()
-                .map(GoalEntity::from)
-                .toList()
-        )
-        .stream()
-        .map(DduduEntity::toDomain)
-        .toList();
-  }
-
-  @Override
   public List<GoalGroupedDdudus> getDailyDdudusOfUserGroupingByGoal(
       LocalDate date, User loginUser, List<Goal> goals
   ) {
@@ -83,32 +68,19 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
   }
 
   @Override
-  public List<GoalGroupedDdudus> getUnassignedDdudusOfUserGroupingByGoal(
-      LocalDate date, User user, List<Goal> goals
-  ) {
-    return dduduRepository.findUnassignedDdudusByUserGroupByGoal(
-        date, UserEntity.from(user), goals.stream()
-            .map(GoalEntity::from)
-            .toList()
-    );
-  }
-
-  @Override
-  public List<TimeGroupedDdudus> getDailyDdudusOfUserGroupingByTime(
-      LocalDate date, User user, List<Goal> goals
-  ) {
-    return dduduRepository.findDailyDdudusByUserGroupByTime(
-        date,
-        UserEntity.from(user),
-        goals.stream()
-            .map(GoalEntity::from)
-            .toList()
-    );
-  }
-
-  @Override
   public List<Ddudu> getRepeatedDdudus(RepeatDdudu repeatDdudu) {
     return dduduRepository.findAllByRepeatDdudu(RepeatDduduEntity.from(repeatDdudu))
+        .stream()
+        .map(DduduEntity::toDomain)
+        .toList();
+  }
+
+  @Override
+  public List<Ddudu> getDailyDdudus(
+      LocalDate date, User user, List<PrivacyType> accessiblePrivacyTypes
+  ) {
+    return dduduRepository.findAllByDateAndUserAndPrivacyTypes(
+            date, UserEntity.from(user), accessiblePrivacyTypes)
         .stream()
         .map(DduduEntity::toDomain)
         .toList();

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/GoalPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/GoalPersistenceAdapter.java
@@ -63,7 +63,7 @@ public class GoalPersistenceAdapter implements SaveGoalPort, GoalLoaderPort, Upd
   }
 
   @Override
-  public List<Goal> findAllByUser(User user) {
+  public List<Goal> findAllByUserAndPrivacyTypes(User user) {
     return goalRepository.findAllByUser(UserEntity.from(user))
         .stream()
         .map(GoalEntity::toDomain)
@@ -71,7 +71,7 @@ public class GoalPersistenceAdapter implements SaveGoalPort, GoalLoaderPort, Upd
   }
 
   @Override
-  public List<Goal> findAllByUser(User user, List<PrivacyType> privacyTypes) {
+  public List<Goal> findAllByUserAndPrivacyTypes(User user, List<PrivacyType> privacyTypes) {
     return goalRepository.findAllByUserAndPrivacyTypes(
             UserEntity.from(user),
             privacyTypes

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
@@ -1,8 +1,6 @@
 package com.ddudu.infrastructure.persistence.repository.ddudu;
 
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
-import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
-import com.ddudu.application.dto.ddudu.TimeGroupedDdudus;
 import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import com.ddudu.application.dto.scroll.request.ScrollRequest;
 import com.ddudu.infrastructure.persistence.dto.DduduCursorDto;
@@ -19,28 +17,12 @@ public interface DduduQueryRepository {
       LocalDateTime startDate, LocalDateTime endDate, UserEntity user
   );
 
-  List<DduduEntity> findDdudusByDateAndUserAndGoals(
-      LocalDate date, UserEntity user, List<GoalEntity> goals
-  );
-
   List<DduduCompletionResponse> findDdudusCompletion(
       LocalDate startDate, LocalDate endDate, UserEntity user,
       List<PrivacyType> privacyTypes
   );
 
   void deleteAllByGoal(GoalEntity goal);
-
-  List<GoalGroupedDdudus> findDailyDdudusByUserGroupByGoal(
-      LocalDate date, UserEntity user, List<GoalEntity> goals
-  );
-
-  List<GoalGroupedDdudus> findUnassignedDdudusByUserGroupByGoal(
-      LocalDate date, UserEntity user, List<GoalEntity> goals
-  );
-
-  List<TimeGroupedDdudus> findDailyDdudusByUserGroupByTime(
-      LocalDate date, UserEntity user, List<GoalEntity> goals
-  );
 
   List<DduduCursorDto> findScrollDdudus(
       Long userId, ScrollRequest request, String query, Boolean isMine, Boolean isFollower

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
@@ -46,4 +46,8 @@ public interface DduduQueryRepository {
       Long userId, ScrollRequest request, String query, Boolean isMine, Boolean isFollower
   );
 
+  List<DduduEntity> findAllByDateAndUserAndPrivacyTypes(
+      LocalDate date, UserEntity from, List<PrivacyType> accessiblePrivacyTypes
+  );
+
 }

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepositoryImpl.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepositoryImpl.java
@@ -5,7 +5,7 @@ import static java.util.Objects.isNull;
 
 import com.ddudu.application.domain.ddudu.domain.enums.DduduStatus;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
-import com.ddudu.application.dto.ddudu.BasicDduduWithGoalId;
+import com.ddudu.application.dto.ddudu.BasicDduduWithGoalIdAndTime;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.SimpleDduduSearchDto;
 import com.ddudu.application.dto.ddudu.TimeGroupedDdudus;
@@ -232,7 +232,7 @@ public class DduduQueryRepositoryImpl implements DduduQueryRepository {
     return times.stream()
         .map(time -> TimeGroupedDdudus.of(time, ddudusByTime.getOrDefault(time, List.of())
             .stream()
-            .map(ddudu -> BasicDduduWithGoalId.of(ddudu.toDomain()))
+            .map(ddudu -> BasicDduduWithGoalIdAndTime.of(ddudu.toDomain()))
             .toList()
         ))
         .toList();

--- a/src/test/java/com/ddudu/application/service/auth/SocialLoginServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/auth/SocialLoginServiceTest.java
@@ -116,7 +116,7 @@ class SocialLoginServiceTest {
     // then
     User user = userLoaderPort.loadSocialUser(authProvider)
         .get();
-    List<Goal> goals = goalLoaderPort.findAllByUser(user);
+    List<Goal> goals = goalLoaderPort.findAllByUserAndPrivacyTypes(user);
 
     assertThat(goals).hasSize(3);
   }

--- a/src/test/java/com/ddudu/application/service/ddudu/GetDailyDdudusByTimeServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/ddudu/GetDailyDdudusByTimeServiceTest.java
@@ -8,7 +8,7 @@ import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
 import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.user.domain.User;
-import com.ddudu.application.dto.ddudu.BasicDduduWithGoalId;
+import com.ddudu.application.dto.ddudu.BasicDduduWithGoalIdAndTime;
 import com.ddudu.application.dto.ddudu.response.TimetableResponse;
 import com.ddudu.application.port.out.auth.SignUpPort;
 import com.ddudu.application.port.out.ddudu.SaveDduduPort;
@@ -76,7 +76,7 @@ class GetDailyDdudusByTimeServiceTest {
     LocalTime earliestTime = response.timetable()
         .get(0)
         .beginAt();
-    BasicDduduWithGoalId firstOfEarliestTime = response.timetable()
+    BasicDduduWithGoalIdAndTime firstOfEarliestTime = response.timetable()
         .get(0)
         .ddudus()
         .get(0);
@@ -140,7 +140,7 @@ class GetDailyDdudusByTimeServiceTest {
     // then
     int countOfTime = response.timetable()
         .size();
-    BasicDduduWithGoalId firstOfEarliestTime = response.timetable()
+    BasicDduduWithGoalIdAndTime firstOfEarliestTime = response.timetable()
         .get(0)
         .ddudus()
         .get(0);


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #213 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 타임테이블 응답 시 `beginAt`과 `endAt`도 함께 응답하도록 변경 
- 유저 사이 관계를 확인하기 위한 `Relationship` enum 추가
- Persistence 레이어에서 처리하는 비즈니스 로직을 비즈니스 레이어로 이동
- `Timetable`, `DduduList` 컬렉션 객체 생성

## 💬 코멘트
저번에 이야기 나눴던 [DB 연산 vs 애플리케이션에서 처리](https://velog.io/@uijin/DB-%EC%A7%91%EA%B3%84%EC%97%B0%EC%82%B0-vs-%EC%95%A0%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98%EC%97%90%EC%84%9C-%EC%B2%98%EB%A6%AC)에 대해 고민해 봤는데, 
Persistence 레이어에서는 데이터를 필터링/최소화해서 가져오는 것에만 집중하고,
 애플리케이션에서 비즈니스 로직을 처리해야 추후 비즈니스 로직 변경에 대한 유연성도 늘어나고, 쿼리에 대한 재사용성도 늘어날 것 같더라구요! 
그래서 일단, 지금 PR 올린 부분만 수정을 해봤습니다:)

그리고 계속 이야기했던, `User` 사이 관계와 `PrivacyType`은 Relationship이라는 enum을 만들어봤는데요! 일단 로직이 Relationship 안에 있긴 하지만, 나중에 팔로우 기능이 구현되면 DB에 접근해야 Relationship을 알 수 있어서.. `UserRelationshipService` 또는 `UserRelationshipFacade` 를 만들거나 해야 될 것 같아요!