### PR TITLE
월별 뚜두 완료도 조회

### DIFF
--- a/src/main/java/com/ddudu/application/dto/ddudu/BasicDduduWithGoalIdAndTime.java
+++ b/src/main/java/com/ddudu/application/dto/ddudu/BasicDduduWithGoalIdAndTime.java
@@ -2,6 +2,8 @@ package com.ddudu.application.dto.ddudu;
 
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.ddudu.domain.enums.DduduStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalTime;
 import lombok.Builder;
 
@@ -11,7 +13,11 @@ public record BasicDduduWithGoalIdAndTime(
     String name,
     DduduStatus status,
     Long goalId,
+    @Schema(type = "string", pattern = "HH:mm", example = "14:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     LocalTime beginAt,
+    @Schema(type = "string", pattern = "HH:mm", example = "14:30")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     LocalTime endAt
 ) {
 

--- a/src/main/java/com/ddudu/application/port/in/ddudu/CalculateCompletionUseCase.java
+++ b/src/main/java/com/ddudu/application/port/in/ddudu/CalculateCompletionUseCase.java
@@ -4,8 +4,8 @@ import com.ddudu.application.dto.ddudu.response.DduduCompletionResponse;
 import java.time.LocalDate;
 import java.util.List;
 
-public interface CalculateWeeklyCompletionUseCase {
+public interface CalculateCompletionUseCase {
 
-  List<DduduCompletionResponse> calculate(Long loginId, Long userId, LocalDate date);
+  List<DduduCompletionResponse> calculate(Long loginId, Long userId, LocalDate from, LocalDate to);
 
 }

--- a/src/main/java/com/ddudu/presentation/api/doc/DduduControllerDoc.java
+++ b/src/main/java/com/ddudu/presentation/api/doc/DduduControllerDoc.java
@@ -131,7 +131,25 @@ public interface DduduControllerDoc {
 
   @Operation(summary = "월간 뚜두 완료도 조회")
   @ApiResponse(
-      responseCode = "200"
+      responseCode = "200",
+      content = @Content(
+          mediaType = MediaType.APPLICATION_JSON_VALUE,
+          array = @ArraySchema(schema = @Schema(implementation = DduduCompletionResponse.class))
+      )
+  )
+  @Parameters(
+      {
+          @Parameter(
+              name = "userId",
+              description = "조회할 뚜두의 사용자 식별자 (기본값: 로그인한 사용자)",
+              in = ParameterIn.QUERY
+          ),
+          @Parameter(
+              name = "date",
+              description = "조회할 달 (기본값: 이번 달)",
+              in = ParameterIn.QUERY
+          )
+      }
   )
   ResponseEntity<List<DduduCompletionResponse>> getMonthlyCompletion(
       Long loginId, Long userId, YearMonth yearMonth

--- a/src/test/java/com/ddudu/application/service/ddudu/CalculateCompletionServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/ddudu/CalculateCompletionServiceTest.java
@@ -31,10 +31,10 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @Transactional
 @DisplayNameGeneration(ReplaceUnderscores.class)
-class CalculateWeeklyCompletionServiceTest {
+class CalculateCompletionServiceTest {
 
   @Autowired
-  CalculateWeeklyCompletionService calculateWeeklyCompletionService;
+  CalculateCompletionService calculateCompletionService;
   @Autowired
   SignUpPort signUpPort;
   @Autowired
@@ -43,6 +43,7 @@ class CalculateWeeklyCompletionServiceTest {
   SaveDduduPort saveDduduPort;
 
   LocalDate today;
+  LocalDate afterOneWeek;
   User user;
   Goal privateGoal;
   Goal publicGoal;
@@ -52,6 +53,7 @@ class CalculateWeeklyCompletionServiceTest {
   @BeforeEach
   void setUp() {
     today = LocalDate.now();
+    afterOneWeek = today.plusDays(7);
     user = signUpPort.save(UserFixture.createRandomUserWithId());
     privateGoal = saveGoalPort.save(
         GoalFixture.createRandomGoalWithUserAndPrivacyType(user, PRIVATE));
@@ -62,14 +64,13 @@ class CalculateWeeklyCompletionServiceTest {
   }
 
   @Test
-  void 자신의_주간_할_일_달성률_조회를_성공한다() {
+  void 특정_날짜_사이의_자신의_할_일_달성률_조회를_성공한다() {
     // given
-    int indexOfToday = today.getDayOfWeek()
-        .getValue() - 1;
+    int indexOfToday = 0;
 
     // when
-    List<DduduCompletionResponse> responses = calculateWeeklyCompletionService.calculate(
-        user.getId(), user.getId(), today);
+    List<DduduCompletionResponse> responses = calculateCompletionService.calculate(
+        user.getId(), user.getId(), today, afterOneWeek);
 
     // then
     assertThat(responses).hasSize(7);
@@ -79,15 +80,14 @@ class CalculateWeeklyCompletionServiceTest {
   }
 
   @Test
-  void 다른_사용자의_주간_할_일_달성률_조회를_성공한다() {
+  void 특정_날짜_사이의_다른_사용자의_할_일_달성률_조회를_성공한다() {
     // given
     User anotherUser = signUpPort.save(UserFixture.createRandomUserWithId());
-    int indexOfToday = today.getDayOfWeek()
-        .getValue() - 1;
+    int indexOfToday = 0;
 
     // when
-    List<DduduCompletionResponse> responses = calculateWeeklyCompletionService.calculate(
-        anotherUser.getId(), user.getId(), today);
+    List<DduduCompletionResponse> responses = calculateCompletionService.calculate(
+        anotherUser.getId(), user.getId(), today, afterOneWeek);
 
     // then
     assertThat(responses).hasSize(7);
@@ -101,8 +101,8 @@ class CalculateWeeklyCompletionServiceTest {
     Long invalidLoginId = UserFixture.getRandomId();
 
     // when
-    ThrowingCallable findWeeklyCompletions = () -> calculateWeeklyCompletionService.calculate(
-        invalidLoginId, user.getId(), today);
+    ThrowingCallable findWeeklyCompletions = () -> calculateCompletionService.calculate(
+        invalidLoginId, user.getId(), today, afterOneWeek);
 
     // then
     assertThatExceptionOfType(MissingResourceException.class).isThrownBy(findWeeklyCompletions)
@@ -113,11 +113,10 @@ class CalculateWeeklyCompletionServiceTest {
   void 사용자_아이디가_존재하지_않아_주간_할_일_달성률_조회를_실패한다() {
     // given
     Long invalidUserId = UserFixture.getRandomId();
-    LocalDate date = LocalDate.now();
 
     // when
-    ThrowingCallable findWeeklyCompletions = () -> calculateWeeklyCompletionService.calculate(
-        user.getId(), invalidUserId, date);
+    ThrowingCallable findWeeklyCompletions = () -> calculateCompletionService.calculate(
+        user.getId(), invalidUserId, today, afterOneWeek);
 
     // then
     assertThatExceptionOfType(MissingResourceException.class).isThrownBy(findWeeklyCompletions)


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #212 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
주별 완료도 조회와 겹치는 부분이 많아서, 그냥 **주별 완료도 조회 서비스를 특정 구간사이의 완료도 조회로 변경해서 범용적으로 사용**했습니다! 
그래서 서비스 로직은 똑같고, 대신 파라미터 초기화하는 부분을 컨트롤러로 이동했습니다!😉 (컨트롤러에서 서비스 호출을 위해 파라미터를 정제하거나 기본값을 주는 건 괜찮다고 생각했는데, 괜찮을까요?)

전에 이야기 나눴던 것처럼, 요부분 인재님이 작업 하시고 있는 걸로 아는데 일단 PR 올리고 추후 리팩토링 하면 좋을 것 같습니다!
+) 타임테이블 조회 시 데이터 포맷이 잘못 올라가서.. 요 PR에 조심스레 같이 올려봅니다ㅎㅎ..