### PR TITLE
반복 뚜두 수정 기능 구현

### DIFF
--- a/src/main/java/com/ddudu/application/domain/repeat_ddudu/domain/RepeatDdudu.java
+++ b/src/main/java/com/ddudu/application/domain/repeat_ddudu/domain/RepeatDdudu.java
@@ -98,4 +98,21 @@ public final class RepeatDdudu {
     );
   }
 
+  public RepeatDdudu update(
+      String name, RepeatType repeatType, RepeatPatternDto repeatPatternDto, LocalDate startDate,
+      LocalDate endDate, LocalTime beginAt, LocalTime endAt
+  ) {
+    return RepeatDdudu.builder()
+        .id(id)
+        .goalId(goalId)
+        .name(name)
+        .repeatType(repeatType)
+        .repeatPatternDto(repeatPatternDto)
+        .startDate(startDate)
+        .endDate(endDate)
+        .beginAt(beginAt)
+        .endAt(endAt)
+        .build();
+  }
+
 }

--- a/src/main/java/com/ddudu/application/domain/repeat_ddudu/exception/RepeatDduduErrorCode.java
+++ b/src/main/java/com/ddudu/application/domain/repeat_ddudu/exception/RepeatDduduErrorCode.java
@@ -20,7 +20,8 @@ public enum RepeatDduduErrorCode implements ErrorCode {
   NULL_OR_EMPTY_REPEAT_DATES_OF_MONTH(6011, "반복되는 날짜가 없습니다."),
   NULL_OR_EMPTY_REPEAT_DAYS_OF_WEEK(6012, "반복되는 요일이 없습니다."),
   NULL_LAST_DAY(6013, "마지막 날 반복 여부는 필수값입니다."),
-  INVALID_GOAL(6014, "유효하지 않은 목표입니다.");
+  INVALID_GOAL(6014, "유효하지 않은 목표입니다."),
+  REPEAT_DDUDU_NOT_EXIST(6015, "해당 아이디를 가진 반복 뚜두가 존재하지 않습니다.");
 
   private final int code;
   private final String message;

--- a/src/main/java/com/ddudu/application/domain/repeat_ddudu/service/RepeatDduduDomainService.java
+++ b/src/main/java/com/ddudu/application/domain/repeat_ddudu/service/RepeatDduduDomainService.java
@@ -6,6 +6,9 @@ import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 import com.ddudu.application.domain.repeat_ddudu.domain.enums.RepeatType;
 import com.ddudu.application.dto.repeat_ddudu.RepeatPatternDto;
 import com.ddudu.application.dto.repeat_ddudu.request.CreateRepeatDduduRequest;
+import com.ddudu.application.dto.repeat_ddudu.request.UpdateRepeatDduduRequest;
+import java.time.LocalDateTime;
+import java.time.chrono.ChronoLocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
@@ -40,6 +43,43 @@ public class RepeatDduduDomainService {
             .build()
         )
         .toList();
+  }
+
+  public List<Ddudu> createRepeatedDdudusAfter(
+      Long userId, RepeatDdudu repeatDdudu, LocalDateTime now
+  ) {
+    return repeatDdudu.getRepeatDates()
+        .stream()
+        .filter(date -> date.isAfter(ChronoLocalDate.from(now)))
+        .map(date -> Ddudu.builder()
+            .name(repeatDdudu.getName())
+            .goalId(repeatDdudu.getGoalId())
+            .userId(userId)
+            .repeatDduduId(repeatDdudu.getId())
+            .scheduledOn(date)
+            .beginAt(repeatDdudu.getBeginAt())
+            .endAt(repeatDdudu.getEndAt())
+            .build()
+        )
+        .toList();
+  }
+
+  public RepeatDdudu update(RepeatDdudu repeatDdudu, UpdateRepeatDduduRequest request) {
+    RepeatPatternDto repeatPatternDto = new RepeatPatternDto(
+        request.repeatDaysOfWeek(),
+        request.repeatDaysOfMonth(),
+        request.lastDayOfMonth()
+    );
+
+    return repeatDdudu.update(
+        request.name(),
+        RepeatType.from(request.repeatType()),
+        repeatPatternDto,
+        request.startDate(),
+        request.endDate(),
+        request.beginAt(),
+        request.endAt()
+    );
   }
 
 }

--- a/src/main/java/com/ddudu/application/dto/goal/request/ChangeGoalStatusRequest.java
+++ b/src/main/java/com/ddudu/application/dto/goal/request/ChangeGoalStatusRequest.java
@@ -1,8 +1,15 @@
 package com.ddudu.application.dto.goal.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "목표 상태 변경 요청")
 public record ChangeGoalStatusRequest(
+    @Schema(
+        name = "status",
+        description = "목표 상태",
+        example = "IN_PROGRESS | DONE"
+    )
     @NotNull(message = "3005 NULL_STATUS")
     String status
 ) {

--- a/src/main/java/com/ddudu/application/dto/repeat_ddudu/request/UpdateRepeatDduduRequest.java
+++ b/src/main/java/com/ddudu/application/dto/repeat_ddudu/request/UpdateRepeatDduduRequest.java
@@ -1,0 +1,79 @@
+package com.ddudu.application.dto.repeat_ddudu.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Schema(description = "반복 뚜두 수정 요청")
+public record UpdateRepeatDduduRequest(
+    @Schema(
+        name = "name",
+        description = "반복 뚜두명",
+        example = "물 한 컵 마시기"
+    )
+    @NotNull(message = "6001 BLANK_NAME")
+    @Size(max = 50, message = "6006 EXCESSIVE_NAME_LENGTH")
+    String name,
+    @Schema(
+        name = "repeatType",
+        description = "반복 유형 (소문자 가능)",
+        example = "DAILY | WEEKLY | MONTHLY"
+    )
+    @NotBlank(message = "6003 NULL_REPEAT_TYPE")
+    String repeatType,
+    @Schema(
+        name = "repeatDaysOfWeek",
+        description = "반복 요일 (WEEKLY일 때만)",
+        nullable = true,
+        example = "[\"월\", \"화\"]"
+    )
+    List<String> repeatDaysOfWeek,
+    @Schema(
+        name = "repeatDaysOfMonth",
+        description = "반복 날짜 (MONTHLY 때만)",
+        nullable = true,
+        example = "[1, 15]"
+    )
+    List<Integer> repeatDaysOfMonth,
+    @Schema(
+        name = "lastDayOfMonth",
+        description = "마지막 날 반복 여부 (MONTHLY 때만)",
+        nullable = true,
+        example = "true"
+    )
+    Boolean lastDayOfMonth,
+    @Schema(
+        name = "startDate",
+        description = "반복 시작 날짜",
+        example = "2024-06-10"
+    )
+    @NotNull(message = "6004 NULL_START_DATE")
+    LocalDate startDate,
+    @Schema(
+        name = "endDate",
+        description = "반복 종료 날짜",
+        example = "2024-12-31"
+    )
+    @NotNull(message = "6005 NULL_END_DATE")
+    LocalDate endDate,
+    @Schema(
+        name = "beginAt",
+        description = "시작 시간",
+        nullable = true,
+        example = "07:00:00"
+    )
+    LocalTime beginAt,
+    @Schema(
+        name = "endAt",
+        description = "종료 시간",
+        nullable = true,
+        example = "08:00:00"
+    )
+    LocalTime endAt
+) {
+
+}

--- a/src/main/java/com/ddudu/application/port/in/repeat_ddudu/UpdateRepeatDduduUseCase.java
+++ b/src/main/java/com/ddudu/application/port/in/repeat_ddudu/UpdateRepeatDduduUseCase.java
@@ -1,0 +1,9 @@
+package com.ddudu.application.port.in.repeat_ddudu;
+
+import com.ddudu.application.dto.repeat_ddudu.request.UpdateRepeatDduduRequest;
+
+public interface UpdateRepeatDduduUseCase {
+
+  Long update(Long loginId, Long id, UpdateRepeatDduduRequest request);
+
+}

--- a/src/main/java/com/ddudu/application/port/out/ddudu/DeleteDduduPort.java
+++ b/src/main/java/com/ddudu/application/port/out/ddudu/DeleteDduduPort.java
@@ -1,9 +1,12 @@
 package com.ddudu.application.port.out.ddudu;
 
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
+import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 
 public interface DeleteDduduPort {
 
   void delete(Ddudu ddudu);
+
+  void deleteAllByRepeatDdudu(RepeatDdudu repeatDdudu);
 
 }

--- a/src/main/java/com/ddudu/application/port/out/repeat_ddudu/RepeatDduduLoaderPort.java
+++ b/src/main/java/com/ddudu/application/port/out/repeat_ddudu/RepeatDduduLoaderPort.java
@@ -11,4 +11,6 @@ public interface RepeatDduduLoaderPort {
 
   List<RepeatDdudu> getAllByGoal(Goal goal);
 
+  RepeatDdudu getOrElseThrow(Long id, String message);
+
 }

--- a/src/main/java/com/ddudu/application/port/out/repeat_ddudu/UpdateRepeatDduduPort.java
+++ b/src/main/java/com/ddudu/application/port/out/repeat_ddudu/UpdateRepeatDduduPort.java
@@ -1,0 +1,9 @@
+package com.ddudu.application.port.out.repeat_ddudu;
+
+import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
+
+public interface UpdateRepeatDduduPort {
+
+  RepeatDdudu update(RepeatDdudu repeatDdudu);
+
+}

--- a/src/main/java/com/ddudu/application/service/repeat_ddudu/UpdateRepeatDduduService.java
+++ b/src/main/java/com/ddudu/application/service/repeat_ddudu/UpdateRepeatDduduService.java
@@ -11,6 +11,7 @@ import com.ddudu.application.port.out.ddudu.DeleteDduduPort;
 import com.ddudu.application.port.out.ddudu.SaveDduduPort;
 import com.ddudu.application.port.out.goal.GoalLoaderPort;
 import com.ddudu.application.port.out.repeat_ddudu.RepeatDduduLoaderPort;
+import com.ddudu.application.port.out.repeat_ddudu.UpdateRepeatDduduPort;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,7 @@ public class UpdateRepeatDduduService implements UpdateRepeatDduduUseCase {
 
   private final RepeatDduduDomainService repeatDduduDomainService;
   private final RepeatDduduLoaderPort repeatDduduLoaderPort;
+  private final UpdateRepeatDduduPort updateRepeatDduduPort;
   private final DeleteDduduPort deleteDduduPort;
   private final GoalLoaderPort goalLoaderPort;
   private final SaveDduduPort saveDduduPort;
@@ -35,7 +37,8 @@ public class UpdateRepeatDduduService implements UpdateRepeatDduduUseCase {
 
     goal.validateGoalCreator(loginId);
 
-    repeatDduduDomainService.update(repeatDdudu, request);
+    repeatDdudu = updateRepeatDduduPort.update(
+        repeatDduduDomainService.update(repeatDdudu, request));
 
     deleteDduduPort.deleteAllByRepeatDdudu(repeatDdudu);
     saveDduduPort.saveAll(

--- a/src/main/java/com/ddudu/application/service/repeat_ddudu/UpdateRepeatDduduService.java
+++ b/src/main/java/com/ddudu/application/service/repeat_ddudu/UpdateRepeatDduduService.java
@@ -1,0 +1,49 @@
+package com.ddudu.application.service.repeat_ddudu;
+
+import com.ddudu.application.annotation.UseCase;
+import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
+import com.ddudu.application.domain.repeat_ddudu.exception.RepeatDduduErrorCode;
+import com.ddudu.application.domain.repeat_ddudu.service.RepeatDduduDomainService;
+import com.ddudu.application.dto.repeat_ddudu.request.UpdateRepeatDduduRequest;
+import com.ddudu.application.port.in.repeat_ddudu.UpdateRepeatDduduUseCase;
+import com.ddudu.application.port.out.ddudu.DeleteDduduPort;
+import com.ddudu.application.port.out.ddudu.SaveDduduPort;
+import com.ddudu.application.port.out.goal.GoalLoaderPort;
+import com.ddudu.application.port.out.repeat_ddudu.RepeatDduduLoaderPort;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class UpdateRepeatDduduService implements UpdateRepeatDduduUseCase {
+
+  private final RepeatDduduDomainService repeatDduduDomainService;
+  private final RepeatDduduLoaderPort repeatDduduLoaderPort;
+  private final DeleteDduduPort deleteDduduPort;
+  private final GoalLoaderPort goalLoaderPort;
+  private final SaveDduduPort saveDduduPort;
+
+  @Override
+  public Long update(Long loginId, Long id, UpdateRepeatDduduRequest request) {
+    RepeatDdudu repeatDdudu = repeatDduduLoaderPort.getOrElseThrow(
+        id, RepeatDduduErrorCode.REPEAT_DDUDU_NOT_EXIST.getCodeName());
+    Goal goal = goalLoaderPort.getGoalOrElseThrow(
+        repeatDdudu.getGoalId(), RepeatDduduErrorCode.INVALID_GOAL.getCodeName());
+
+    goal.validateGoalCreator(loginId);
+
+    repeatDduduDomainService.update(repeatDdudu, request);
+
+    deleteDduduPort.deleteAllByRepeatDdudu(repeatDdudu);
+    saveDduduPort.saveAll(
+        repeatDduduDomainService.createRepeatedDdudusAfter(
+            loginId, repeatDdudu, LocalDateTime.now())
+    );
+
+    return repeatDdudu.getId();
+  }
+
+}

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/DduduPersistenceAdapter.java
@@ -114,6 +114,11 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
     dduduRepository.delete(DduduEntity.from(ddudu));
   }
 
+  @Override
+  public void deleteAllByRepeatDdudu(RepeatDdudu repeatDdudu) {
+    dduduRepository.deleteAllByRepeatDdudu(RepeatDduduEntity.from(repeatDdudu));
+  }
+
   private ScrollResponse<SimpleDduduSearchDto> getScrollResponse(
       List<DduduCursorDto> ddudusWithCursor, int size
   ) {

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/RepeatDduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/RepeatDduduPersistenceAdapter.java
@@ -9,6 +9,7 @@ import com.ddudu.infrastructure.persistence.entity.GoalEntity;
 import com.ddudu.infrastructure.persistence.entity.RepeatDduduEntity;
 import com.ddudu.infrastructure.persistence.repository.repeat_ddudu.RepeatDduduRepository;
 import java.util.List;
+import java.util.MissingResourceException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
@@ -37,6 +38,17 @@ public class RepeatDduduPersistenceAdapter implements SaveRepeatDduduPort, Repea
         .stream()
         .map(RepeatDduduEntity::toDomain)
         .toList();
+  }
+
+  @Override
+  public RepeatDdudu getOrElseThrow(Long id, String message) {
+    return repeatDduduRepository.findById(id)
+        .orElseThrow(() -> new MissingResourceException(
+            message,
+            RepeatDdudu.class.getName(),
+            id.toString()
+        ))
+        .toDomain();
   }
 
 }

--- a/src/main/java/com/ddudu/infrastructure/persistence/adapter/RepeatDduduPersistenceAdapter.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/adapter/RepeatDduduPersistenceAdapter.java
@@ -4,10 +4,12 @@ import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 import com.ddudu.application.port.out.repeat_ddudu.RepeatDduduLoaderPort;
 import com.ddudu.application.port.out.repeat_ddudu.SaveRepeatDduduPort;
+import com.ddudu.application.port.out.repeat_ddudu.UpdateRepeatDduduPort;
 import com.ddudu.infrastructure.annotation.DrivenAdapter;
 import com.ddudu.infrastructure.persistence.entity.GoalEntity;
 import com.ddudu.infrastructure.persistence.entity.RepeatDduduEntity;
 import com.ddudu.infrastructure.persistence.repository.repeat_ddudu.RepeatDduduRepository;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.MissingResourceException;
 import java.util.Optional;
@@ -15,7 +17,8 @@ import lombok.RequiredArgsConstructor;
 
 @DrivenAdapter
 @RequiredArgsConstructor
-public class RepeatDduduPersistenceAdapter implements SaveRepeatDduduPort, RepeatDduduLoaderPort {
+public class RepeatDduduPersistenceAdapter implements SaveRepeatDduduPort, RepeatDduduLoaderPort,
+    UpdateRepeatDduduPort {
 
   private final RepeatDduduRepository repeatDduduRepository;
 
@@ -49,6 +52,16 @@ public class RepeatDduduPersistenceAdapter implements SaveRepeatDduduPort, Repea
             id.toString()
         ))
         .toDomain();
+  }
+
+  @Override
+  public RepeatDdudu update(RepeatDdudu repeatDdudu) {
+    RepeatDduduEntity repeatDduduEntity = repeatDduduRepository.findById(repeatDdudu.getId())
+        .orElseThrow(EntityNotFoundException::new);
+
+    repeatDduduEntity.update(repeatDdudu);
+
+    return repeatDduduEntity.toDomain();
   }
 
 }

--- a/src/main/java/com/ddudu/infrastructure/persistence/entity/RepeatDduduEntity.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/entity/RepeatDduduEntity.java
@@ -124,4 +124,14 @@ public class RepeatDduduEntity extends BaseEntity {
         .build();
   }
 
+  public void update(RepeatDdudu repeatDdudu) {
+    this.name = repeatDdudu.getName();
+    this.repeatType = repeatDdudu.getRepeatType();
+    this.repeatInfo = repeatDdudu.getRepeatPattern();
+    this.startDate = repeatDdudu.getStartDate();
+    this.endDate = repeatDdudu.getEndDate();
+    this.beginAt = repeatDdudu.getBeginAt();
+    this.endAt = repeatDdudu.getEndAt();
+  }
+
 }

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepository.java
@@ -6,6 +6,7 @@ import com.ddudu.application.dto.scroll.request.ScrollRequest;
 import com.ddudu.infrastructure.persistence.dto.DduduCursorDto;
 import com.ddudu.infrastructure.persistence.entity.DduduEntity;
 import com.ddudu.infrastructure.persistence.entity.GoalEntity;
+import com.ddudu.infrastructure.persistence.entity.RepeatDduduEntity;
 import com.ddudu.infrastructure.persistence.entity.UserEntity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -31,5 +32,7 @@ public interface DduduQueryRepository {
   List<DduduEntity> findAllByDateAndUserAndPrivacyTypes(
       LocalDate date, UserEntity from, List<PrivacyType> accessiblePrivacyTypes
   );
+
+  void deleteAllByRepeatDdudu(RepeatDduduEntity repeatDdudu);
 
 }

--- a/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepositoryImpl.java
+++ b/src/main/java/com/ddudu/infrastructure/persistence/repository/ddudu/DduduQueryRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.ddudu.application.dto.scroll.request.ScrollRequest;
 import com.ddudu.infrastructure.persistence.dto.DduduCursorDto;
 import com.ddudu.infrastructure.persistence.entity.DduduEntity;
 import com.ddudu.infrastructure.persistence.entity.GoalEntity;
+import com.ddudu.infrastructure.persistence.entity.RepeatDduduEntity;
 import com.ddudu.infrastructure.persistence.entity.UserEntity;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.ConstructorExpression;
@@ -159,6 +160,17 @@ public class DduduQueryRepositoryImpl implements DduduQueryRepository {
             privacyTypesIn(accessiblePrivacyTypes)
         )
         .fetch();
+  }
+
+  @Override
+  public void deleteAllByRepeatDdudu(RepeatDduduEntity repeatDdudu) {
+    jpaQueryFactory
+        .delete(dduduEntity)
+        .where(
+            dduduEntity.repeatDdudu.eq(repeatDdudu),
+            dduduEntity.status.eq(DduduStatus.UNCOMPLETED)
+        )
+        .execute();
   }
 
   private Predicate getOpenness(boolean isMine, boolean isFollower) {

--- a/src/main/java/com/ddudu/presentation/api/controller/RepeatDduduController.java
+++ b/src/main/java/com/ddudu/presentation/api/controller/RepeatDduduController.java
@@ -1,7 +1,9 @@
 package com.ddudu.presentation.api.controller;
 
 import com.ddudu.application.dto.repeat_ddudu.request.CreateRepeatDduduRequest;
+import com.ddudu.application.dto.repeat_ddudu.request.UpdateRepeatDduduRequest;
 import com.ddudu.application.port.in.repeat_ddudu.CreateRepeatDduduUseCase;
+import com.ddudu.application.port.in.repeat_ddudu.UpdateRepeatDduduUseCase;
 import com.ddudu.presentation.api.annotation.Login;
 import com.ddudu.presentation.api.common.dto.response.IdResponse;
 import com.ddudu.presentation.api.doc.RepeatDduduControllerDoc;
@@ -9,7 +11,9 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RepeatDduduController implements RepeatDduduControllerDoc {
 
   private final CreateRepeatDduduUseCase createRepeatDduduUseCase;
+  private final UpdateRepeatDduduUseCase updateRepeatDduduUseCase;
 
   @PostMapping
   public ResponseEntity<IdResponse> create(
@@ -34,6 +39,21 @@ public class RepeatDduduController implements RepeatDduduControllerDoc {
 
     return ResponseEntity.created(uri)
         .body(new IdResponse(id));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<IdResponse> update(
+      @Login
+      Long loginId,
+      @PathVariable
+      Long id,
+      @RequestBody
+      @Valid
+      UpdateRepeatDduduRequest request
+  ) {
+    Long repeatDduduId = updateRepeatDduduUseCase.update(loginId, id, request);
+
+    return ResponseEntity.ok(new IdResponse(repeatDduduId));
   }
 
 }

--- a/src/main/java/com/ddudu/presentation/api/doc/RepeatDduduControllerDoc.java
+++ b/src/main/java/com/ddudu/presentation/api/doc/RepeatDduduControllerDoc.java
@@ -1,11 +1,14 @@
 package com.ddudu.presentation.api.doc;
 
 import com.ddudu.application.dto.repeat_ddudu.request.CreateRepeatDduduRequest;
+import com.ddudu.application.dto.repeat_ddudu.request.UpdateRepeatDduduRequest;
 import com.ddudu.presentation.api.common.dto.response.IdResponse;
 import com.ddudu.presentation.api.doc.error.AuthErrorExamples;
 import com.ddudu.presentation.api.doc.error.GoalErrorExamples;
 import com.ddudu.presentation.api.doc.error.RepeatDduduErrorExamples;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -113,5 +116,101 @@ public interface RepeatDduduControllerDoc {
       }
   )
   ResponseEntity<IdResponse> create(Long loginId, CreateRepeatDduduRequest request);
+
+
+  @Operation(summary = "반복 뚜두 수정")
+  @ApiResponses(
+      value = {
+          @ApiResponse(
+              responseCode = "200", description = "OK", useReturnTypeSchema = true
+          ),
+          @ApiResponse(
+              responseCode = "400", description = "BAD_REQUEST",
+              content = @Content(
+                  examples = {
+                      @ExampleObject(
+                          name = "6001",
+                          value = RepeatDduduErrorExamples.REPEAT_DDUDU_BLANK_NAME
+                      ),
+                      @ExampleObject(
+                          name = "6006",
+                          value = RepeatDduduErrorExamples.REPEAT_DDUDU_EXCESSIVE_NAME_LENGTH
+                      ),
+                      @ExampleObject(
+                          name = "6003",
+                          value = RepeatDduduErrorExamples.REPEAT_DDUDU_NULL_REPEAT_TYPE
+                      ),
+                      @ExampleObject(
+                          name = "6009",
+                          value = RepeatDduduErrorExamples.REPEAT_DDUDU_INVALID_REPEAT_TYPE
+                      ),
+                      @ExampleObject(
+                          name = "6004",
+                          value = RepeatDduduErrorExamples.REPEAT_DDUDU_NULL_START_DATE
+                      ),
+                      @ExampleObject(
+                          name = "6005",
+                          value = RepeatDduduErrorExamples.REPEAT_DDUDU_NULL_END_DATE
+                      ),
+                      @ExampleObject(
+                          name = "6007",
+                          value = RepeatDduduErrorExamples.REPEAT_DDUDU_UNABLE_TO_END_BEFORE_START
+                      ),
+                      @ExampleObject(
+                          name = "6008",
+                          value = RepeatDduduErrorExamples.REPEAT_DDUDU_UNABLE_TO_FINISH_BEFORE_BEGIN
+                      ),
+                      @ExampleObject(
+                          name = "6010",
+                          value = RepeatDduduErrorExamples.REPEAT_DDUDU_INVALID_DAY_OF_WEEK
+                      ),
+                      @ExampleObject(
+                          name = "6011",
+                          value = RepeatDduduErrorExamples.REPEAT_DDUDU_NULL_OR_EMPTY_REPEAT_DATES_OF_MONTH
+                      ),
+                      @ExampleObject(
+                          name = "6012",
+                          value = RepeatDduduErrorExamples.REPEAT_DDUDU_NULL_OR_EMPTY_REPEAT_DAYS_OF_WEEK
+                      ),
+                      @ExampleObject(
+                          name = "6013",
+                          value = RepeatDduduErrorExamples.REPEAT_DDUDU_NULL_LAST_DAY
+                      )
+                  }
+              )
+          ),
+          @ApiResponse(
+              responseCode = "401", description = "UNAUTHORIZED",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "5002",
+                      value = AuthErrorExamples.AUTH_BAD_TOKEN_CONTENT
+                  )
+              )
+          ),
+          @ApiResponse(
+              responseCode = "403", description = "FORBIDDEN",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "6014",
+                      description = "해당 목표에 대한 권한이 없는 경우 (본인만 가능)",
+                      value = GoalErrorExamples.GOAL_INVALID_AUTHORITY
+                  )
+              )
+          ),
+          @ApiResponse(
+              responseCode = "404", description = "NOT_FOUND",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "6015",
+                      description = "반복 뚜두 아이디가 유효하지 않은 경우",
+                      value = RepeatDduduErrorExamples.REPEAT_DDUDU_NOT_EXIST
+                  )
+              )
+          )
+      }
+  )
+  @Parameter(name = "id", description = "변경할 반복 뚜두 식별자", in = ParameterIn.PATH)
+  ResponseEntity<IdResponse> update(Long loginId, Long id, UpdateRepeatDduduRequest request);
 
 }

--- a/src/main/java/com/ddudu/presentation/api/doc/error/RepeatDduduErrorExamples.java
+++ b/src/main/java/com/ddudu/presentation/api/doc/error/RepeatDduduErrorExamples.java
@@ -100,4 +100,11 @@ public final class RepeatDduduErrorExamples {
       }
       """;
 
+  public static final String REPEAT_DDUDU_NOT_EXIST = """
+      {
+        "code": 6015,
+        "message": "해당 아이디를 가진 반복 뚜두가 존재하지 않습니다."
+      }
+      """;
+
 }

--- a/src/test/java/com/ddudu/application/service/repeat_ddudu/UpdateRepeatDduduServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/repeat_ddudu/UpdateRepeatDduduServiceTest.java
@@ -1,0 +1,144 @@
+package com.ddudu.application.service.repeat_ddudu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddudu.application.domain.ddudu.domain.Ddudu;
+import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
+import com.ddudu.application.domain.repeat_ddudu.domain.enums.RepeatType;
+import com.ddudu.application.domain.repeat_ddudu.service.RepeatDduduDomainService;
+import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.dto.repeat_ddudu.RepeatPatternDto;
+import com.ddudu.application.dto.repeat_ddudu.request.UpdateRepeatDduduRequest;
+import com.ddudu.application.port.out.auth.SignUpPort;
+import com.ddudu.application.port.out.ddudu.DduduLoaderPort;
+import com.ddudu.application.port.out.ddudu.DduduUpdatePort;
+import com.ddudu.application.port.out.ddudu.SaveDduduPort;
+import com.ddudu.application.port.out.goal.SaveGoalPort;
+import com.ddudu.application.port.out.repeat_ddudu.RepeatDduduLoaderPort;
+import com.ddudu.application.port.out.repeat_ddudu.SaveRepeatDduduPort;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.UserFixture;
+import jakarta.transaction.Transactional;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class UpdateRepeatDduduServiceTest {
+
+  @Autowired
+  UpdateRepeatDduduService updateRepeatDduduService;
+  @Autowired
+  RepeatDduduDomainService repeatDduduDomainService;
+  @Autowired
+  RepeatDduduLoaderPort repeatDduduLoaderPort;
+  @Autowired
+  DduduLoaderPort dduduLoaderPort;
+  @Autowired
+  SaveGoalPort saveGoalPort;
+  @Autowired
+  SignUpPort signUpPort;
+  @Autowired
+  SaveRepeatDduduPort saveRepeatDduduPort;
+  @Autowired
+  SaveDduduPort saveDduduPort;
+  @Autowired
+  DduduUpdatePort dduduUpdatePort;
+
+  User user;
+  Goal goal;
+  LocalDate nextMonday;
+  LocalDate nextSunday;
+  RepeatDdudu repeatDdudu;
+  List<Ddudu> repeatedDdudus;
+  String nameToUpdate;
+  DayOfWeek originalRepeatDayOfWeek;
+  DayOfWeek repeatDayOfWeekToUpdate;
+  UpdateRepeatDduduRequest request;
+
+  @BeforeEach
+  void setUp() {
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user));
+    nextMonday = LocalDate.now()
+        .with(DayOfWeek.MONDAY)
+        .plusDays(7);
+    nextSunday = nextMonday.plusDays(6);
+    originalRepeatDayOfWeek = DayOfWeek.MONDAY;
+    repeatDdudu = saveRepeatDduduPort.save(
+        RepeatDdudu.builder()
+            .name("반복 뚜두")
+            .repeatType(RepeatType.WEEKLY)
+            .repeatPatternDto(
+                RepeatPatternDto.weeklyPatternOf(List.of(originalRepeatDayOfWeek.name())))
+            .goalId(goal.getId())
+            .startDate(nextMonday)
+            .endDate(nextSunday)
+            .build()
+    );
+    repeatedDdudus = saveDduduPort.saveAll(
+        repeatDduduDomainService.createRepeatedDdudus(user.getId(), repeatDdudu)
+    );
+    repeatDayOfWeekToUpdate = DayOfWeek.TUESDAY;
+    nameToUpdate = "수정된 반복 뚜두";
+    request = new UpdateRepeatDduduRequest(
+        nameToUpdate,
+        RepeatType.WEEKLY.name(),
+        List.of(repeatDayOfWeekToUpdate.name()),
+        null,
+        null,
+        nextMonday,
+        nextSunday,
+        null,
+        null
+    );
+  }
+
+  @Test
+  void 반복_뚜두를_업데이트_하면_연결된_뚜두들도_함께_업데이트된다() {
+    // when
+    updateRepeatDduduService.update(user.getId(), repeatDdudu.getId(), request);
+
+    // then
+    RepeatDdudu updated = repeatDduduLoaderPort.getOptionalRepeatDdudu(repeatDdudu.getId())
+        .get();
+    assertThat(updated.getName()).isEqualTo(nameToUpdate);
+
+    List<Ddudu> updatedDdudus = dduduLoaderPort.getRepeatedDdudus(repeatDdudu);
+    assertThat(updatedDdudus).hasSize(1);
+    assertThat(updatedDdudus).extracting(Ddudu::getName)
+        .containsExactly(nameToUpdate);
+    assertThat(updatedDdudus.get(0)
+        .getScheduledOn()
+        .getDayOfWeek())
+        .isEqualTo(repeatDayOfWeekToUpdate);
+  }
+
+  @Test
+  void 이미_완료된_반복_뚜두는_변경되지_않는다() {
+    // given
+    dduduUpdatePort.update(repeatedDdudus.get(0)
+        .switchStatus());
+
+    // when
+    updateRepeatDduduService.update(user.getId(), repeatDdudu.getId(), request);
+
+    // then
+    List<Ddudu> updatedDdudus = dduduLoaderPort.getRepeatedDdudus(repeatDdudu);
+    assertThat(updatedDdudus).hasSize(2);
+    assertThat(updatedDdudus)
+        .extracting(ddudu -> ddudu.getScheduledOn()
+            .getDayOfWeek())
+        .containsExactlyInAnyOrder(originalRepeatDayOfWeek, repeatDayOfWeekToUpdate);
+  }
+
+}


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #200 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 반복 뚜두 수정 시, 해당 반복 뚜두와 연관된 뚜두는 기본적으로 **삭제** 후 변경된 내용에 맞게 다시 연관된 뚜두들을 생성 (오늘 이후부터)
 ❗️ 만약, 이미 완료한 뚜두라면 그대로 둠

### 추후 개선하면 좋을 사항
- 반복 패턴이 변경되는 것이 아니라면 굳이 관련 뚜두들을 삭제 후 생성할 필요없이, 벌크 업데이트 가능!