### PR TITLE
목표 생성 시 반복  뚜두도 함께 생성할 수 있도록 변경

### DIFF
--- a/src/main/java/com/ddudu/application/domain/repeat_ddudu/service/RepeatDduduDomainService.java
+++ b/src/main/java/com/ddudu/application/domain/repeat_ddudu/service/RepeatDduduDomainService.java
@@ -4,6 +4,7 @@ import com.ddudu.application.annotation.DomainService;
 import com.ddudu.application.domain.ddudu.domain.Ddudu;
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 import com.ddudu.application.domain.repeat_ddudu.domain.enums.RepeatType;
+import com.ddudu.application.dto.goal.request.CreateRepeatDduduRequestWithoutGoal;
 import com.ddudu.application.dto.repeat_ddudu.RepeatPatternDto;
 import com.ddudu.application.dto.repeat_ddudu.request.CreateRepeatDduduRequest;
 import java.util.List;
@@ -17,6 +18,19 @@ public class RepeatDduduDomainService {
     return RepeatDdudu.builder()
         .name(request.name())
         .goalId(request.goalId())
+        .startDate(request.startDate())
+        .endDate(request.endDate())
+        .repeatType(RepeatType.from(request.repeatType()))
+        .repeatPatternDto(RepeatPatternDto.from(request))
+        .beginAt(request.beginAt())
+        .endAt(request.endAt())
+        .build();
+  }
+
+  public RepeatDdudu create(Long goalId, CreateRepeatDduduRequestWithoutGoal request) {
+    return RepeatDdudu.builder()
+        .name(request.name())
+        .goalId(goalId)
         .startDate(request.startDate())
         .endDate(request.endDate())
         .repeatType(RepeatType.from(request.repeatType()))

--- a/src/main/java/com/ddudu/application/dto/goal/request/CreateGoalRequest.java
+++ b/src/main/java/com/ddudu/application/dto/goal/request/CreateGoalRequest.java
@@ -3,14 +3,17 @@ package com.ddudu.application.dto.goal.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 
 public record CreateGoalRequest(
+
     @NotBlank(message = "3001 BLANK_NAME")
     @Size(max = 50, message = "3002 EXCESSIVE_NAME_LENGTH")
     String name,
     @Size(max = 6, message = "3003 INVALID_COLOR_FORMAT")
     String color,
-    String privacyType
+    String privacyType,
+    List<CreateRepeatDduduRequestWithoutGoal> repeatDdudus
 ) {
 
 }

--- a/src/main/java/com/ddudu/application/dto/goal/request/CreateRepeatDduduRequestWithoutGoal.java
+++ b/src/main/java/com/ddudu/application/dto/goal/request/CreateRepeatDduduRequestWithoutGoal.java
@@ -1,0 +1,79 @@
+package com.ddudu.application.dto.goal.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Schema(description = "반복 뚜두 생성 요청 (in 목표 생성 요청)")
+public record CreateRepeatDduduRequestWithoutGoal(
+    @Schema(
+        name = "name",
+        description = "반복 뚜두명",
+        example = "물 한 컵 마시기"
+    )
+    @NotNull(message = "6001 BLANK_NAME")
+    @Size(max = 50, message = "6006 EXCESSIVE_NAME_LENGTH")
+    String name,
+    @Schema(
+        name = "repeatType",
+        description = "반복 유형 (소문자 가능)",
+        example = "DAILY | WEEKLY | MONTHLY"
+    )
+    @NotBlank(message = "6003 NULL_REPEAT_TYPE")
+    String repeatType,
+    @Schema(
+        name = "repeatDaysOfWeek",
+        description = "반복 요일 (WEEKLY일 때만)",
+        nullable = true,
+        example = "[\"월\", \"화\"]"
+    )
+    List<String> repeatDaysOfWeek,
+    @Schema(
+        name = "repeatDaysOfMonth",
+        description = "반복 날짜 (MONTHLY 때만)",
+        nullable = true,
+        example = "[1, 15]"
+    )
+    List<Integer> repeatDaysOfMonth,
+    @Schema(
+        name = "lastDayOfMonth",
+        description = "마지막 날 반복 여부 (MONTHLY 때만)",
+        nullable = true,
+        example = "true"
+    )
+    Boolean lastDayOfMonth,
+    @Schema(
+        name = "startDate",
+        description = "반복 시작 날짜",
+        example = "2024-06-10"
+    )
+    @NotNull(message = "6004 NULL_START_DATE")
+    LocalDate startDate,
+    @Schema(
+        name = "endDate",
+        description = "반복 종료 날짜",
+        example = "2024-12-31"
+    )
+    @NotNull(message = "6005 NULL_END_DATE")
+    LocalDate endDate,
+    @Schema(
+        name = "beginAt",
+        description = "시작 시간",
+        nullable = true,
+        example = "07:00:00"
+    )
+    LocalTime beginAt,
+    @Schema(
+        name = "endAt",
+        description = "종료 시간",
+        nullable = true,
+        example = "08:00:00"
+    )
+    LocalTime endAt
+) {
+
+}

--- a/src/main/java/com/ddudu/application/dto/repeat_ddudu/RepeatPatternDto.java
+++ b/src/main/java/com/ddudu/application/dto/repeat_ddudu/RepeatPatternDto.java
@@ -1,5 +1,6 @@
 package com.ddudu.application.dto.repeat_ddudu;
 
+import com.ddudu.application.dto.goal.request.CreateRepeatDduduRequestWithoutGoal;
 import com.ddudu.application.dto.repeat_ddudu.request.CreateRepeatDduduRequest;
 import java.util.List;
 
@@ -10,6 +11,14 @@ public record RepeatPatternDto(
 ) {
 
   public static RepeatPatternDto from(CreateRepeatDduduRequest request) {
+    return new RepeatPatternDto(
+        request.repeatDaysOfWeek(),
+        request.repeatDaysOfMonth(),
+        request.lastDayOfMonth()
+    );
+  }
+
+  public static RepeatPatternDto from(CreateRepeatDduduRequestWithoutGoal request) {
     return new RepeatPatternDto(
         request.repeatDaysOfWeek(),
         request.repeatDaysOfMonth(),

--- a/src/main/java/com/ddudu/application/service/goal/CreateGoalService.java
+++ b/src/main/java/com/ddudu/application/service/goal/CreateGoalService.java
@@ -6,10 +6,13 @@ import com.ddudu.application.domain.goal.exception.GoalErrorCode;
 import com.ddudu.application.domain.goal.service.GoalDomainService;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.dto.goal.request.CreateGoalRequest;
+import com.ddudu.application.dto.goal.request.CreateRepeatDduduRequestWithoutGoal;
 import com.ddudu.application.dto.goal.response.GoalIdResponse;
+import com.ddudu.application.dto.repeat_ddudu.request.CreateRepeatDduduRequest;
 import com.ddudu.application.port.in.goal.CreateGoalUseCase;
 import com.ddudu.application.port.out.goal.SaveGoalPort;
 import com.ddudu.application.port.out.user.UserLoaderPort;
+import com.ddudu.application.service.repeat_ddudu.CreateRepeatDduduService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
@@ -20,15 +23,39 @@ public class CreateGoalService implements CreateGoalUseCase {
 
   private final UserLoaderPort userLoaderPort;
   private final GoalDomainService goalDomainService;
+  private final CreateRepeatDduduService createRepeatDduduService;
   private final SaveGoalPort saveGoalPort;
 
   @Override
   public GoalIdResponse create(Long userId, CreateGoalRequest request) {
     User user = userLoaderPort.getUserOrElseThrow(
         userId, GoalErrorCode.USER_NOT_EXISTING.getCodeName());
-    Goal goal = goalDomainService.create(user, request);
+    Goal goal = saveGoalPort.save(goalDomainService.create(user, request));
 
-    return GoalIdResponse.from(saveGoalPort.save(goal));
+    request.repeatDdudus()
+        .forEach(repeatDduduRequest ->
+            createRepeatDduduService.create(
+                userId, toCreateRepeatDduduRequest(repeatDduduRequest, goal))
+        );
+
+    return GoalIdResponse.from(goal);
+  }
+
+  private CreateRepeatDduduRequest toCreateRepeatDduduRequest(
+      CreateRepeatDduduRequestWithoutGoal repeatDduduRequest, Goal goal
+  ) {
+    return new CreateRepeatDduduRequest(
+        repeatDduduRequest.name(),
+        goal.getId(),
+        repeatDduduRequest.repeatType(),
+        repeatDduduRequest.repeatDaysOfWeek(),
+        repeatDduduRequest.repeatDaysOfMonth(),
+        repeatDduduRequest.lastDayOfMonth(),
+        repeatDduduRequest.startDate(),
+        repeatDduduRequest.endDate(),
+        repeatDduduRequest.beginAt(),
+        repeatDduduRequest.endAt()
+    );
   }
 
 }

--- a/src/test/java/com/ddudu/application/domain/goal/service/GoalDomainServiceTest.java
+++ b/src/test/java/com/ddudu/application/domain/goal/service/GoalDomainServiceTest.java
@@ -10,6 +10,7 @@ import com.ddudu.application.dto.goal.request.CreateGoalRequest;
 import com.ddudu.fixture.BaseFixture;
 import com.ddudu.fixture.GoalFixture;
 import com.ddudu.fixture.UserFixture;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -42,7 +43,7 @@ class GoalDomainServiceTest {
       privacyType = GoalFixture.getRandomPrivacyType()
           .name();
       color = BaseFixture.getRandomColor();
-      request = new CreateGoalRequest(name, color, privacyType);
+      request = new CreateGoalRequest(name, color, privacyType, new ArrayList<>());
     }
 
     @Test


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #198 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 반복 뚜두 생성을 위해 `CreateGoalService`가  `CreateRepeatDduduService` 의 메서드를 호출하도록 구현했습니다.

#### 추후 개선 사항
- Service 간 의존성을 퍼사드 패턴으로 해결
- 목표 생성 후 반복 뚜두 생성을 비동기로 변경