### PR TITLE
뚜두 날짜를 자유롭게 과거로 변경할 수 있도록 변경

### DIFF
--- a/src/main/java/com/ddudu/application/domain/ddudu/domain/Ddudu.java
+++ b/src/main/java/com/ddudu/application/domain/ddudu/domain/Ddudu.java
@@ -16,7 +16,6 @@ import java.util.Objects;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import org.apache.commons.lang3.BooleanUtils;
 
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
@@ -82,25 +81,19 @@ public class Ddudu {
     return builder.build();
   }
 
-  public Ddudu moveDate(LocalDate newDate, Boolean isPostponed) {
+  public Ddudu moveDate(LocalDate newDate) {
     checkArgument(Objects.nonNull(newDate), DduduErrorCode.NULL_DATE_TO_MOVE.getCodeName());
-
-    if (!newDate.isAfter(this.scheduledOn) && !this.isPostponed) {
-      checkArgument(
-          BooleanUtils.isNotTrue(isPostponed),
-          DduduErrorCode.SHOULD_POSTPONE_UNTIL_FUTURE.getCodeName()
-      );
-    }
 
     DduduBuilder builder = getFullBuilder()
         .scheduledOn(newDate);
 
-    if (this.status.isCompleted()) {
+    // 완료한 뚜두이거나 과거로 날짜를 변경하는 경우, 기존 미루기 상태가 적용된다.
+    if (this.status.isCompleted() || newDate.isBefore(scheduledOn)) {
       return builder.build();
     }
 
     return builder
-        .isPostponed(isPostponed)
+        .isPostponed(true)
         .build();
   }
 

--- a/src/main/java/com/ddudu/application/dto/ddudu/request/MoveDateRequest.java
+++ b/src/main/java/com/ddudu/application/dto/ddudu/request/MoveDateRequest.java
@@ -5,8 +5,7 @@ import java.time.LocalDate;
 
 public record MoveDateRequest(
     @NotNull(message = "2011 NULL_DATE_TO_MOVE")
-    LocalDate newDate,
-    Boolean isPostponed
+    LocalDate newDate
 ) {
 
 }

--- a/src/main/java/com/ddudu/application/service/ddudu/MoveDateService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/MoveDateService.java
@@ -25,7 +25,7 @@ public class MoveDateService implements MoveDateUseCase {
 
     ddudu.validateDduduCreator(loginId);
 
-    Ddudu movedDdudu = ddudu.moveDate(request.newDate(), request.isPostponed());
+    Ddudu movedDdudu = ddudu.moveDate(request.newDate());
 
     dduduUpdatePort.update(movedDdudu);
   }

--- a/src/test/java/com/ddudu/application/service/ddudu/MoveDateServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/ddudu/MoveDateServiceTest.java
@@ -67,7 +67,7 @@ class MoveDateServiceTest {
   @Test
   void 뚜두를_미루기_한다() {
     // given
-    MoveDateRequest request = new MoveDateRequest(tomorrow, true);
+    MoveDateRequest request = new MoveDateRequest(tomorrow);
 
     // when
     moveDateService.moveDate(user.getId(), ddudu.getId(), request);
@@ -86,7 +86,7 @@ class MoveDateServiceTest {
         .minusDays(1);
     Ddudu pastDdudu = saveDduduPort.save(
         DduduFixture.createRandomDduduWithSchedule(goal, yesterday));
-    MoveDateRequest request = new MoveDateRequest(LocalDate.now(), true);
+    MoveDateRequest request = new MoveDateRequest(LocalDate.now());
 
     // when
     moveDateService.moveDate(user.getId(), pastDdudu.getId(), request);
@@ -106,7 +106,7 @@ class MoveDateServiceTest {
         DduduFixture.createRandomDduduWithSchedule(goal, twoDaysAgo));
     LocalDate yesterday = LocalDate.now()
         .minusDays(1);
-    MoveDateRequest request = new MoveDateRequest(yesterday, null);
+    MoveDateRequest request = new MoveDateRequest(yesterday);
 
     // when
     moveDateService.moveDate(user.getId(), pastDdudu.getId(), request);
@@ -121,7 +121,7 @@ class MoveDateServiceTest {
   void 뚜두가_존재하지_않으면_날짜_변경을_실패한다() {
     // given
     long invalidId = DduduFixture.getRandomId();
-    MoveDateRequest request = new MoveDateRequest(tomorrow, null);
+    MoveDateRequest request = new MoveDateRequest(tomorrow);
 
     // when
     ThrowingCallable moveDate = () -> moveDateService.moveDate(user.getId(), invalidId, request);


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #232 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
승현님이 미루기 또는 날짜 변경 시 과거로 변경이 안되어서 변경 가능하도록 바꾸는게 어떠냐고 여쭤보시더라고요!
사용자 입장에서 고려했을 때, 과거로의 날짜 변경이 자유로우면 좋을 것 같아서 바꿔보았습니다!

그리고 날짜 변경시 `isPostponed` 값도 함께 받아오는데, 이건 서버에서 내부적으로 미루기인지, 아닌지 판단하는 것이 좋을 것 같아서 받지않도록 변경 했습니다. 전반적인 날짜 변경 로직은 다음과 같습니다.

- 뚜두 상태와 관련없이 모든 날짜 변경은 가능하다.
- 완료 뚜두의 날짜를 변경할 경우, 기존 미루기 상태가 유지된다. (기존에 미루기 ⭕ 였으면 여전히 ⭕, 기존에 미루기 ❌ 였으면 여전히 ❌)
- 미완료 뚜두의 날짜를 변경할 경우
  - 과거로 변경이면, 기존 미루기 상태가 유지된다. 
  - 미래로 변경이면, 미루기 상태가 `true`가 된다.
