### PR TITLE
Feat/#223 collect ddudu creation stats

### DIFF
--- a/src/main/java/com/ddudu/application/dto/stats/CompletionPerGoalDto.java
+++ b/src/main/java/com/ddudu/application/dto/stats/CompletionPerGoalDto.java
@@ -1,5 +1,15 @@
 package com.ddudu.application.dto.stats;
 
+import lombok.Builder;
+
+@Builder
 public record CompletionPerGoalDto(Long goalId, int count) {
+
+  public static CompletionPerGoalDto from(Long goalId, int count) {
+    return CompletionPerGoalDto.builder()
+        .goalId(goalId)
+        .count(count)
+        .build();
+  }
 
 }

--- a/src/main/java/com/ddudu/application/port/in/ddudu/CollectMonthlyCreationStatsUseCase.java
+++ b/src/main/java/com/ddudu/application/port/in/ddudu/CollectMonthlyCreationStatsUseCase.java
@@ -1,0 +1,11 @@
+package com.ddudu.application.port.in.ddudu;
+
+import com.ddudu.application.dto.stats.CompletionPerGoalDto;
+import com.ddudu.application.dto.stats.response.MonthlyStatsResponse;
+import java.time.YearMonth;
+
+public interface CollectMonthlyCreationStatsUseCase {
+
+  MonthlyStatsResponse<CompletionPerGoalDto> collectCreation(Long loginId, YearMonth yearMonth);
+
+}

--- a/src/main/java/com/ddudu/application/service/ddudu/CollectMonthlyCreationStatsService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/CollectMonthlyCreationStatsService.java
@@ -1,0 +1,52 @@
+package com.ddudu.application.service.ddudu;
+
+import com.ddudu.application.annotation.UseCase;
+import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
+import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.dto.stats.CompletionPerGoalDto;
+import com.ddudu.application.dto.stats.StatsBaseDto;
+import com.ddudu.application.dto.stats.response.MonthlyStatsResponse;
+import com.ddudu.application.port.in.ddudu.CollectMonthlyCreationStatsUseCase;
+import com.ddudu.application.port.out.goal.MonthlyStatsPort;
+import com.ddudu.application.port.out.user.UserLoaderPort;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CollectMonthlyCreationStatsService implements CollectMonthlyCreationStatsUseCase {
+
+  private static final int FIRST_DATE = 1;
+
+  private final UserLoaderPort userLoaderPort;
+  private final MonthlyStatsPort monthlyStatsPort;
+
+  @Override
+  public MonthlyStatsResponse<CompletionPerGoalDto> collectCreation(
+      Long loginId, YearMonth yearMonth
+  ) {
+    User user = userLoaderPort.getUserOrElseThrow(
+        loginId, DduduErrorCode.USER_NOT_EXISTING.getCodeName());
+    LocalDate from = yearMonth.atDay(FIRST_DATE);
+    LocalDate to = yearMonth.atEndOfMonth();
+    List<StatsBaseDto> stats = monthlyStatsPort.collectMonthlyStats(user, null, from, to);
+    List<CompletionPerGoalDto> completions = countPerGoalId(stats);
+
+    return MonthlyStatsResponse.from(completions);
+  }
+
+  private List<CompletionPerGoalDto> countPerGoalId(List<StatsBaseDto> stats) {
+    return stats.stream()
+        .collect(Collectors.groupingBy(StatsBaseDto::id, Collectors.summingInt(toAdd -> 1)))
+        .entrySet()
+        .stream()
+        .map(completion -> CompletionPerGoalDto.from(completion.getKey(), completion.getValue()))
+        .toList();
+  }
+
+}

--- a/src/main/java/com/ddudu/presentation/api/controller/StatsController.java
+++ b/src/main/java/com/ddudu/presentation/api/controller/StatsController.java
@@ -3,12 +3,12 @@ package com.ddudu.presentation.api.controller;
 import com.ddudu.application.dto.stats.CompletionPerGoalDto;
 import com.ddudu.application.dto.stats.response.MonthlyStatsResponse;
 import com.ddudu.application.dto.stats.response.MonthlyStatsSummaryResponse;
+import com.ddudu.application.port.in.ddudu.CollectMonthlyCreationStatsUseCase;
 import com.ddudu.application.port.in.ddudu.CollectMonthlyStatsSummaryUseCase;
 import com.ddudu.presentation.api.annotation.Login;
 import com.ddudu.presentation.api.doc.StatsControllerDoc;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class StatsController implements StatsControllerDoc {
 
   private final CollectMonthlyStatsSummaryUseCase collectMonthlyStatsSummaryUseCase;
+  private final CollectMonthlyCreationStatsUseCase collectMonthlyCreationStatsUseCase;
 
   @GetMapping
   public ResponseEntity<MonthlyStatsSummaryResponse> collectSummary(
@@ -45,7 +46,10 @@ public class StatsController implements StatsControllerDoc {
       @DateTimeFormat(pattern = "yyyy-MM")
       YearMonth yearMonth
   ) {
-    throw new NotImplementedException();
+    MonthlyStatsResponse<CompletionPerGoalDto> response = collectMonthlyCreationStatsUseCase.collectCreation(
+        loginId, yearMonth);
+
+    return ResponseEntity.ok(response);
   }
 
 }

--- a/src/test/java/com/ddudu/application/service/ddudu/CollectMonthlyCreationStatsServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/ddudu/CollectMonthlyCreationStatsServiceTest.java
@@ -1,0 +1,133 @@
+package com.ddudu.application.service.ddudu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
+import com.ddudu.application.domain.goal.domain.Goal;
+import com.ddudu.application.domain.user.domain.User;
+import com.ddudu.application.dto.stats.CompletionPerGoalDto;
+import com.ddudu.application.dto.stats.response.MonthlyStatsResponse;
+import com.ddudu.application.port.out.auth.SignUpPort;
+import com.ddudu.application.port.out.ddudu.SaveDduduPort;
+import com.ddudu.application.port.out.goal.SaveGoalPort;
+import com.ddudu.fixture.DduduFixture;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.UserFixture;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.MissingResourceException;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class CollectMonthlyCreationStatsServiceTest {
+
+  @Autowired
+  CollectMonthlyCreationStatsService collectMonthlyCreationStatsService;
+
+  @Autowired
+  SignUpPort signUpPort;
+
+  @Autowired
+  SaveGoalPort saveGoalPort;
+
+  @Autowired
+  SaveDduduPort saveDduduPort;
+
+  User user;
+  List<Goal> goals;
+  List<Integer> sizes;
+
+  @BeforeEach
+  void setUp() {
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    goals = saveGoalPort.saveAll(GoalFixture.createRandomGoalsWithUser(user, 5));
+    sizes = new ArrayList<>();
+
+    for (int i = 0; i < 5; i++) {
+      sizes.add(DduduFixture.getRandomInt(1, 100));
+    }
+
+    Iterator<Integer> sizeIterator = sizes.iterator();
+
+    goals.forEach(goal -> saveDduduPort.saveAll(
+        DduduFixture.createMultipleDdudusWithGoal(goal, sizeIterator.next())));
+
+    sizes.sort(Comparator.reverseOrder());
+  }
+
+  @Test
+  void 이번_달_월별_목표들의_뚜두_생성_수_통계를_내림차순으로_낸다() {
+    // given
+    YearMonth thisMonth = YearMonth.now();
+
+    // when
+    MonthlyStatsResponse<CompletionPerGoalDto> response = collectMonthlyCreationStatsService.collectCreation(
+        user.getId(), thisMonth);
+
+    // then
+    List<CompletionPerGoalDto> actual = response.contents();
+    Iterator<Integer> sizeIterator = sizes.iterator();
+
+    assertThat(actual.size()).isEqualTo(goals.size());
+    assertThat(actual).allMatch(goal -> goal.count() == sizeIterator.next());
+  }
+
+  @Test
+  void 목표에_해당_달_생성_뚜두가_없으면_통계에서_제외한다() {
+    // given
+    YearMonth lastMonth = YearMonth.now()
+        .minusMonths(1);
+
+    // when
+    MonthlyStatsResponse<CompletionPerGoalDto> response = collectMonthlyCreationStatsService.collectCreation(
+        user.getId(), lastMonth);
+
+    // then
+    assertThat(response.isEmpty()).isTrue();
+  }
+
+  @Test
+  void 날짜가_없으면_이번_달_통계를_낸다() {
+    // given
+
+    // when
+    MonthlyStatsResponse<CompletionPerGoalDto> response = collectMonthlyCreationStatsService.collectCreation(
+        user.getId(), null);
+
+    // then
+    List<CompletionPerGoalDto> actual = response.contents();
+    Iterator<Integer> sizeIterator = sizes.iterator();
+
+    assertThat(actual.size()).isEqualTo(goals.size());
+    assertThat(actual).allMatch(goal -> goal.count() == sizeIterator.next());
+  }
+
+  @Test
+  void 로그인_사용자가_없으면_월_달성_뚜두_수_통계를_실패한다() {
+    // given
+    long invalidId = GoalFixture.getRandomId();
+    YearMonth thisMonth = YearMonth.now();
+
+    // when
+    ThrowingCallable collect = () -> collectMonthlyCreationStatsService.collectCreation(
+        invalidId, thisMonth);
+
+    // then
+    assertThatExceptionOfType(MissingResourceException.class).isThrownBy(collect)
+        .withMessage(DduduErrorCode.USER_NOT_EXISTING.getCodeName());
+  }
+
+}


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
* Resolves #223 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 월 별 뚜두 생성 통계
- 통계 쿼리 재사용 의도로 비즈니스 로직만 구현 했는데,
- 정렬이랑 collect를 결국 다시 해야하니 쿼리를 새로 짜는게 맞나 생각도 들고
- 아님 그냥 한 API에 다 묶는게 낫나 싶기도 하고..
- 쿼리 : #187
- 응답: #224 

## 여담
- save 할 때 보면, 컨텍스트에 있나 확인 후 없으면 select로 db에 찔러본 다음에 없어야 insert를 하네요. 뭔가 개선할 수 있을 것 같기도 합니다 나중에! 블로그 쓰기 좋은 느낌