### PR TITLE
feat: 응답 데이터 형식 변경 (타임테이블 API, 목표 상세 조회 API)

### DIFF
--- a/src/main/java/com/ddudu/application/domain/ddudu/domain/Timetable.java
+++ b/src/main/java/com/ddudu/application/domain/ddudu/domain/Timetable.java
@@ -5,13 +5,14 @@ import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.groupingBy;
 
 import com.ddudu.application.domain.goal.domain.Goal;
-import com.ddudu.application.dto.ddudu.BasicDduduWithGoalIdAndTime;
+import com.ddudu.application.dto.ddudu.DduduForTimetable;
 import com.ddudu.application.dto.ddudu.GoalGroupedDdudus;
 import com.ddudu.application.dto.ddudu.TimeGroupedDdudus;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class Timetable {
 
@@ -30,16 +31,15 @@ public class Timetable {
     unassignedDdudus = new DduduList(split.getOrDefault(false, new ArrayList<>()));
   }
 
-  public List<TimeGroupedDdudus> getTimeGroupedDdudus() {
+  public List<TimeGroupedDdudus> getTimeGroupedDdudus(List<Goal> goals) {
+    Map<Long, String> goalToColor = mapGoalsToColors(goals);
+
     return timetable.entrySet()
         .stream()
         .map(entry ->
             TimeGroupedDdudus.of(
                 LocalTime.of(entry.getKey(), 0),
-                entry.getValue()
-                    .stream()
-                    .map(BasicDduduWithGoalIdAndTime::of)
-                    .toList()
+                toDduduForTimetableList(entry.getValue(), goalToColor)
             )
         )
         .toList();
@@ -47,6 +47,19 @@ public class Timetable {
 
   public List<GoalGroupedDdudus> getUnassignedDdudusWithGoal(List<Goal> goals) {
     return unassignedDdudus.getDdudusWithGoal(goals);
+  }
+
+  private Map<Long, String> mapGoalsToColors(List<Goal> goals) {
+    return goals.stream()
+        .collect(Collectors.toMap(Goal::getId, Goal::getColor));
+  }
+
+  private List<DduduForTimetable> toDduduForTimetableList(
+      List<Ddudu> ddudus, Map<Long, String> goalToColor
+  ) {
+    return ddudus.stream()
+        .map((ddudu) -> DduduForTimetable.of(ddudu, goalToColor.get(ddudu.getGoalId())))
+        .toList();
   }
 
 }

--- a/src/main/java/com/ddudu/application/dto/ddudu/DduduForTimetable.java
+++ b/src/main/java/com/ddudu/application/dto/ddudu/DduduForTimetable.java
@@ -8,11 +8,12 @@ import java.time.LocalTime;
 import lombok.Builder;
 
 @Builder
-public record BasicDduduWithGoalIdAndTime(
+public record DduduForTimetable(
     Long id,
     String name,
     DduduStatus status,
     Long goalId,
+    String color,
     @Schema(type = "string", pattern = "HH:mm", example = "14:00")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     LocalTime beginAt,
@@ -21,13 +22,13 @@ public record BasicDduduWithGoalIdAndTime(
     LocalTime endAt
 ) {
 
-  public static BasicDduduWithGoalIdAndTime of(Ddudu ddudu) {
-
-    return BasicDduduWithGoalIdAndTime.builder()
+  public static DduduForTimetable of(Ddudu ddudu, String color) {
+    return DduduForTimetable.builder()
         .id(ddudu.getId())
         .name(ddudu.getName())
         .status(ddudu.getStatus())
         .goalId(ddudu.getGoalId())
+        .color(color)
         .beginAt(ddudu.getBeginAt())
         .endAt(ddudu.getEndAt())
         .build();

--- a/src/main/java/com/ddudu/application/dto/ddudu/TimeGroupedDdudus.java
+++ b/src/main/java/com/ddudu/application/dto/ddudu/TimeGroupedDdudus.java
@@ -11,10 +11,10 @@ public record TimeGroupedDdudus(
     @Schema(type = "string", pattern = "HH:mm", example = "14:00")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     LocalTime beginAt,
-    List<BasicDduduWithGoalIdAndTime> ddudus
+    List<DduduForTimetable> ddudus
 ) {
 
-  public static TimeGroupedDdudus of(LocalTime beginAt, List<BasicDduduWithGoalIdAndTime> ddudus) {
+  public static TimeGroupedDdudus of(LocalTime beginAt, List<DduduForTimetable> ddudus) {
     return TimeGroupedDdudus.builder()
         .beginAt(beginAt)
         .ddudus(ddudus)

--- a/src/main/java/com/ddudu/application/dto/goal/response/GoalWithRepeatDduduResponse.java
+++ b/src/main/java/com/ddudu/application/dto/goal/response/GoalWithRepeatDduduResponse.java
@@ -4,7 +4,7 @@ import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.domain.goal.domain.enums.GoalStatus;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
-import com.ddudu.application.dto.repeat_ddudu.RepeatDduduSummary;
+import com.ddudu.application.dto.repeat_ddudu.RepeatDduduDto;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -24,8 +24,8 @@ public record GoalWithRepeatDduduResponse(
     String color,
     @Schema(description = "목표 공개 범위 [PRIVATE|FOLLOWER|PUBLIC]", example = "PUBLIC")
     PrivacyType privacyType,
-    @ArraySchema(schema = @Schema(implementation = RepeatDduduSummary.class))
-    List<RepeatDduduSummary> repeatDdudus
+    @ArraySchema(schema = @Schema(implementation = RepeatDduduDto.class))
+    List<RepeatDduduDto> repeatDdudus
 ) {
 
   public static GoalWithRepeatDduduResponse from(Goal goal, List<RepeatDdudu> repeatDdudus) {
@@ -37,7 +37,7 @@ public record GoalWithRepeatDduduResponse(
         .privacyType(goal.getPrivacyType())
         .repeatDdudus(
             repeatDdudus.stream()
-                .map(RepeatDduduSummary::from)
+                .map(RepeatDduduDto::from)
                 .toList())
         .build();
   }

--- a/src/main/java/com/ddudu/application/dto/repeat_ddudu/RepeatDduduDto.java
+++ b/src/main/java/com/ddudu/application/dto/repeat_ddudu/RepeatDduduDto.java
@@ -2,11 +2,13 @@ package com.ddudu.application.dto.repeat_ddudu;
 
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatPattern;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Schema(description = "반복 뚜두 요약")
-public record RepeatDduduSummary(
+public record RepeatDduduDto(
     @Schema(description = "반복 뚜두 식별자", example = "1")
     Long id,
     @Schema(description = "반복 뚜두 이름", example = "매일 아침 물 마시기")
@@ -16,16 +18,24 @@ public record RepeatDduduSummary(
     @Schema(description = "반복 뚜두 시작 날짜", example = "2024-01-01")
     LocalDate startDate,
     @Schema(description = "반복 뚜두 종료 날짜", example = "2024-12-31")
-    LocalDate endDate
+    LocalDate endDate,
+    @Schema(type = "string", pattern = "HH:mm", example = "14:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    LocalTime beginAt,
+    @Schema(type = "string", pattern = "HH:mm", example = "14:30")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    LocalTime endAt
 ) {
 
-  public static RepeatDduduSummary from(RepeatDdudu repeatDdudu) {
-    return new RepeatDduduSummary(
+  public static RepeatDduduDto from(RepeatDdudu repeatDdudu) {
+    return new RepeatDduduDto(
         repeatDdudu.getId(),
         repeatDdudu.getName(),
         repeatDdudu.getRepeatPattern(),
         repeatDdudu.getStartDate(),
-        repeatDdudu.getEndDate()
+        repeatDdudu.getEndDate(),
+        repeatDdudu.getBeginAt(),
+        repeatDdudu.getEndAt()
     );
   }
 

--- a/src/main/java/com/ddudu/application/service/ddudu/GetTimetableService.java
+++ b/src/main/java/com/ddudu/application/service/ddudu/GetTimetableService.java
@@ -3,6 +3,7 @@ package com.ddudu.application.service.ddudu;
 import com.ddudu.application.annotation.UseCase;
 import com.ddudu.application.domain.ddudu.domain.Timetable;
 import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
+import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.domain.user.domain.enums.Relationship;
@@ -44,10 +45,11 @@ public class GetTimetableService implements
     Timetable timetable = new Timetable(
         dduduLoaderPort.getDailyDdudus(date, user, accessiblePrivacyTypes));
 
-    List<TimeGroupedDdudus> assignedDdudus = timetable.getTimeGroupedDdudus();
-    List<GoalGroupedDdudus> unassignedDdudus = timetable.getUnassignedDdudusWithGoal(
-        goalLoaderPort.findAllByUserAndPrivacyTypes(user, accessiblePrivacyTypes)
-    );
+    // 4. 응답 생성 (데이터 변환)
+    List<Goal> goals = goalLoaderPort.findAllByUserAndPrivacyTypes(
+        user, accessiblePrivacyTypes);
+    List<TimeGroupedDdudus> assignedDdudus = timetable.getTimeGroupedDdudus(goals);
+    List<GoalGroupedDdudus> unassignedDdudus = timetable.getUnassignedDdudusWithGoal(goals);
 
     return TimetableResponse.of(assignedDdudus, unassignedDdudus);
   }

--- a/src/test/java/com/ddudu/application/service/ddudu/GetDailyDdudusByTimeServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/ddudu/GetDailyDdudusByTimeServiceTest.java
@@ -8,7 +8,7 @@ import com.ddudu.application.domain.ddudu.exception.DduduErrorCode;
 import com.ddudu.application.domain.goal.domain.Goal;
 import com.ddudu.application.domain.goal.domain.enums.PrivacyType;
 import com.ddudu.application.domain.user.domain.User;
-import com.ddudu.application.dto.ddudu.BasicDduduWithGoalIdAndTime;
+import com.ddudu.application.dto.ddudu.DduduForTimetable;
 import com.ddudu.application.dto.ddudu.response.TimetableResponse;
 import com.ddudu.application.port.out.auth.SignUpPort;
 import com.ddudu.application.port.out.ddudu.SaveDduduPort;
@@ -76,7 +76,7 @@ class GetDailyDdudusByTimeServiceTest {
     LocalTime earliestTime = response.timetable()
         .get(0)
         .beginAt();
-    BasicDduduWithGoalIdAndTime firstOfEarliestTime = response.timetable()
+    DduduForTimetable firstOfEarliestTime = response.timetable()
         .get(0)
         .ddudus()
         .get(0);
@@ -140,7 +140,7 @@ class GetDailyDdudusByTimeServiceTest {
     // then
     int countOfTime = response.timetable()
         .size();
-    BasicDduduWithGoalIdAndTime firstOfEarliestTime = response.timetable()
+    DduduForTimetable firstOfEarliestTime = response.timetable()
         .get(0)
         .ddudus()
         .get(0);

--- a/src/test/java/com/ddudu/application/service/goal/RetrieveGoalServiceTest.java
+++ b/src/test/java/com/ddudu/application/service/goal/RetrieveGoalServiceTest.java
@@ -8,7 +8,7 @@ import com.ddudu.application.domain.goal.exception.GoalErrorCode;
 import com.ddudu.application.domain.repeat_ddudu.domain.RepeatDdudu;
 import com.ddudu.application.domain.user.domain.User;
 import com.ddudu.application.dto.goal.response.GoalWithRepeatDduduResponse;
-import com.ddudu.application.dto.repeat_ddudu.RepeatDduduSummary;
+import com.ddudu.application.dto.repeat_ddudu.RepeatDduduDto;
 import com.ddudu.application.port.out.auth.SignUpPort;
 import com.ddudu.application.port.out.goal.GoalLoaderPort;
 import com.ddudu.application.port.out.goal.SaveGoalPort;
@@ -91,7 +91,7 @@ class RetrieveGoalServiceTest {
     GoalWithRepeatDduduResponse response = retrieveGoalService.getById(userId, goal.getId());
 
     // then
-    RepeatDduduSummary first = response.repeatDdudus()
+    RepeatDduduDto first = response.repeatDdudus()
         .get(0);
     RepeatDdudu actual = repeatDduduLoaderPort.getOptionalRepeatDdudu(first.id())
         .get();


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #240 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 타임테이블 조회 시 ddudus 하위에 color 컬럼 추가
- 목표 상세 조회 시 반복 뚜두에 beginAt, endAt 추가

### 변경 사항
#### 타임 테이블 조회 시 timetable > ddudus 하위에 color 컬럼 추가
<img width="1160" alt="스크린샷 2025-01-13 14 13 02" src="https://github.com/user-attachments/assets/e3e8841c-78fe-4418-8287-19612a97d2c4" />

#### 목표 상세 조회 시 반복 뚜두에 beginAt, endAt 추가 (존재 하지 않으면 null)
<img width="1295" alt="스크린샷 2025-01-13 14 11 26" src="https://github.com/user-attachments/assets/fb4ec5e0-a4d4-4047-8fde-7c5e7f340aaf" />
