### PR TITLE
Feat: 월 목표 별 달성률 통계 구현

### DIFF
--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/stats/AchievementPerGoal.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/stats/AchievementPerGoal.java
@@ -1,0 +1,17 @@
+package com.ddudu.application.common.dto.stats;
+
+import com.ddudu.aggregate.MonthlyStats;
+import lombok.Builder;
+
+@Builder
+public record AchievementPerGoal(Long goalId, String goalName, Integer achievementPercentage) {
+
+  public static AchievementPerGoal from(MonthlyStats monthlyStats) {
+    return AchievementPerGoal.builder()
+        .goalId(monthlyStats.getGoalId())
+        .goalName(monthlyStats.getGoalName())
+        .achievementPercentage(monthlyStats.calculateAchievementPercentage())
+        .build();
+  }
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/stats/CreationCountPerGoalDto.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/stats/CreationCountPerGoalDto.java
@@ -1,14 +1,16 @@
 package com.ddudu.application.common.dto.stats;
 
+import com.ddudu.aggregate.MonthlyStats;
 import lombok.Builder;
 
 @Builder
-public record CreationCountPerGoalDto(Long goalId, int count) {
+public record CreationCountPerGoalDto(Long goalId, String goalName, int count) {
 
-  public static CreationCountPerGoalDto from(Long goalId, int count) {
+  public static CreationCountPerGoalDto from(MonthlyStats monthlyStats) {
     return CreationCountPerGoalDto.builder()
-        .goalId(goalId)
-        .count(count)
+        .goalId(monthlyStats.getGoalId())
+        .goalName(monthlyStats.getGoalName())
+        .count(monthlyStats.size())
         .build();
   }
 

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/stats/in/CollectMonthlyAchievementUseCase.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/stats/in/CollectMonthlyAchievementUseCase.java
@@ -1,0 +1,11 @@
+package com.ddudu.application.common.port.stats.in;
+
+import com.ddudu.application.common.dto.stats.AchievementPerGoal;
+import com.ddudu.application.common.dto.stats.response.GenericStatsResponse;
+import java.time.YearMonth;
+
+public interface CollectMonthlyAchievementUseCase {
+
+  GenericStatsResponse<AchievementPerGoal> collectAchievement(Long loginId, YearMonth yearMonth);
+
+}

--- a/application/stats-application/src/main/java/com/ddudu/application/stats/service/CollectMonthlyAchievementService.java
+++ b/application/stats-application/src/main/java/com/ddudu/application/stats/service/CollectMonthlyAchievementService.java
@@ -1,0 +1,58 @@
+package com.ddudu.application.stats.service;
+
+import com.ddudu.aggregate.MonthlyStats;
+import com.ddudu.application.common.dto.stats.AchievementPerGoal;
+import com.ddudu.application.common.dto.stats.response.GenericStatsResponse;
+import com.ddudu.application.common.port.stats.in.CollectMonthlyAchievementUseCase;
+import com.ddudu.application.common.port.stats.out.MonthlyStatsPort;
+import com.ddudu.application.common.port.user.out.UserLoaderPort;
+import com.ddudu.common.annotation.UseCase;
+import com.ddudu.common.exception.StatsErrorCode;
+import com.ddudu.domain.user.user.aggregate.User;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CollectMonthlyAchievementService implements CollectMonthlyAchievementUseCase {
+
+  private static final int FIRST_DATE = 1;
+
+  private final UserLoaderPort userLoaderPort;
+  private final MonthlyStatsPort monthlyStatsPort;
+
+  @Override
+  public GenericStatsResponse<AchievementPerGoal> collectAchievement(
+      Long loginId,
+      YearMonth yearMonth
+  ) {
+    User user = userLoaderPort.getUserOrElseThrow(
+        loginId,
+        StatsErrorCode.USER_NOT_EXISTING.getCodeName()
+    );
+
+    if (Objects.isNull(yearMonth)) {
+      yearMonth = YearMonth.now();
+    }
+
+    LocalDate from = yearMonth.atDay(FIRST_DATE);
+    LocalDate to = yearMonth.atEndOfMonth();
+    MonthlyStats monthlyStats = monthlyStatsPort.collectMonthlyStats(user.getId(), null, from, to)
+        .getOrDefault(yearMonth, MonthlyStats.empty(user.getId(), yearMonth));
+    Map<Long, MonthlyStats> monthlyStatsPerGoal = monthlyStats.groupByGoal();
+    List<AchievementPerGoal> achievements = monthlyStatsPerGoal.values()
+        .stream()
+        .map(AchievementPerGoal::from)
+        .sorted((first, second) -> second.achievementPercentage() - first.achievementPercentage())
+        .toList();
+
+    return GenericStatsResponse.from(achievements);
+  }
+
+}

--- a/application/stats-application/src/test/java/com/ddudu/application/stats/service/CollectMonthlyAchievementServiceTest.java
+++ b/application/stats-application/src/test/java/com/ddudu/application/stats/service/CollectMonthlyAchievementServiceTest.java
@@ -1,0 +1,139 @@
+package com.ddudu.application.stats.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.ddudu.application.common.dto.stats.AchievementPerGoal;
+import com.ddudu.application.common.dto.stats.response.GenericStatsResponse;
+import com.ddudu.application.common.port.auth.out.SignUpPort;
+import com.ddudu.application.common.port.ddudu.out.SaveDduduPort;
+import com.ddudu.application.common.port.goal.out.SaveGoalPort;
+import com.ddudu.common.exception.StatsErrorCode;
+import com.ddudu.domain.planning.goal.aggregate.Goal;
+import com.ddudu.domain.user.user.aggregate.User;
+import com.ddudu.fixture.DduduFixture;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.UserFixture;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.MissingResourceException;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class CollectMonthlyAchievementServiceTest {
+
+  @Autowired
+  CollectMonthlyAchievementService collectMonthlyAchievementService;
+
+  @Autowired
+  SignUpPort signUpPort;
+
+  @Autowired
+  SaveGoalPort saveGoalPort;
+
+  @Autowired
+  SaveDduduPort saveDduduPort;
+
+  User user;
+  List<Goal> goals;
+  List<Integer> sizes;
+
+  @BeforeEach
+  void setUp() {
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    goals = saveGoalPort.saveAll(GoalFixture.createRandomGoalsWithUser(user.getId(), 5));
+    sizes = new ArrayList<>();
+
+    for (int i = 0; i < 5; i++) {
+      sizes.add(DduduFixture.getRandomInt(1, 100));
+    }
+
+    Iterator<Integer> sizeIterator = sizes.iterator();
+
+    goals.forEach(goal -> saveDduduPort.saveAll(DduduFixture.createMultipleDdudusWithGoal(
+        goal,
+        sizeIterator.next()
+    )));
+
+    sizes.sort(Comparator.reverseOrder());
+  }
+
+  @Test
+  void 이번_달_목표별_뚜두_달성률_통계를_내림차순으로_반환한다() {
+    // given
+    YearMonth thisMonth = YearMonth.now();
+
+    // when
+    GenericStatsResponse<AchievementPerGoal> response = collectMonthlyAchievementService.collectAchievement(
+        user.getId(),
+        thisMonth
+    );
+
+    // then
+    assertThat(response.contents()).hasSize(goals.size());
+  }
+
+  @Test
+  void 목표에_해당_달의_뚜두_데이터가_없으면_통계에_포함되지_않는다() {
+    // given
+    YearMonth lastMonth = YearMonth.now()
+        .minusMonths(1);
+
+    // when
+    GenericStatsResponse<AchievementPerGoal> response = collectMonthlyAchievementService.collectAchievement(
+        user.getId(),
+        lastMonth
+    );
+
+    // then
+    assertThat(response.isEmpty()).isTrue();
+  }
+
+  @ParameterizedTest
+  @NullSource
+  void 날짜가_null이면_이번_달_통계를_반환한다(YearMonth yearMonth) {
+    // given
+
+    // when
+    GenericStatsResponse<AchievementPerGoal> response = collectMonthlyAchievementService.collectAchievement(
+        user.getId(),
+        yearMonth
+    );
+
+    // then
+    assertThat(response.contents()).hasSize(goals.size());
+  }
+
+  @Test
+  void 존재하지_않는_사용자_ID이면_예외를_던진다() {
+    // given
+    long invalidId = GoalFixture.getRandomId();
+    YearMonth thisMonth = YearMonth.now();
+
+    // when
+    ThrowingCallable collect = () -> collectMonthlyAchievementService.collectAchievement(
+        invalidId,
+        thisMonth
+    );
+
+    // then
+    assertThatExceptionOfType(MissingResourceException.class)
+        .isThrownBy(collect)
+        .withMessage(StatsErrorCode.USER_NOT_EXISTING.getCodeName());
+  }
+
+}

--- a/application/stats-application/src/test/java/com/ddudu/application/stats/service/CollectMonthlyStatsSummaryTest.java
+++ b/application/stats-application/src/test/java/com/ddudu/application/stats/service/CollectMonthlyStatsSummaryTest.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @Transactional
 @DisplayNameGeneration(ReplaceUnderscores.class)
-class CollectNumberStatsServiceTest {
+class CollectMonthlyStatsSummaryTest {
 
   @Autowired
   CollectMonthlyStatsSummaryService collectMonthlyStatsService;

--- a/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/StatsErrorExamples.java
+++ b/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/StatsErrorExamples.java
@@ -23,4 +23,18 @@ public final class StatsErrorExamples {
       }
       """;
 
+  public static final String STATS_MONTHLY_STATS_EMPTY = """
+      {
+        "code": 9004,
+        "message": "월 통계 데이터가 없습니다."
+      }
+      """;
+
+  public static final String STATS_MONTHLY_MONTHLY_STATS_NOT_GROUPED_BY_GOAL = """
+      {
+        "code": 9005,
+        "message": "다른 목표의 스탯이 포함되어 있습니다."
+      }
+      """;
+
 }

--- a/bootstrap/stats-api/src/main/java/com/ddudu/api/stats/controller/StatsController.java
+++ b/bootstrap/stats-api/src/main/java/com/ddudu/api/stats/controller/StatsController.java
@@ -3,11 +3,13 @@ package com.ddudu.api.stats.controller;
 import static java.util.Objects.isNull;
 
 import com.ddudu.api.stats.doc.StatsControllerDoc;
+import com.ddudu.application.common.dto.stats.AchievementPerGoal;
 import com.ddudu.application.common.dto.stats.CreationCountPerGoalDto;
 import com.ddudu.application.common.dto.stats.response.DduduCompletionResponse;
 import com.ddudu.application.common.dto.stats.response.GenericStatsResponse;
 import com.ddudu.application.common.dto.stats.response.MonthlyStatsSummaryResponse;
 import com.ddudu.application.common.port.stats.in.CalculateCompletionUseCase;
+import com.ddudu.application.common.port.stats.in.CollectMonthlyAchievementUseCase;
 import com.ddudu.application.common.port.stats.in.CollectMonthlyCreationStatsUseCase;
 import com.ddudu.application.common.port.stats.in.CollectMonthlyStatsSummaryUseCase;
 import com.ddudu.bootstrap.common.annotation.Login;
@@ -30,11 +32,12 @@ public class StatsController implements StatsControllerDoc {
   private final CollectMonthlyStatsSummaryUseCase collectMonthlyStatsSummaryUseCase;
   private final CollectMonthlyCreationStatsUseCase collectMonthlyCreationStatsUseCase;
   private final CalculateCompletionUseCase calculateCompletionUseCase;
+  private final CollectMonthlyAchievementUseCase collectMonthlyAchievementUseCase;
 
   /**
    * 월별 뚜두 완료율 조회 API (달성 뚜두 수 / 생성 뚜두 수)
    */
-  @GetMapping("/monthly")
+  @GetMapping("/completion/monthly")
   public ResponseEntity<List<DduduCompletionResponse>> getMonthlyCompletion(
       @Login
       Long loginId,
@@ -105,6 +108,23 @@ public class StatsController implements StatsControllerDoc {
       YearMonth yearMonth
   ) {
     GenericStatsResponse<CreationCountPerGoalDto> response = collectMonthlyCreationStatsUseCase.collectCreation(
+        loginId,
+        yearMonth
+    );
+
+    return ResponseEntity.ok(response);
+  }
+
+  @Override
+  @GetMapping("/achievement")
+  public ResponseEntity<GenericStatsResponse<AchievementPerGoal>> collectAchievement(
+      @Login
+      Long loginId,
+      @RequestParam(required = false)
+      @DateTimeFormat(pattern = "yyyy-MM")
+      YearMonth yearMonth
+  ) {
+    GenericStatsResponse<AchievementPerGoal> response = collectMonthlyAchievementUseCase.collectAchievement(
         loginId,
         yearMonth
     );

--- a/bootstrap/stats-api/src/main/java/com/ddudu/api/stats/doc/StatsControllerDoc.java
+++ b/bootstrap/stats-api/src/main/java/com/ddudu/api/stats/doc/StatsControllerDoc.java
@@ -1,5 +1,6 @@
 package com.ddudu.api.stats.doc;
 
+import com.ddudu.application.common.dto.stats.AchievementPerGoal;
 import com.ddudu.application.common.dto.stats.CreationCountPerGoalDto;
 import com.ddudu.application.common.dto.stats.response.DduduCompletionResponse;
 import com.ddudu.application.common.dto.stats.response.GenericStatsResponse;
@@ -237,6 +238,71 @@ public interface StatsControllerDoc {
       example = "2024-08"
   )
   ResponseEntity<GenericStatsResponse<CreationCountPerGoalDto>> collectCreation(
+      Long loginId,
+      YearMonth yearMonth
+  );
+
+  @Operation(summary = "월 별 목표들의 뚜두 달성률 통계")
+  @ApiResponses(
+      {
+          @ApiResponse(
+              responseCode = "200",
+              description = "OK",
+              useReturnTypeSchema = true
+          ),
+          @ApiResponse(
+              responseCode = "401",
+              description = "UNAUTHORIZED",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "5002",
+                      value = AuthErrorExamples.AUTH_BAD_TOKEN_CONTENT
+                  )
+              )
+          ),
+          @ApiResponse(
+              responseCode = "404",
+              description = "NOT_FOUND",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "9002",
+                      description = "로그인 사용자 아이디가 유효하지 않는 경우",
+                      value = StatsErrorExamples.STATS_LOGIN_USER_NOT_FOUND
+                  )
+              )
+          ),
+          @ApiResponse(
+              responseCode = "500",
+              description = "INTERNAL_SERVER_ERROR",
+              content = @Content(
+                  examples = {
+                      @ExampleObject(
+                          name = "9001",
+                          description = "서버 내부 문제로 뚜두 상태 파싱에 실패한 경우",
+                          value = StatsErrorExamples.STATS_INVALID_DDUDU_STATS
+                      ),
+                      @ExampleObject(
+                          name = "9004",
+                          description = "서버 내부 문제로 뚜두 데이터가 없는 월의 통계 시도할 경우",
+                          value = StatsErrorExamples.STATS_MONTHLY_STATS_EMPTY
+                      ),
+                      @ExampleObject(
+                          name = "9005",
+                          description = "서버 내부 문제로 월의 통계 시도 시 다른 월의 뚜두가 포함될 경우",
+                          value = StatsErrorExamples.STATS_MONTHLY_MONTHLY_STATS_NOT_GROUPED_BY_GOAL
+                      )
+                  }
+              )
+          )
+      }
+  )
+  @Parameter(
+      name = "yearMonth",
+      description = "통계 조회 대상 기간 월 (기본값: 이번 달)",
+      in = ParameterIn.QUERY,
+      example = "2024-08"
+  )
+  ResponseEntity<GenericStatsResponse<AchievementPerGoal>> collectAchievement(
       Long loginId,
       YearMonth yearMonth
   );

--- a/common/src/main/java/com/ddudu/common/exception/StatsErrorCode.java
+++ b/common/src/main/java/com/ddudu/common/exception/StatsErrorCode.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 public enum StatsErrorCode implements ErrorCode {
   INVALID_DDUDU_STATUS(9001, "유효한 뚜두 상태가 아닙니다."),
   LOGIN_USER_NOT_EXISTING(9002, "로그인 사용자가 존재하지 않습니다."),
-  USER_NOT_EXISTING(9003, "사용자가 존재하지 않습니다.")
+  USER_NOT_EXISTING(9003, "사용자가 존재하지 않습니다."),
+  MONTHLY_STATS_EMPTY(9004, "월 통계 데이터가 없습니다."),
+  MONTHLY_STATS_NOT_GROUPED_BY_GOAL(9005, "다른 목표의 스탯이 포함되어 있습니다.")
   ;
 
   private final int code;

--- a/domain/stats-domain/src/main/java/com/ddudu/aggregate/BaseStats.java
+++ b/domain/stats-domain/src/main/java/com/ddudu/aggregate/BaseStats.java
@@ -3,22 +3,30 @@ package com.ddudu.aggregate;
 import com.ddudu.aggregate.enums.DduduStatus;
 import java.time.LocalDate;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
 @Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class BaseStats {
 
+  @EqualsAndHashCode.Include
   private final Long dduduId;
   private final Long goalId;
+  private final String goalName;
   private final DduduStatus status;
   private final boolean isPostponed;
   private final LocalDate scheduledOn;
 
   public boolean isCompleted() {
     return status.isCompleted();
+  }
+
+  public boolean isUnderSameGoal(Long goalId) {
+    return this.goalId.equals(goalId);
   }
 
 }

--- a/domain/stats-domain/src/test/java/com/ddudu/aggregate/MonthlyStatsTest.java
+++ b/domain/stats-domain/src/test/java/com/ddudu/aggregate/MonthlyStatsTest.java
@@ -1,12 +1,17 @@
 package com.ddudu.aggregate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatRuntimeException;
+
+import com.ddudu.common.exception.StatsErrorCode;
 import com.ddudu.fixtures.BaseStatsFixture;
 import com.ddudu.fixtures.MonthlyStatsFixture;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
-import org.assertj.core.api.Assertions;
+import java.util.Map;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -29,6 +34,114 @@ class MonthlyStatsTest {
     userId = BaseStatsFixture.getRandomId();
     goalId = BaseStatsFixture.getRandomId();
     stats = new ArrayList<>();
+  }
+
+  @Nested
+  class 월_통계_목표_그룹핑_테스트 {
+
+    Long anotherGoalId;
+
+    @BeforeEach
+    void setUp() {
+      anotherGoalId = BaseStatsFixture.getRandomId();
+      totalSize = BaseStatsFixture.getRandomInt(10, 100);
+      completedSize = BaseStatsFixture.getRandomInt(1, totalSize);
+      uncompletedSize = totalSize - completedSize;
+
+      stats.addAll(BaseStatsFixture.createNotPostponedStats(goalId, completedSize));
+      stats.addAll(BaseStatsFixture.createNotPostponedStats(anotherGoalId, uncompletedSize));
+
+      monthlyStats = MonthlyStatsFixture.createMonthlyStats(userId, YearMonth.now(), stats);
+    }
+
+    @Test
+    void 목표_별_그룹핑을_성공한다() {
+      // when
+      Map<Long, MonthlyStats> actual = monthlyStats.groupByGoal();
+
+      // then
+      assertThat(actual).containsKeys(goalId, anotherGoalId);
+      assertThat(actual.get(goalId).getStats()).hasSize(completedSize);
+      assertThat(actual.get(anotherGoalId).getStats()).hasSize(uncompletedSize);
+    }
+
+    @Test
+    void 목표로_그룹핑_된_통계의_목표_아이디를_반환한다() {
+      // given
+      Map<Long, MonthlyStats> byGoal = monthlyStats.groupByGoal();
+
+      // when
+      Long actual = byGoal.get(goalId)
+          .getGoalId();
+
+      // then
+      assertThat(actual).isEqualTo(goalId);
+    }
+
+    @Test
+    void 통계_데이터가_없는_월_통계의_목표_아이디_반환을_실패한다() {
+      // given
+      MonthlyStats empty = MonthlyStats.empty(userId, YearMonth.now());
+
+      // when
+      ThrowingCallable getGoalId = () -> empty.getGoalId();
+
+      // then
+      assertThatRuntimeException().isThrownBy(getGoalId)
+          .withMessage(StatsErrorCode.MONTHLY_STATS_EMPTY.getCodeName());
+    }
+
+    @Test
+    void 목표가_여러개인_월_통계의_목표_아이디_반환을_실패한다() {
+      // given
+
+      // when
+      ThrowingCallable getGoalId = () -> monthlyStats.getGoalId();
+
+      // then
+      assertThatRuntimeException().isThrownBy(getGoalId)
+          .withMessage(StatsErrorCode.MONTHLY_STATS_NOT_GROUPED_BY_GOAL.getCodeName());
+    }
+
+    @Test
+    void 통계_데이터가_없는_월_통계의_목표명_반환을_실패한다() {
+      // given
+      MonthlyStats empty = MonthlyStats.empty(userId, YearMonth.now());
+
+      // when
+      ThrowingCallable getGoalName = () -> empty.getGoalName();
+
+      // then
+      assertThatRuntimeException().isThrownBy(getGoalName)
+          .withMessage(StatsErrorCode.MONTHLY_STATS_EMPTY.getCodeName());
+    }
+
+    @Test
+    void 목표가_여러개인_월_통계의_목표명_반환을_실패한다() {
+      // given
+
+      // when
+      ThrowingCallable getGoalName = () -> monthlyStats.getGoalName();
+
+      // then
+      assertThatRuntimeException().isThrownBy(getGoalName)
+          .withMessage(StatsErrorCode.MONTHLY_STATS_NOT_GROUPED_BY_GOAL.getCodeName());
+    }
+
+    @Test
+    void 목표로_그룹핑_된_통계의_목표명을_반환한다() {
+      // given
+      Map<Long, MonthlyStats> byGoal = monthlyStats.groupByGoal();
+      String expected = String.valueOf(goalId);
+
+      // when
+      String actual = byGoal.get(goalId)
+          .getGoalName();
+
+      // then
+      assertThat(actual).isEqualTo(expected);
+    }
+
   }
 
   @Nested
@@ -55,7 +168,7 @@ class MonthlyStatsTest {
       int actual = monthlyStats.calculateAchievementPercentage();
 
       // then
-      Assertions.assertThat(actual)
+      assertThat(actual)
           .isEqualTo(expected);
     }
 
@@ -68,7 +181,7 @@ class MonthlyStatsTest {
       int actual = emptyStats.calculateAchievementPercentage();
 
       // then
-      Assertions.assertThat(actual)
+      assertThat(actual)
           .isZero();
     }
 
@@ -99,7 +212,7 @@ class MonthlyStatsTest {
       int actual = monthlyStats.calculateSustenanceCount();
 
       // then
-      Assertions.assertThat(actual)
+      assertThat(actual)
           .isEqualTo(completedSize);
     }
 
@@ -112,7 +225,7 @@ class MonthlyStatsTest {
       int actual = emptyStats.calculateSustenanceCount();
 
       // then
-      Assertions.assertThat(actual)
+      assertThat(actual)
           .isZero();
     }
 
@@ -141,7 +254,7 @@ class MonthlyStatsTest {
       int actual = monthlyStats.calculatePostponementCount();
 
       // then
-      Assertions.assertThat(actual)
+      assertThat(actual)
           .isEqualTo(uncompletedSize);
     }
 
@@ -154,7 +267,7 @@ class MonthlyStatsTest {
       int actual = emptyStats.calculatePostponementCount();
 
       // then
-      Assertions.assertThat(actual)
+      assertThat(actual)
           .isZero();
     }
 
@@ -184,7 +297,7 @@ class MonthlyStatsTest {
       int actual = monthlyStats.calculateReattainmentCount();
 
       // then
-      Assertions.assertThat(actual)
+      assertThat(actual)
           .isEqualTo(expected);
     }
 
@@ -197,7 +310,7 @@ class MonthlyStatsTest {
       int actual = emptyStats.calculateReattainmentCount();
 
       // then
-      Assertions.assertThat(actual)
+      assertThat(actual)
           .isZero();
     }
 

--- a/domain/stats-domain/src/testFixtures/java/com/ddudu/fixtures/BaseStatsFixture.java
+++ b/domain/stats-domain/src/testFixtures/java/com/ddudu/fixtures/BaseStatsFixture.java
@@ -193,6 +193,7 @@ public final class BaseStatsFixture extends BaseFixture {
     return BaseStats.builder()
         .dduduId(dduduId)
         .goalId(goalId)
+        .goalName(goalId.toString())
         .status(status)
         .scheduledOn(scheduledOn)
         .isPostponed(isPostponed)

--- a/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/repository/DduduQueryRepositoryImpl.java
+++ b/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/repository/DduduQueryRepositoryImpl.java
@@ -288,6 +288,7 @@ public class DduduQueryRepositoryImpl implements DduduQueryRepository {
         BaseStats.class,
         dduduEntity.id.as("dduduId"),
         goalEntity.id,
+        goalEntity.name,
         status,
         dduduEntity.isPostponed,
         dduduEntity.scheduledOn


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
- Resolves #182 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 월 목표 별 달성률 통계 구현
- 기본 통계 정보에 목표명 추가
- 월 통계 도메인에 목표 별 그룹핑 추가
- 목표 별 그룹핑된 월 통계에서 공통 정보(목표아이디, 목표명) 사용 시 검증 추가
- 뚜두 생성 수 통계에 해당 변경 사항 반영