### PR TITLE
Feat: 미리알림 설정 기능

### DIFF
--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/ddudu/request/SetReminderRequest.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/ddudu/request/SetReminderRequest.java
@@ -1,0 +1,14 @@
+package com.ddudu.application.common.dto.ddudu.request;
+
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record SetReminderRequest(
+    @PositiveOrZero(message = "2020 NEGATIVE_REMINDER_INPUT_EXISTS")
+    int days,
+    @PositiveOrZero(message = "2020 NEGATIVE_REMINDER_INPUT_EXISTS")
+    int hours,
+    @PositiveOrZero(message = "2020 NEGATIVE_REMINDER_INPUT_EXISTS")
+    int minutes
+) {
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/ddudu/in/SetReminderUseCase.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/ddudu/in/SetReminderUseCase.java
@@ -1,0 +1,9 @@
+package com.ddudu.application.common.port.ddudu.in;
+
+import com.ddudu.application.common.dto.ddudu.request.SetReminderRequest;
+
+public interface SetReminderUseCase {
+
+  void setReminder(Long loginId, Long id, SetReminderRequest request);
+
+}

--- a/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/SetReminderService.java
+++ b/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/SetReminderService.java
@@ -1,0 +1,46 @@
+package com.ddudu.application.planning.ddudu.service;
+
+import com.ddudu.application.common.dto.ddudu.request.SetReminderRequest;
+import com.ddudu.application.common.port.ddudu.in.SetReminderUseCase;
+import com.ddudu.application.common.port.ddudu.out.DduduLoaderPort;
+import com.ddudu.application.common.port.ddudu.out.DduduUpdatePort;
+import com.ddudu.application.common.port.user.out.UserLoaderPort;
+import com.ddudu.common.annotation.UseCase;
+import com.ddudu.common.exception.DduduErrorCode;
+import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
+import com.ddudu.domain.user.user.aggregate.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class SetReminderService implements SetReminderUseCase {
+
+  private final UserLoaderPort userLoaderPort;
+  private final DduduLoaderPort dduduLoaderPort;
+  private final DduduUpdatePort dduduUpdatePort;
+
+  @Override
+  public void setReminder(Long loginId, Long id, SetReminderRequest request) {
+    User user = userLoaderPort.getUserOrElseThrow(
+        loginId,
+        DduduErrorCode.LOGIN_USER_NOT_EXISTING.getCodeName()
+    );
+    Ddudu ddudu = dduduLoaderPort.getDduduOrElseThrow(
+        id,
+        DduduErrorCode.ID_NOT_EXISTING.getCodeName()
+    );
+
+    ddudu.validateDduduCreator(user.getId());
+
+    Ddudu dduduWithReminder = ddudu.setReminder(request.days(), request.hours(), request.minutes());
+
+    dduduUpdatePort.update(dduduWithReminder);
+
+    if (ddudu.isScheduledToday()) {
+      // TODO: TaskScheduler 구현 후 Scheduler에 추가하기
+    }
+  }
+
+}

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/ChangeNameServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/ChangeNameServiceTest.java
@@ -110,7 +110,7 @@ class ChangeNameServiceTest {
 
     // then
     Assertions.assertThatThrownBy(changeName)
-        .isInstanceOf(SecurityException.class)
+        .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
   }
 

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/DeleteDduduServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/DeleteDduduServiceTest.java
@@ -81,7 +81,7 @@ class DeleteDduduServiceTest {
     ThrowingCallable delete = () -> deleteDduduService.delete(anotherUser.getId(), ddudu.getId());
 
     // then
-    Assertions.assertThatExceptionOfType(SecurityException.class)
+    Assertions.assertThatExceptionOfType(UnsupportedOperationException.class)
         .isThrownBy(delete)
         .withMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
   }

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/MoveDateServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/MoveDateServiceTest.java
@@ -81,7 +81,8 @@ class MoveDateServiceTest {
     LocalDate yesterday = LocalDate.now()
         .minusDays(1);
     Ddudu pastDdudu = saveDduduPort.save(DduduFixture.createRandomDduduWithSchedule(
-        goal,
+        user.getId(),
+        goal.getId(),
         yesterday
     ));
     MoveDateRequest request = new MoveDateRequest(LocalDate.now());
@@ -101,7 +102,8 @@ class MoveDateServiceTest {
     LocalDate twoDaysAgo = LocalDate.now()
         .minusDays(2);
     Ddudu pastDdudu = saveDduduPort.save(DduduFixture.createRandomDduduWithSchedule(
-        goal,
+        user.getId(),
+        goal.getId(),
         twoDaysAgo
     ));
     LocalDate yesterday = LocalDate.now()

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/RetrieveDduduServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/RetrieveDduduServiceTest.java
@@ -97,7 +97,7 @@ class RetrieveDduduServiceTest {
 
     // then
     AssertionsForClassTypes.assertThatThrownBy(callable)
-        .isInstanceOf(SecurityException.class)
+        .isInstanceOf(UnsupportedOperationException.class)
         .hasMessageContaining(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
   }
 

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/SetReminderServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/SetReminderServiceTest.java
@@ -1,0 +1,138 @@
+package com.ddudu.application.planning.ddudu.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddudu.application.common.dto.ddudu.request.SetReminderRequest;
+import com.ddudu.application.common.port.auth.out.SignUpPort;
+import com.ddudu.application.common.port.ddudu.out.DduduLoaderPort;
+import com.ddudu.application.common.port.ddudu.out.SaveDduduPort;
+import com.ddudu.application.common.port.goal.out.SaveGoalPort;
+import com.ddudu.common.exception.DduduErrorCode;
+import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
+import com.ddudu.domain.planning.goal.aggregate.Goal;
+import com.ddudu.domain.user.user.aggregate.User;
+import com.ddudu.fixture.DduduFixture;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.UserFixture;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.MissingResourceException;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class SetReminderServiceTest {
+
+  @Autowired
+  SetReminderService setReminderService;
+
+  @Autowired
+  SignUpPort signUpPort;
+
+  @Autowired
+  SaveGoalPort saveGoalPort;
+
+  @Autowired
+  SaveDduduPort saveDduduPort;
+
+  @Autowired
+  DduduLoaderPort dduduLoaderPort;
+
+  User user;
+  Goal goal;
+  Ddudu ddudu;
+
+  @BeforeEach
+  void setUp() {
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user.getId()));
+    LocalTime beginAt = LocalTime.now()
+        .plusHours(1);
+    ddudu = saveDduduPort.save(DduduFixture.createRandomDduduWithGoalAndTime(goal, beginAt, null));
+  }
+
+  @Test
+  void 미리알림을_설정한다() {
+    // given
+    SetReminderRequest request = new SetReminderRequest(0, 0, 30);
+
+    // when
+    setReminderService.setReminder(user.getId(), ddudu.getId(), request);
+
+    // then
+    Ddudu actual = dduduLoaderPort.getDduduOrElseThrow(ddudu.getId(), "not found");
+    LocalDateTime expected = ddudu.getScheduledOn()
+        .atTime(ddudu.getBeginAt())
+        .minusHours(request.hours())
+        .minusMinutes(request.minutes());
+
+    assertThat(actual.getRemindAt()).isEqualTo(expected);
+  }
+
+  @Test
+  void 존재하지_않는_사용자는_미리알림_설정에_실패한다() {
+    // given
+    long invalidId = DduduFixture.getRandomId();
+    SetReminderRequest request = new SetReminderRequest(0, 1, 0);
+
+    // when
+    ThrowingCallable setReminder = () -> setReminderService.setReminder(
+        invalidId,
+        ddudu.getId(),
+        request
+    );
+
+    // then
+    Assertions.assertThatExceptionOfType(MissingResourceException.class)
+        .isThrownBy(setReminder)
+        .withMessage(DduduErrorCode.LOGIN_USER_NOT_EXISTING.getCodeName());
+  }
+
+  @Test
+  void 존재하지_않는_뚜두는_미리알림_설정에_실패한다() {
+    // given
+    long invalidId = DduduFixture.getRandomId();
+    SetReminderRequest request = new SetReminderRequest(0, 1, 0);
+
+    // when
+    ThrowingCallable setReminder = () -> setReminderService.setReminder(
+        user.getId(),
+        invalidId,
+        request
+    );
+
+    // then
+    Assertions.assertThatExceptionOfType(MissingResourceException.class)
+        .isThrownBy(setReminder)
+        .withMessage(DduduErrorCode.ID_NOT_EXISTING.getCodeName());
+  }
+
+  @Test
+  void 다른_사용자는_미리알림_설정에_실패한다() {
+    // given
+    User another = signUpPort.save(UserFixture.createRandomUserWithId());
+    SetReminderRequest request = new SetReminderRequest(0, 1, 0);
+
+    // when
+    ThrowingCallable setReminder = () -> setReminderService.setReminder(
+        another.getId(),
+        ddudu.getId(),
+        request
+    );
+
+    // then
+    Assertions.assertThatExceptionOfType(UnsupportedOperationException.class)
+        .isThrownBy(setReminder)
+        .withMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
+  }
+
+}

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/SwitchStatusServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/SwitchStatusServiceTest.java
@@ -98,7 +98,7 @@ class SwitchStatusServiceTest {
     );
 
     // then
-    AssertionsForClassTypes.assertThatExceptionOfType(SecurityException.class)
+    AssertionsForClassTypes.assertThatExceptionOfType(UnsupportedOperationException.class)
         .isThrownBy(updateStatus)
         .withMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
   }

--- a/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/DduduErrorExamples.java
+++ b/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/DduduErrorExamples.java
@@ -107,4 +107,40 @@ public final class DduduErrorExamples {
       }
       """;
 
+  public static final String GOAL_ALREADY_DONE = """
+      {
+        "code": 2016,
+        "message": "목표가 이미 완료되었습니다."
+      }
+      """;
+
+  public static final String BEGIN_AT_REQUIRED_FOR_REMINDER = """
+      {
+        "code": 2017,
+        "message": "시작 시간 없이 미리알림을 설정할 수 없습니다."
+      }
+      """;
+
+  public static final String REMINDER_NOT_AFTER_NOW = """
+      {
+        "code": 2018,
+        "message": "미리알림 시간은 현재 시간보다 이후여야 합니다."
+      }
+      """;
+
+  public static final String ZERO_REMINDER = """
+      {
+        "code": 2019,
+        "message": "미리알림 입력값이 없습니다."
+      }
+      """;
+
+  public static final String NEGATIVE_REMINDER_INPUT_EXISTS = """
+      {
+        "code": 2020,
+        "message": "미리알림을 입력값 중 음수가 포함되어 있습니다."
+      }
+      """;
+
+
 }

--- a/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/exception/GlobalExceptionHandler.java
+++ b/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -132,7 +133,7 @@ public class GlobalExceptionHandler {
   private List<ErrorResponse> convertToErrorResponses(MethodArgumentNotValidException e) {
     return e.getFieldErrors()
         .stream()
-        .map(fieldError -> ErrorResponse.from(INVALID_INPUT_CODE, fieldError.getDefaultMessage()))
+        .map(this::parseFromFieldError)
         .toList();
   }
 
@@ -151,6 +152,12 @@ public class GlobalExceptionHandler {
         .collect(Collectors.joining(", "));
 
     return enumTypeName + "는 [" + validValues + "] 중 하나여야 합니다.";
+  }
+
+  private ErrorResponse parseFromFieldError(FieldError fieldError) {
+    ErrorCode errorCode = errorCodeParser.parse(fieldError.getDefaultMessage());
+
+    return ErrorResponse.from(errorCode);
   }
 
 }

--- a/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/controller/DduduController.java
+++ b/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/controller/DduduController.java
@@ -12,6 +12,7 @@ import com.ddudu.application.common.dto.ddudu.request.DduduSearchRequest;
 import com.ddudu.application.common.dto.ddudu.request.MoveDateRequest;
 import com.ddudu.application.common.dto.ddudu.request.PeriodSetupRequest;
 import com.ddudu.application.common.dto.ddudu.request.RepeatAnotherDayRequest;
+import com.ddudu.application.common.dto.ddudu.request.SetReminderRequest;
 import com.ddudu.application.common.dto.ddudu.response.BasicDduduResponse;
 import com.ddudu.application.common.dto.ddudu.response.DduduDetailResponse;
 import com.ddudu.application.common.dto.ddudu.response.RepeatAnotherDayResponse;
@@ -27,6 +28,7 @@ import com.ddudu.application.common.port.ddudu.in.MoveDateUseCase;
 import com.ddudu.application.common.port.ddudu.in.PeriodSetupUseCase;
 import com.ddudu.application.common.port.ddudu.in.RepeatUseCase;
 import com.ddudu.application.common.port.ddudu.in.RetrieveDduduUseCase;
+import com.ddudu.application.common.port.ddudu.in.SetReminderUseCase;
 import com.ddudu.application.common.port.ddudu.in.SwitchStatusUseCase;
 import com.ddudu.bootstrap.common.annotation.Login;
 import jakarta.validation.Valid;
@@ -64,6 +66,7 @@ public class DduduController implements DduduControllerDoc {
   private final SwitchStatusUseCase switchStatusUseCase;
   private final ChangeNameUseCase changeNameUseCase;
   private final DeleteDduduUseCase deleteDduduUseCase;
+  private final SetReminderUseCase setReminderUseCase;
 
   /**
    * 뚜두 생성 API
@@ -150,6 +153,23 @@ public class DduduController implements DduduControllerDoc {
     DduduDetailResponse response = retrieveDduduUseCase.findById(loginId, id);
 
     return ResponseEntity.ok(response);
+  }
+
+  @Override
+  @PatchMapping("/{id}/reminder")
+  public ResponseEntity<Void> setReminder(
+      @Login
+      Long loginId,
+      @PathVariable("id")
+      Long id,
+      @RequestBody
+      @Valid
+      SetReminderRequest request
+  ) {
+    setReminderUseCase.setReminder(loginId, id, request);
+
+    return ResponseEntity.noContent()
+        .build();
   }
 
   /**

--- a/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/doc/DduduControllerDoc.java
+++ b/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/doc/DduduControllerDoc.java
@@ -9,6 +9,7 @@ import com.ddudu.application.common.dto.ddudu.request.DduduSearchRequest;
 import com.ddudu.application.common.dto.ddudu.request.MoveDateRequest;
 import com.ddudu.application.common.dto.ddudu.request.PeriodSetupRequest;
 import com.ddudu.application.common.dto.ddudu.request.RepeatAnotherDayRequest;
+import com.ddudu.application.common.dto.ddudu.request.SetReminderRequest;
 import com.ddudu.application.common.dto.ddudu.response.DduduDetailResponse;
 import com.ddudu.application.common.dto.ddudu.response.RepeatAnotherDayResponse;
 import com.ddudu.application.common.dto.ddudu.response.TimetableResponse;
@@ -559,7 +560,9 @@ public interface DduduControllerDoc {
       }
   )
   ResponseEntity<RepeatAnotherDayResponse> repeatOnAnotherDay(
-      Long loginId, Long id, RepeatAnotherDayRequest request
+      Long loginId,
+      Long id,
+      RepeatAnotherDayRequest request
   );
 
   @Operation(summary = "뚜두 검색")
@@ -587,5 +590,58 @@ public interface DduduControllerDoc {
       @ParameterObject
       DduduSearchRequest request
   );
+
+  @Operation(summary = "미리알림 설정")
+  @ApiResponses(
+      {
+          @ApiResponse(
+              responseCode = "204",
+              description = "NO CONTENT"
+          ),
+          @ApiResponse(
+              responseCode = "400",
+              description = "BAD REQUEST",
+              content = @Content(
+                  examples = {
+                      @ExampleObject(
+                        name = "2008",
+                        value = DduduErrorExamples.DDUDU_LOGIN_USER_NOT_EXISTING
+                      ),
+                      @ExampleObject(
+                          name = "2004",
+                          value = DduduErrorExamples.DDUDU_ID_NOT_EXISTING
+                      ),
+                      @ExampleObject(
+                          name = "2017",
+                          value = DduduErrorExamples.BEGIN_AT_REQUIRED_FOR_REMINDER
+                      ),
+                      @ExampleObject(
+                          name = "2018",
+                          value = DduduErrorExamples.REMINDER_NOT_AFTER_NOW
+                      ),
+                      @ExampleObject(
+                          name = "2019",
+                          value = DduduErrorExamples.ZERO_REMINDER
+                      ),
+                      @ExampleObject(
+                          name = "2020",
+                          value = DduduErrorExamples.NEGATIVE_REMINDER_INPUT_EXISTS
+                      )
+                  }
+              )
+          ),
+          @ApiResponse(
+              responseCode = "401",
+              description = "UNAUTHORIZED",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "5002",
+                      value = AuthErrorExamples.AUTH_BAD_TOKEN_CONTENT
+                  )
+              )
+          )
+      }
+  )
+  ResponseEntity<Void> setReminder(Long loginId, Long dduduId, SetReminderRequest request);
 
 }

--- a/common/src/main/java/com/ddudu/common/exception/DduduErrorCode.java
+++ b/common/src/main/java/com/ddudu/common/exception/DduduErrorCode.java
@@ -22,7 +22,11 @@ public enum DduduErrorCode implements ErrorCode {
   UNABLE_TO_REPRODUCE_ON_SAME_DATE(2013, "다시 하기의 날짜는 기존과 달라야합니다."),
   NEGATIVE_OR_ZERO_GOAL_ID(2014, "목표 ID는 양수입니다."),
   NULL_SCHEDULED_DATE(2015, "날짜는 필수값입니다."),
-  GOAL_ALREADY_DONE(2016, "목표가 이미 완료되었습니다.");
+  GOAL_ALREADY_DONE(2016, "목표가 이미 완료되었습니다."),
+  BEGIN_AT_REQUIRED_FOR_REMINDER(2017, "시작 시간 없이 미리알림을 설정할 수 없습니다."),
+  REMINDER_NOT_AFTER_NOW(2018, "미리알림 시간은 현재 시간보다 이후여야 합니다."),
+  ZERO_REMINDER(2019, "미리알림 입력값이 없습니다."),
+  NEGATIVE_REMINDER_INPUT_EXISTS(2020, "미리알림을 입력값 중 음수가 포함되어 있습니다.");
 
   private final int code;
   private final String message;

--- a/common/src/main/java/com/ddudu/common/exception/DefaultErrorCode.java
+++ b/common/src/main/java/com/ddudu/common/exception/DefaultErrorCode.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class DefaultErrorCode implements ErrorCode {
 
   private static final int UNKNOWN_ERROR_CODE = 9999;
+  private static final String DEFAULT_UNKNOWN_ERROR = "알 수 없는 예외입니다.";
 
   private final int code;
   private final String message;
@@ -13,6 +14,10 @@ public class DefaultErrorCode implements ErrorCode {
   public DefaultErrorCode(String message) {
     this.code = UNKNOWN_ERROR_CODE;
     this.message = message;
+  }
+
+  public static DefaultErrorCode defaultMessage() {
+    return new DefaultErrorCode(DEFAULT_UNKNOWN_ERROR);
   }
 
   @Override

--- a/common/src/main/java/com/ddudu/common/exception/ErrorCodeParser.java
+++ b/common/src/main/java/com/ddudu/common/exception/ErrorCodeParser.java
@@ -1,11 +1,16 @@
 package com.ddudu.common.exception;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ErrorCodeParser {
 
   public ErrorCode parse(String message) {
+    if (StringUtils.isBlank(message)) {
+      return DefaultErrorCode.defaultMessage();
+    }
+
     String[] codeName = message.split(" ");
     String code = codeName[0];
     String name = codeName[1];

--- a/common/src/testFixtures/java/com/ddudu/fixture/BaseFixture.java
+++ b/common/src/testFixtures/java/com/ddudu/fixture/BaseFixture.java
@@ -1,6 +1,7 @@
 package com.ddudu.fixture;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Locale;
@@ -57,6 +58,34 @@ public class BaseFixture {
     return faker.color()
         .hex()
         .substring(1);
+  }
+
+  public static LocalDate getFutureDate(int futureDaysScope) {
+    LocalDateTime tomorrow = LocalDateTime.now()
+        .plusDays(1);
+    LocalDateTime until = LocalDateTime.now()
+        .plusDays(futureDaysScope);
+    Timestamp from = Timestamp.valueOf(tomorrow);
+    Timestamp to = Timestamp.valueOf(until);
+
+    return faker.date()
+        .between(from, to)
+        .toLocalDateTime()
+        .toLocalDate();
+  }
+
+  public static LocalDate getPastDate(int pastDaysScope) {
+    LocalDateTime yesterday = LocalDateTime.now()
+        .minusDays(1);
+    LocalDateTime until = LocalDateTime.now()
+        .minusDays(pastDaysScope);
+    Timestamp from = Timestamp.valueOf(until);
+    Timestamp to = Timestamp.valueOf(yesterday);
+
+    return faker.date()
+        .between(from, to)
+        .toLocalDateTime()
+        .toLocalDate();
   }
 
   public static LocalDateTime getRandomDateTime() {

--- a/domain/planning-domain/src/test/java/com/ddudu/domain/planning/repeatddudu/service/RepeatDduduDomainServiceTest.java
+++ b/domain/planning-domain/src/test/java/com/ddudu/domain/planning/repeatddudu/service/RepeatDduduDomainServiceTest.java
@@ -149,8 +149,7 @@ class RepeatDduduDomainServiceTest {
       );
 
       // when
-      List<Ddudu> ddudus = repeatDduduDomainService.createRepeatedDdudus(
-          userId, dailyRepeatDdudu);
+      List<Ddudu> ddudus = repeatDduduDomainService.createRepeatedDdudus(userId, dailyRepeatDdudu);
 
       // then
       Assertions.assertThat(ddudus)
@@ -174,8 +173,7 @@ class RepeatDduduDomainServiceTest {
       );
 
       // when
-      List<Ddudu> ddudus = repeatDduduDomainService.createRepeatedDdudus(
-          userId, weeklyRepeatDdudu);
+      List<Ddudu> ddudus = repeatDduduDomainService.createRepeatedDdudus(userId, weeklyRepeatDdudu);
 
       // then
       ddudus.stream()

--- a/domain/planning-domain/src/testFixtures/java/com/ddudu/fixture/DduduFixture.java
+++ b/domain/planning-domain/src/testFixtures/java/com/ddudu/fixture/DduduFixture.java
@@ -171,10 +171,10 @@ public class DduduFixture extends BaseFixture {
         .build();
   }
 
-  public static Ddudu createRandomDduduWithSchedule(Goal goal, LocalDate scheduledOn) {
+  public static Ddudu createRandomDduduWithSchedule(Long userId, Long goalId, LocalDate scheduledOn) {
     return getDduduBuilder()
-        .goalId(goal.getId())
-        .userId(goal.getUserId())
+        .goalId(goalId)
+        .userId(userId)
         .scheduledOn(scheduledOn)
         .build();
   }


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
- Resolves #265 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 미리알림 설정 기능 구현
- LocalDate 관련 BaseFixture 추가
- Unauthorized와 연결되는 자바 예외 수정 (SecurityException -> UnsupportedOperationException)
- Spring Validation이 GlobalExceptionHandler에 적용 안되는 버그 수정