### PR TITLE
Feat: 미리알림 취소 기능 구현

### DIFF
--- a/application/application-common/src/main/java/com/ddudu/application/common/port/ddudu/in/CancelReminderUseCase.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/ddudu/in/CancelReminderUseCase.java
@@ -1,0 +1,7 @@
+package com.ddudu.application.common.port.ddudu.in;
+
+public interface CancelReminderUseCase {
+
+  void cancel(Long loginId, Long id);
+
+}

--- a/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/CancelReminderService.java
+++ b/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/CancelReminderService.java
@@ -1,0 +1,42 @@
+package com.ddudu.application.planning.ddudu.service;
+
+import com.ddudu.application.common.port.ddudu.in.CancelReminderUseCase;
+import com.ddudu.application.common.port.ddudu.out.DduduLoaderPort;
+import com.ddudu.application.common.port.ddudu.out.DduduUpdatePort;
+import com.ddudu.application.common.port.user.out.UserLoaderPort;
+import com.ddudu.common.annotation.UseCase;
+import com.ddudu.common.exception.DduduErrorCode;
+import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
+import com.ddudu.domain.user.user.aggregate.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class CancelReminderService implements CancelReminderUseCase {
+
+  private final UserLoaderPort userLoaderPort;
+  private final DduduLoaderPort dduduLoaderPort;
+  private final DduduUpdatePort dduduUpdatePort;
+
+  @Override
+  public void cancel(Long loginId, Long id) {
+    User user = userLoaderPort.getUserOrElseThrow(
+        loginId,
+        DduduErrorCode.LOGIN_USER_NOT_EXISTING.getCodeName()
+    );
+    Ddudu ddudu = dduduLoaderPort.getDduduOrElseThrow(
+        id,
+        DduduErrorCode.ID_NOT_EXISTING.getCodeName()
+    );
+
+    ddudu.validateDduduCreator(user.getId());
+
+    Ddudu dduduWithoutReminder = ddudu.cancelReminder();
+    Ddudu updated = dduduUpdatePort.update(dduduWithoutReminder);
+
+    // TODO: notification event 구현 이후 알림 이벤트 삭제 + TaskScheduler에서 삭제
+  }
+
+}

--- a/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/SetReminderService.java
+++ b/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/SetReminderService.java
@@ -38,6 +38,8 @@ public class SetReminderService implements SetReminderUseCase {
 
     dduduUpdatePort.update(dduduWithReminder);
 
+    // TODO: notification event 구현 후 notification event에 존재 여부에 따라 Upsert 추가
+
     if (ddudu.isScheduledToday()) {
       // TODO: TaskScheduler 구현 후 Scheduler에 추가하기
     }

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/CancelReminderServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/CancelReminderServiceTest.java
@@ -1,0 +1,123 @@
+package com.ddudu.application.planning.ddudu.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddudu.application.common.port.auth.out.SignUpPort;
+import com.ddudu.application.common.port.ddudu.out.DduduLoaderPort;
+import com.ddudu.application.common.port.ddudu.out.SaveDduduPort;
+import com.ddudu.application.common.port.goal.out.SaveGoalPort;
+import com.ddudu.common.exception.DduduErrorCode;
+import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
+import com.ddudu.domain.planning.goal.aggregate.Goal;
+import com.ddudu.domain.user.user.aggregate.User;
+import com.ddudu.fixture.DduduFixture;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.UserFixture;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.MissingResourceException;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class CancelReminderServiceTest {
+
+  @Autowired
+  CancelReminderService cancelReminderService;
+
+  @Autowired
+  SignUpPort signUpPort;
+
+  @Autowired
+  SaveGoalPort saveGoalPort;
+
+  @Autowired
+  SaveDduduPort saveDduduPort;
+
+  @Autowired
+  DduduLoaderPort dduduLoaderPort;
+
+  User user;
+  Goal goal;
+  Ddudu ddudu;
+
+  @BeforeEach
+  void setUp() {
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user.getId()));
+    LocalTime beginAt = LocalTime.MAX;
+    ddudu = DduduFixture.createRandomDduduWithGoalAndTime(
+        goal,
+        beginAt,
+        null
+    );
+    ddudu = ddudu.moveDate(LocalDate.now()
+        .plusDays(1));
+    ddudu = saveDduduPort.save(ddudu.setReminder(0, 0, 10));
+  }
+
+  @Test
+  void 미리알림_취소를_성공한다() {
+    // given
+
+    // when
+    cancelReminderService.cancel(user.getId(), ddudu.getId());
+
+    // then
+    Ddudu actual = dduduLoaderPort.getDduduOrElseThrow(ddudu.getId(), "not found");
+
+    assertThat(actual.getRemindAt()).isNull();
+  }
+
+  @Test
+  void 존재하지_않는_사용자는_미리알림_취소에_실패한다() {
+    // given
+    long invalidId = UserFixture.getRandomId();
+
+    // when
+    ThrowingCallable cancel = () -> cancelReminderService.cancel(invalidId, ddudu.getId());
+
+    // then
+    Assertions.assertThatExceptionOfType(MissingResourceException.class)
+        .isThrownBy(cancel)
+        .withMessage(DduduErrorCode.LOGIN_USER_NOT_EXISTING.getCodeName());
+  }
+
+  @Test
+  void 존재하지_않는_뚜두는_미리알림_취소에_실패한다() {
+    // given
+    long invalidId = DduduFixture.getRandomId();
+
+    // when
+    ThrowingCallable cancel = () -> cancelReminderService.cancel(user.getId(), invalidId);
+
+    // then
+    Assertions.assertThatExceptionOfType(MissingResourceException.class)
+        .isThrownBy(cancel)
+        .withMessage(DduduErrorCode.ID_NOT_EXISTING.getCodeName());
+  }
+
+  @Test
+  void 다른_사용자는_미리알림_취소에_실패한다() {
+    // given
+    User another = signUpPort.save(UserFixture.createRandomUserWithId());
+
+    // when
+    ThrowingCallable cancel = () -> cancelReminderService.cancel(another.getId(), ddudu.getId());
+
+    // then
+    Assertions.assertThatExceptionOfType(UnsupportedOperationException.class)
+        .isThrownBy(cancel)
+        .withMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
+  }
+
+}

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/SetReminderServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/SetReminderServiceTest.java
@@ -14,6 +14,7 @@ import com.ddudu.domain.user.user.aggregate.User;
 import com.ddudu.fixture.DduduFixture;
 import com.ddudu.fixture.GoalFixture;
 import com.ddudu.fixture.UserFixture;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.MissingResourceException;
@@ -55,9 +56,13 @@ class SetReminderServiceTest {
   void setUp() {
     user = signUpPort.save(UserFixture.createRandomUserWithId());
     goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user.getId()));
-    LocalTime beginAt = LocalTime.now()
-        .plusHours(1);
-    ddudu = saveDduduPort.save(DduduFixture.createRandomDduduWithGoalAndTime(goal, beginAt, null));
+    LocalTime beginAt = LocalTime.MAX;
+    Ddudu temp = DduduFixture.createRandomDduduWithGoalAndTime(
+        goal,
+        beginAt,
+        null
+    );
+    ddudu = saveDduduPort.save(temp.moveDate(LocalDate.now().plusDays(1)));
   }
 
   @Test

--- a/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/controller/DduduController.java
+++ b/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/controller/DduduController.java
@@ -18,6 +18,7 @@ import com.ddudu.application.common.dto.ddudu.response.DduduDetailResponse;
 import com.ddudu.application.common.dto.ddudu.response.RepeatAnotherDayResponse;
 import com.ddudu.application.common.dto.ddudu.response.TimetableResponse;
 import com.ddudu.application.common.dto.scroll.response.ScrollResponse;
+import com.ddudu.application.common.port.ddudu.in.CancelReminderUseCase;
 import com.ddudu.application.common.port.ddudu.in.ChangeNameUseCase;
 import com.ddudu.application.common.port.ddudu.in.CreateDduduUseCase;
 import com.ddudu.application.common.port.ddudu.in.DduduSearchUseCase;
@@ -67,6 +68,7 @@ public class DduduController implements DduduControllerDoc {
   private final ChangeNameUseCase changeNameUseCase;
   private final DeleteDduduUseCase deleteDduduUseCase;
   private final SetReminderUseCase setReminderUseCase;
+  private final CancelReminderUseCase cancelReminderUseCase;
 
   /**
    * 뚜두 생성 API
@@ -167,6 +169,20 @@ public class DduduController implements DduduControllerDoc {
       SetReminderRequest request
   ) {
     setReminderUseCase.setReminder(loginId, id, request);
+
+    return ResponseEntity.noContent()
+        .build();
+  }
+
+  @Override
+  @DeleteMapping("/{id}/reminder")
+  public ResponseEntity<Void> cancelReminder(
+      @Login
+      Long loginId,
+      @PathVariable("id")
+      Long id
+  ) {
+    cancelReminderUseCase.cancel(loginId, id);
 
     return ResponseEntity.noContent()
         .build();

--- a/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/doc/DduduControllerDoc.java
+++ b/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/doc/DduduControllerDoc.java
@@ -134,10 +134,26 @@ public interface DduduControllerDoc {
               )
           ),
           @ApiResponse(
+              responseCode = "403",
+              description = "FORBIDDEN",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "2007",
+                      description = "해당 뚜두에 대한 권한이 없는 경우 (본인만 가능)",
+                      value = DduduErrorExamples.DDUDU_INVALID_AUTHORITY
+                  )
+              )
+          ),
+          @ApiResponse(
               responseCode = "404",
               description = "NOT_FOUND",
               content = @Content(
                   examples = {
+                      @ExampleObject(
+                          name = "2004",
+                          description = "존재하지 않는 뚜두인 경우",
+                          value = DduduErrorExamples.DDUDU_ID_NOT_EXISTING
+                      ),
                       @ExampleObject(
                           name = "2008",
                           description = "로그인 사용자 아이디가 유효하지 않는 경우",
@@ -416,6 +432,17 @@ public interface DduduControllerDoc {
                       value = DduduErrorExamples.DDUDU_INVALID_AUTHORITY
                   )
               )
+          ),
+          @ApiResponse(
+              responseCode = "404",
+              description = "NOT_FOUND",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "2004",
+                      description = "존재하지 않는 뚜두인 경우",
+                      value = DduduErrorExamples.DDUDU_ID_NOT_EXISTING
+                  )
+              )
           )
       }
   )
@@ -604,8 +631,8 @@ public interface DduduControllerDoc {
               content = @Content(
                   examples = {
                       @ExampleObject(
-                        name = "2008",
-                        value = DduduErrorExamples.DDUDU_LOGIN_USER_NOT_EXISTING
+                          name = "2008",
+                          value = DduduErrorExamples.DDUDU_LOGIN_USER_NOT_EXISTING
                       ),
                       @ExampleObject(
                           name = "2004",
@@ -637,6 +664,17 @@ public interface DduduControllerDoc {
                   examples = @ExampleObject(
                       name = "5002",
                       value = AuthErrorExamples.AUTH_BAD_TOKEN_CONTENT
+                  )
+              )
+          ),
+          @ApiResponse(
+              responseCode = "403",
+              description = "FORBIDDEN",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "2007",
+                      description = "해당 뚜두에 대한 권한이 없는 경우 (본인만 가능)",
+                      value = DduduErrorExamples.DDUDU_INVALID_AUTHORITY
                   )
               )
           )

--- a/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/doc/DduduControllerDoc.java
+++ b/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/doc/DduduControllerDoc.java
@@ -682,4 +682,47 @@ public interface DduduControllerDoc {
   )
   ResponseEntity<Void> setReminder(Long loginId, Long dduduId, SetReminderRequest request);
 
+  @Operation(summary = "미리알림 취소")
+  @ApiResponses(
+      {
+          @ApiResponse(
+              responseCode = "204",
+              description = "NO CONTENT"
+          ),
+          @ApiResponse(
+              responseCode = "401",
+              description = "UNAUTHORIZED",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "5002",
+                      value = AuthErrorExamples.AUTH_BAD_TOKEN_CONTENT
+                  )
+              )
+          ),
+          @ApiResponse(
+              responseCode = "403",
+              description = "FORBIDDEN",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "2007",
+                      description = "해당 뚜두에 대한 권한이 없는 경우 (본인만 가능)",
+                      value = DduduErrorExamples.DDUDU_INVALID_AUTHORITY
+                  )
+              )
+          ),
+          @ApiResponse(
+              responseCode = "404",
+              description = "NOT_FOUND",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "2004",
+                      description = "존재하지 않는 뚜두인 경우",
+                      value = DduduErrorExamples.DDUDU_ID_NOT_EXISTING
+                  )
+              )
+          )
+      }
+  )
+  ResponseEntity<Void> cancelReminder(Long loginId, Long id);
+
 }

--- a/domain/planning-domain/src/main/java/com/ddudu/domain/planning/ddudu/aggregate/Ddudu.java
+++ b/domain/planning-domain/src/main/java/com/ddudu/domain/planning/ddudu/aggregate/Ddudu.java
@@ -152,6 +152,12 @@ public class Ddudu {
     return scheduledOn.isEqual(LocalDate.now());
   }
 
+  public Ddudu cancelReminder() {
+    return getFullBuilder()
+        .remindAt(null)
+        .build();
+  }
+
   private DduduBuilder getFullBuilder() {
     return Ddudu.builder()
         .id(this.id)

--- a/domain/planning-domain/src/test/java/com/ddudu/domain/planning/ddudu/aggregate/DduduTest.java
+++ b/domain/planning-domain/src/test/java/com/ddudu/domain/planning/ddudu/aggregate/DduduTest.java
@@ -293,6 +293,22 @@ class DduduTest {
             .withMessage(DduduErrorCode.REMINDER_NOT_AFTER_NOW.getCodeName());
       }
 
+      @Test
+      void 미리알림_취소를_성공한다() {
+        // given
+        LocalDate futureDate = LocalDate.now().plusDays(2);
+        LocalTime beginAt = LocalTime.of(23, 30);
+        Ddudu scheduled = DduduFixture.createRandomDduduWithSchedule(userId, goalId, futureDate)
+            .setUpPeriod(beginAt, null);
+        Ddudu withReminder = scheduled.setReminder(0, 0, 15);
+
+        // when
+        Ddudu canceled = withReminder.cancelReminder();
+
+        // then
+        assertThat(canceled.getRemindAt()).isNull();
+      }
+
     }
 
     @Nested


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
- Resolves #269 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 미리알림 취소 도메인 로직 및 서비스 구현
- 문서에 누락된 예시 추가
- 테스트 예외 발생 사항 수정