### PR TITLE
Fix: Forbidden 예외 발생 수정

### DIFF
--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/CancelReminderServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/CancelReminderServiceTest.java
@@ -115,7 +115,7 @@ class CancelReminderServiceTest {
     ThrowingCallable cancel = () -> cancelReminderService.cancel(another.getId(), ddudu.getId());
 
     // then
-    Assertions.assertThatExceptionOfType(UnsupportedOperationException.class)
+    Assertions.assertThatExceptionOfType(SecurityException.class)
         .isThrownBy(cancel)
         .withMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
   }

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/ChangeNameServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/ChangeNameServiceTest.java
@@ -110,7 +110,7 @@ class ChangeNameServiceTest {
 
     // then
     Assertions.assertThatThrownBy(changeName)
-        .isInstanceOf(UnsupportedOperationException.class)
+        .isInstanceOf(SecurityException.class)
         .hasMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
   }
 

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/DeleteDduduServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/DeleteDduduServiceTest.java
@@ -81,7 +81,7 @@ class DeleteDduduServiceTest {
     ThrowingCallable delete = () -> deleteDduduService.delete(anotherUser.getId(), ddudu.getId());
 
     // then
-    Assertions.assertThatExceptionOfType(UnsupportedOperationException.class)
+    Assertions.assertThatExceptionOfType(SecurityException.class)
         .isThrownBy(delete)
         .withMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
   }

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/RetrieveDduduServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/RetrieveDduduServiceTest.java
@@ -98,7 +98,7 @@ class RetrieveDduduServiceTest {
 
     // then
     AssertionsForClassTypes.assertThatThrownBy(callable)
-        .isInstanceOf(UnsupportedOperationException.class)
+        .isInstanceOf(SecurityException.class)
         .hasMessageContaining(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
   }
 

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/SetReminderServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/SetReminderServiceTest.java
@@ -62,7 +62,8 @@ class SetReminderServiceTest {
         beginAt,
         null
     );
-    ddudu = saveDduduPort.save(temp.moveDate(LocalDate.now().plusDays(1)));
+    ddudu = saveDduduPort.save(temp.moveDate(LocalDate.now()
+        .plusDays(1)));
   }
 
   @Test
@@ -135,7 +136,7 @@ class SetReminderServiceTest {
     );
 
     // then
-    Assertions.assertThatExceptionOfType(UnsupportedOperationException.class)
+    Assertions.assertThatExceptionOfType(SecurityException.class)
         .isThrownBy(setReminder)
         .withMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
   }

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/SwitchStatusServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/SwitchStatusServiceTest.java
@@ -98,7 +98,7 @@ class SwitchStatusServiceTest {
     );
 
     // then
-    AssertionsForClassTypes.assertThatExceptionOfType(UnsupportedOperationException.class)
+    AssertionsForClassTypes.assertThatExceptionOfType(SecurityException.class)
         .isThrownBy(updateStatus)
         .withMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
   }

--- a/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/exception/GlobalExceptionHandler.java
+++ b/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/exception/GlobalExceptionHandler.java
@@ -97,6 +97,21 @@ public class GlobalExceptionHandler {
         .body(response);
   }
 
+  @ExceptionHandler(SecurityException.class)
+  public ResponseEntity<ErrorResponse> handleForbidden(SecurityException e) {
+    log.warn(e.getMessage(), e);
+
+    ErrorCode errorCode = errorCodeParser.parse(e.getMessage());
+    ErrorResponse response = ErrorResponse.from(errorCode);
+
+    if (errorCode instanceof DefaultErrorCode) {
+      return handleUnexpected(response);
+    }
+
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .body(response);
+  }
+
   @ExceptionHandler(MissingResourceException.class)
   public ResponseEntity<ErrorResponse> handleNotFound(MissingResourceException e) {
     log.warn(e.getMessage(), e);

--- a/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/doc/DduduControllerDoc.java
+++ b/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/doc/DduduControllerDoc.java
@@ -491,6 +491,17 @@ public interface DduduControllerDoc {
                       value = DduduErrorExamples.DDUDU_ID_NOT_EXISTING
                   )
               )
+          ),
+          @ApiResponse(
+              responseCode = "403",
+              description = "FORBIDDEN",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "2007",
+                      description = "해당 뚜두에 대한 권한이 없는 경우 (본인만 가능)",
+                      value = DduduErrorExamples.DDUDU_INVALID_AUTHORITY
+                  )
+              )
           )
       }
   )
@@ -540,6 +551,17 @@ public interface DduduControllerDoc {
                       value = DduduErrorExamples.DDUDU_ID_NOT_EXISTING
                   )
               )
+          ),
+          @ApiResponse(
+              responseCode = "403",
+              description = "FORBIDDEN",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "2007",
+                      description = "해당 뚜두에 대한 권한이 없는 경우 (본인만 가능)",
+                      value = DduduErrorExamples.DDUDU_INVALID_AUTHORITY
+                  )
+              )
           )
       }
   )
@@ -581,6 +603,17 @@ public interface DduduControllerDoc {
                       name = "2004",
                       description = "존재하지 않는 뚜두인 경우",
                       value = DduduErrorExamples.DDUDU_ID_NOT_EXISTING
+                  )
+              )
+          ),
+          @ApiResponse(
+              responseCode = "403",
+              description = "FORBIDDEN",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "2007",
+                      description = "해당 뚜두에 대한 권한이 없는 경우 (본인만 가능)",
+                      value = DduduErrorExamples.DDUDU_INVALID_AUTHORITY
                   )
               )
           )

--- a/domain/planning-domain/src/main/java/com/ddudu/domain/planning/ddudu/aggregate/Ddudu.java
+++ b/domain/planning-domain/src/main/java/com/ddudu/domain/planning/ddudu/aggregate/Ddudu.java
@@ -67,7 +67,7 @@ public class Ddudu {
 
   public void validateDduduCreator(Long userId) {
     if (!isCreatedByUser(userId)) {
-      throw new UnsupportedOperationException(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
+      throw new SecurityException(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
     }
   }
 

--- a/domain/planning-domain/src/test/java/com/ddudu/domain/planning/ddudu/aggregate/DduduTest.java
+++ b/domain/planning-domain/src/test/java/com/ddudu/domain/planning/ddudu/aggregate/DduduTest.java
@@ -296,7 +296,8 @@ class DduduTest {
       @Test
       void 미리알림_취소를_성공한다() {
         // given
-        LocalDate futureDate = LocalDate.now().plusDays(2);
+        LocalDate futureDate = LocalDate.now()
+            .plusDays(2);
         LocalTime beginAt = LocalTime.of(23, 30);
         Ddudu scheduled = DduduFixture.createRandomDduduWithSchedule(userId, goalId, futureDate)
             .setUpPeriod(beginAt, null);
@@ -335,7 +336,7 @@ class DduduTest {
         ThrowingCallable check = () -> ddudu.validateDduduCreator(wrongUserId);
 
         // then
-        Assertions.assertThatExceptionOfType(UnsupportedOperationException.class)
+        Assertions.assertThatExceptionOfType(SecurityException.class)
             .isThrownBy(check)
             .withMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
       }


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
- Resolves #270 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 권한 없음은 SecurityException 예외 발생
- GlobalExceptionHandler에 SecurityException 핸들링 추가
- 누락 문서 예외 추가