### PR TITLE
Feat: 알림 이벤트 생성/수정/취소 구현

### DIFF
--- a/application/application-common/build.gradle.kts
+++ b/application/application-common/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
     implementation(project(":domain:user-domain"))
     implementation(project(":domain:planning-domain"))
     implementation(project(":domain:stats-domain"))
+    implementation(project(":domain:notification-domain"))
 }

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/NotificationEventCommandPort.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/NotificationEventCommandPort.java
@@ -1,0 +1,14 @@
+package com.ddudu.application.common.port.notification.out;
+
+import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+
+public interface NotificationEventCommandPort {
+
+  NotificationEvent save(NotificationEvent event);
+
+  void delete(NotificationEvent event);
+
+  void deleteAllByContext(NotificationEventTypeCode typeCode, Long contextId);
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/NotificationEventLoaderPort.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/NotificationEventLoaderPort.java
@@ -1,0 +1,16 @@
+package com.ddudu.application.common.port.notification.out;
+
+import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import java.util.Optional;
+
+public interface NotificationEventLoaderPort {
+
+  boolean existsByContext(NotificationEventTypeCode typeCode, Long contextId);
+
+  Optional<NotificationEvent> getOptionalEventByContext(
+      NotificationEventTypeCode typeCode,
+      Long contextId
+  );
+
+}

--- a/application/planning-application/build.gradle.kts
+++ b/application/planning-application/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation(project(":common"))
     implementation(project(":domain:user-domain"))
     implementation(project(":domain:planning-domain"))
+    implementation(project(":domain:notification-domain"))
 
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework:spring-tx")
@@ -17,10 +18,12 @@ dependencies {
     testImplementation(testFixtures(project(":common")))
     testImplementation(testFixtures(project(":domain:user-domain")))
     testImplementation(testFixtures(project(":domain:planning-domain")))
+    testImplementation(testFixtures(project(":domain:notification-domain")))
 
     // For integration test, instead of mocking
     testImplementation(project(":infra:user-infra-mysql"))
     testImplementation(project(":infra:planning-infra-mysql"))
+    testImplementation(project(":infra:notification-infra-mysql"))
 }
 
 val copyTestSecret by tasks.registering(Copy::class) {

--- a/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/DeleteDduduService.java
+++ b/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/DeleteDduduService.java
@@ -3,7 +3,11 @@ package com.ddudu.application.planning.ddudu.service;
 import com.ddudu.application.common.port.ddudu.in.DeleteDduduUseCase;
 import com.ddudu.application.common.port.ddudu.out.DduduLoaderPort;
 import com.ddudu.application.common.port.ddudu.out.DeleteDduduPort;
+import com.ddudu.application.common.port.notification.out.NotificationEventCommandPort;
 import com.ddudu.common.annotation.UseCase;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,14 +18,21 @@ public class DeleteDduduService implements DeleteDduduUseCase {
 
   private final DduduLoaderPort dduduLoaderPort;
   private final DeleteDduduPort deleteDduduPort;
+  private final NotificationEventCommandPort notificationEventCommandPort;
 
   @Override
   public void delete(Long loginId, Long dduduId) {
-    dduduLoaderPort.getOptionalDdudu(dduduId)
-        .ifPresent(ddudu -> {
-          ddudu.validateDduduCreator(loginId);
-          deleteDduduPort.delete(ddudu);
-        });
+    Optional<Ddudu> optionalDdudu = dduduLoaderPort.getOptionalDdudu(dduduId);
+
+    if (optionalDdudu.isEmpty()) {
+      return;
+    }
+
+    Ddudu ddudu = optionalDdudu.get();
+
+    ddudu.validateDduduCreator(loginId);
+    deleteDduduPort.delete(ddudu);
+    notificationEventCommandPort.deleteAllByContext(NotificationEventTypeCode.DDUDU, ddudu.getId());
   }
 
 }

--- a/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/SetReminderService.java
+++ b/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/SetReminderService.java
@@ -4,9 +4,13 @@ import com.ddudu.application.common.dto.ddudu.request.SetReminderRequest;
 import com.ddudu.application.common.port.ddudu.in.SetReminderUseCase;
 import com.ddudu.application.common.port.ddudu.out.DduduLoaderPort;
 import com.ddudu.application.common.port.ddudu.out.DduduUpdatePort;
+import com.ddudu.application.common.port.notification.out.NotificationEventLoaderPort;
+import com.ddudu.application.common.port.notification.out.NotificationEventCommandPort;
 import com.ddudu.application.common.port.user.out.UserLoaderPort;
 import com.ddudu.common.annotation.UseCase;
 import com.ddudu.common.exception.DduduErrorCode;
+import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
 import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
 import com.ddudu.domain.user.user.aggregate.User;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +24,8 @@ public class SetReminderService implements SetReminderUseCase {
   private final UserLoaderPort userLoaderPort;
   private final DduduLoaderPort dduduLoaderPort;
   private final DduduUpdatePort dduduUpdatePort;
+  private final NotificationEventLoaderPort notificationEventLoaderPort;
+  private final NotificationEventCommandPort notificationEventCommandPort;
 
   @Override
   public void setReminder(Long loginId, Long id, SetReminderRequest request) {
@@ -37,8 +43,28 @@ public class SetReminderService implements SetReminderUseCase {
     Ddudu dduduWithReminder = ddudu.setReminder(request.days(), request.hours(), request.minutes());
 
     dduduUpdatePort.update(dduduWithReminder);
+    upsertNotification(user.getId(), ddudu);
+  }
 
-    // TODO: notification event 구현 후 notification event에 존재 여부에 따라 Upsert 추가
+  private void upsertNotification(Long userId, Ddudu ddudu) {
+    boolean notificationRegistered = notificationEventLoaderPort.existsByContext(
+        NotificationEventTypeCode.DDUDU,
+        ddudu.getId()
+    );
+
+    if (notificationRegistered) {
+      // TODO: TaskScheduler 구현 후 Scheduler에서 삭제
+    }
+
+    NotificationEvent notificationEvent = NotificationEvent.builder()
+        .contextId(ddudu.getId())
+        .typeCode(NotificationEventTypeCode.DDUDU)
+        .receiverId(userId)
+        .senderId(userId)
+        .willFireAt(ddudu.getRemindAt())
+        .build();
+
+    notificationEventCommandPort.save(notificationEvent);
 
     if (ddudu.isScheduledToday()) {
       // TODO: TaskScheduler 구현 후 Scheduler에 추가하기

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/SetReminderServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/SetReminderServiceTest.java
@@ -7,17 +7,23 @@ import com.ddudu.application.common.port.auth.out.SignUpPort;
 import com.ddudu.application.common.port.ddudu.out.DduduLoaderPort;
 import com.ddudu.application.common.port.ddudu.out.SaveDduduPort;
 import com.ddudu.application.common.port.goal.out.SaveGoalPort;
+import com.ddudu.application.common.port.notification.out.NotificationEventCommandPort;
+import com.ddudu.application.common.port.notification.out.NotificationEventLoaderPort;
 import com.ddudu.common.exception.DduduErrorCode;
+import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
 import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
 import com.ddudu.domain.planning.goal.aggregate.Goal;
 import com.ddudu.domain.user.user.aggregate.User;
 import com.ddudu.fixture.DduduFixture;
 import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.NotificationEventFixture;
 import com.ddudu.fixture.UserFixture;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.MissingResourceException;
+import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +54,12 @@ class SetReminderServiceTest {
   @Autowired
   DduduLoaderPort dduduLoaderPort;
 
+  @Autowired
+  NotificationEventLoaderPort notificationEventLoaderPort;
+
+  @Autowired
+  NotificationEventCommandPort notificationEventCommandPort;
+
   User user;
   Goal goal;
   Ddudu ddudu;
@@ -75,13 +87,44 @@ class SetReminderServiceTest {
     setReminderService.setReminder(user.getId(), ddudu.getId(), request);
 
     // then
-    Ddudu actual = dduduLoaderPort.getDduduOrElseThrow(ddudu.getId(), "not found");
+    Ddudu actualDdudu = dduduLoaderPort.getDduduOrElseThrow(ddudu.getId(), "not found");
+    Optional<NotificationEvent> actualEvent = notificationEventLoaderPort.getOptionalEventByContext(
+        NotificationEventTypeCode.DDUDU,
+        ddudu.getId()
+    );
     LocalDateTime expected = ddudu.getScheduledOn()
         .atTime(ddudu.getBeginAt())
         .minusHours(request.hours())
         .minusMinutes(request.minutes());
 
-    assertThat(actual.getRemindAt()).isEqualTo(expected);
+    assertThat(actualDdudu.getRemindAt()).isEqualTo(expected);
+    assertThat(actualEvent).isPresent();
+  }
+
+  @Test
+  void 알림_이벤트가_존재하면_알림_이벤트를_수정한다() {
+    // given
+    NotificationEvent event = NotificationEventFixture.createValidDduduEventNowWithUserAndContext(
+        user.getId(),
+        ddudu.getId()
+    );
+    LocalDateTime previous = event.getWillFireAt();
+
+    notificationEventCommandPort.save(event);
+
+    SetReminderRequest request = new SetReminderRequest(0, 0, 30);
+
+    // when
+    setReminderService.setReminder(user.getId(), ddudu.getId(), request);
+
+    // then
+    NotificationEvent actual = notificationEventLoaderPort.getOptionalEventByContext(
+            NotificationEventTypeCode.DDUDU,
+            ddudu.getId()
+        )
+        .get();
+
+    assertThat(actual.getWillFireAt()).isNotEqualTo(previous);
   }
 
   @Test

--- a/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/NotificationEventErrorExcamples.java
+++ b/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/NotificationEventErrorExcamples.java
@@ -1,0 +1,26 @@
+package com.ddudu.bootstrap.common.doc.examples;
+
+public final class NotificationEventErrorExcamples {
+
+  public static final String NULL_TYPE_CODE = """
+      {
+        "code": 10001,
+        "message": "알림 유형은 필수값입니다."
+      }
+      """;
+
+  public static final String NULL_RECEIVER_ID = """
+      {
+        "code": 10002,
+        "message": "알림 수신자는 필수값입니다."
+      }
+      """;
+
+  public static final String NULL_CONTEXT_ID = """
+      {
+        "code": 10003,
+        "message": "알림 대상 컨텍스트는 필수값입니다."
+      }
+      """;
+
+}

--- a/bootstrap/bootstrap-gateway/build.gradle.kts
+++ b/bootstrap/bootstrap-gateway/build.gradle.kts
@@ -24,10 +24,12 @@ dependencies {
     implementation(project(":infra:stats-infra-mysql"))
     implementation(project(":infra:user-infra-mysql"))
     implementation(project(":infra:user-infra-external-api"))
+    implementation(project(":infra:notification-infra-mysql"))
     implementation(project(":bootstrap:bootstrap-common"))
     implementation(project(":bootstrap:user-api"))
     implementation(project(":bootstrap:planning-api"))
     implementation(project(":bootstrap:stats-api"))
+    implementation(project(":bootstrap:notification-api"))
 
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 }

--- a/bootstrap/bootstrap-gateway/src/main/resources/db/migration/V11__add_fire_at_to_notification_event.sql
+++ b/bootstrap/bootstrap-gateway/src/main/resources/db/migration/V11__add_fire_at_to_notification_event.sql
@@ -1,0 +1,2 @@
+ALTER TABLE notification_events
+    ADD will_fire_at TIMESTAMP NOT NULL;

--- a/common/src/main/java/com/ddudu/common/exception/ErrorCodeParser.java
+++ b/common/src/main/java/com/ddudu/common/exception/ErrorCodeParser.java
@@ -13,19 +13,21 @@ public class ErrorCodeParser {
 
     String[] codeName = message.split(" ");
     String code = codeName[0];
+    int codeValue = Integer.parseInt(codeName[0]);
     String name = codeName[1];
 
-    return switch (code.charAt(0)) {
-      case '1' -> UserErrorCode.valueOf(name);
-      case '2' -> DduduErrorCode.valueOf(name);
-      case '3' -> GoalErrorCode.valueOf(name);
-      case '4' -> PeriodGoalErrorCode.valueOf(name);
-      case '5' -> AuthErrorCode.valueOf(name);
-      case '6' -> RepeatDduduErrorCode.valueOf(name);
-      case '7' -> LikeErrorCode.valueOf(name);
-      case '8' -> FollowingErrorCode.valueOf(name);
-      case '9' ->
+    return switch (codeValue / 1000) {
+      case 1 -> UserErrorCode.valueOf(name);
+      case 2 -> DduduErrorCode.valueOf(name);
+      case 3 -> GoalErrorCode.valueOf(name);
+      case 4 -> PeriodGoalErrorCode.valueOf(name);
+      case 5 -> AuthErrorCode.valueOf(name);
+      case 6 -> RepeatDduduErrorCode.valueOf(name);
+      case 7 -> LikeErrorCode.valueOf(name);
+      case 8 -> FollowingErrorCode.valueOf(name);
+      case 9 ->
           code.charAt(1) != '9' ? StatsErrorCode.valueOf(name) : new DefaultErrorCode(message);
+      case 10 -> NotificationEventErrorCode.valueOf(name);
       default -> new DefaultErrorCode(message);
     };
   }

--- a/common/src/main/java/com/ddudu/common/exception/NotificationEventErrorCode.java
+++ b/common/src/main/java/com/ddudu/common/exception/NotificationEventErrorCode.java
@@ -1,0 +1,21 @@
+package com.ddudu.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum NotificationEventErrorCode implements ErrorCode {
+  NULL_TYPE_CODE(10001, "알림 유형은 필수값입니다."),
+  NULL_RECEIVER_ID(10002, "알림 수신자는 필수값입니다."),
+  NULL_CONTEXT_ID(10003, "알림 대상 컨텍스트는 필수값입니다.");
+
+  private final int code;
+  private final String message;
+
+  @Override
+  public String getCodeName() {
+    return this.code + " " + this.name();
+  }
+
+}

--- a/domain/notification-domain/src/main/java/com/ddudu/domain/notification/event/aggregate/NotificationEvent.java
+++ b/domain/notification-domain/src/main/java/com/ddudu/domain/notification/event/aggregate/NotificationEvent.java
@@ -1,23 +1,66 @@
 package com.ddudu.domain.notification.event.aggregate;
 
-import java.time.LocalDateTime;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import static com.google.common.base.Preconditions.checkArgument;
 
+import com.ddudu.common.exception.NotificationEventErrorCode;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Getter
-@Builder
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class NotificationEvent {
 
-  private Long id;
-  private String typeCode;
-  private Long senderId;
-  private Long receiverId;
-  private Long contextId;
-  private LocalDateTime firedAt;
+  @EqualsAndHashCode.Include
+  private final Long id;
+  private final NotificationEventTypeCode typeCode;
+  private final Long senderId;
+  private final Long receiverId;
+  private final Long contextId;
+  private final LocalDateTime willFireAt;
+  private final LocalDateTime firedAt;
+
+  @Builder
+  public NotificationEvent(
+      Long id,
+      NotificationEventTypeCode typeCode,
+      Long senderId,
+      Long receiverId,
+      Long contextId,
+      LocalDateTime willFireAt,
+      LocalDateTime firedAt
+  ) {
+    validate(typeCode, receiverId, contextId);
+
+    this.id = id;
+    this.typeCode = typeCode;
+    this.senderId = senderId;
+    this.receiverId = receiverId;
+    this.contextId = contextId;
+    this.willFireAt = Objects.requireNonNullElse(willFireAt, LocalDateTime.now());
+    this.firedAt = firedAt;
+  }
+
+  public boolean isAlreadyFired() {
+    return Objects.nonNull(firedAt);
+  }
+
+  private void validate(NotificationEventTypeCode typeCode, Long receiverId, Long contextId) {
+    checkArgument(
+        Objects.nonNull(typeCode),
+        NotificationEventErrorCode.NULL_TYPE_CODE.getCodeName()
+    );
+    checkArgument(
+        Objects.nonNull(receiverId),
+        NotificationEventErrorCode.NULL_RECEIVER_ID.getCodeName()
+    );
+    checkArgument(
+        Objects.nonNull(contextId),
+        NotificationEventErrorCode.NULL_CONTEXT_ID.getCodeName()
+    );
+  }
 
 }

--- a/domain/notification-domain/src/main/java/com/ddudu/domain/notification/event/aggregate/enums/NotificationEventTypeCode.java
+++ b/domain/notification-domain/src/main/java/com/ddudu/domain/notification/event/aggregate/enums/NotificationEventTypeCode.java
@@ -1,0 +1,9 @@
+package com.ddudu.domain.notification.event.aggregate.enums;
+
+public enum NotificationEventTypeCode {
+  DDUDU,
+  TEMPLATE,
+  FOLLOWING,
+  ANNOUNCE;
+
+}

--- a/domain/notification-domain/src/test/java/com/ddudu/domain/notification/event/aggregate/NotificationEventTest.java
+++ b/domain/notification-domain/src/test/java/com/ddudu/domain/notification/event/aggregate/NotificationEventTest.java
@@ -1,0 +1,145 @@
+package com.ddudu.domain.notification.event.aggregate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddudu.common.exception.NotificationEventErrorCode;
+import com.ddudu.domain.notification.event.aggregate.NotificationEvent.NotificationEventBuilder;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import com.ddudu.fixture.NotificationEventFixture;
+import java.time.LocalDateTime;
+import java.util.Random;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class NotificationEventTest {
+
+  Long userId;
+  Long contextId;
+  NotificationEventTypeCode typeCode;
+
+  Random random = new Random();
+
+  @BeforeEach
+  void setUp() {
+    userId = NotificationEventFixture.getRandomId();
+    contextId = NotificationEventFixture.getRandomId();
+    int index = random.nextInt(NotificationEventTypeCode.values().length) + 1;
+    typeCode = NotificationEventTypeCode.values()[index];
+  }
+
+  @Nested
+  class 생성_테스트 {
+
+    @Test
+    void 알림_이벤트_생성을_성공한다() {
+      // given
+      NotificationEventBuilder builder = NotificationEvent.builder()
+          .typeCode(typeCode)
+          .senderId(userId)
+          .receiverId(userId)
+          .contextId(contextId);
+
+      // when
+      NotificationEvent event = builder.build();
+
+      // then
+      assertThat(event.getTypeCode()).isEqualTo(typeCode);
+      assertThat(event.getReceiverId()).isEqualTo(userId);
+      assertThat(event.getContextId()).isEqualTo(contextId);
+    }
+
+    @Test
+    void 타입코드가_null이면_생성을_실패한다() {
+      // given
+      NotificationEventBuilder builder = NotificationEvent.builder()
+          .receiverId(userId)
+          .contextId(contextId);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      Assertions.assertThatIllegalArgumentException()
+          .isThrownBy(create)
+          .withMessage(NotificationEventErrorCode.NULL_TYPE_CODE.getCodeName());
+    }
+
+    @Test
+    void 수신자_ID가_null이면_생성을_실패한다() {
+      // given
+      NotificationEventBuilder builder = NotificationEvent.builder()
+          .typeCode(typeCode)
+          .contextId(contextId);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      Assertions.assertThatIllegalArgumentException()
+          .isThrownBy(create)
+          .withMessage(NotificationEventErrorCode.NULL_RECEIVER_ID.getCodeName());
+    }
+
+    @Test
+    void 컨텍스트_ID가_null이면_생성을_실패한다() {
+      // given
+      NotificationEventBuilder builder = NotificationEvent.builder()
+          .typeCode(typeCode)
+          .receiverId(userId);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      Assertions.assertThatIllegalArgumentException()
+          .isThrownBy(create)
+          .withMessage(NotificationEventErrorCode.NULL_CONTEXT_ID.getCodeName());
+    }
+
+  }
+
+  @Nested
+  class 기능_테스트 {
+
+    @Test
+    void 이미_발송된_이벤트는_true를_반환한다() {
+      // given
+      NotificationEvent fired = NotificationEventFixture.createFiredEventWithUserAndContext(
+          userId,
+          typeCode,
+          contextId,
+          LocalDateTime.now()
+      );
+
+      // when
+      boolean actual = fired.isAlreadyFired();
+
+      // then
+      assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 발송되지_않은_이벤트는_false를_반환한다() {
+      // given
+      NotificationEvent notFired = NotificationEventFixture.createFiredEventWithUserAndContext(
+          userId,
+          typeCode,
+          contextId,
+          LocalDateTime.now()
+      );
+
+      // when
+      boolean actual = notFired.isAlreadyFired();
+
+      // then
+      assertThat(actual).isFalse();
+    }
+  }
+
+}

--- a/domain/notification-domain/src/testFixtures/java/com/ddudu/fixture/NotificationEventFixture.java
+++ b/domain/notification-domain/src/testFixtures/java/com/ddudu/fixture/NotificationEventFixture.java
@@ -1,0 +1,120 @@
+package com.ddudu.fixture;
+
+import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NotificationEventFixture extends BaseFixture {
+
+  private static NotificationEvent createFiredDduduEventNowWithUserAndContext(
+      Long receiverId,
+      Long dduduId
+  ) {
+    return createFiredDduduEventWithUserAndContext(receiverId, dduduId, LocalDateTime.now());
+  }
+
+  public static NotificationEvent createValidDduduEventNowWithUserAndContext(
+      Long receiverId,
+      Long dduduId
+  ) {
+    return createValidDduduEventWithUserAndContext(receiverId, dduduId, LocalDateTime.now());
+  }
+
+  public static NotificationEvent createFiredDduduEventWithUserAndContext(
+      Long receiverId,
+      Long dduduId,
+      LocalDateTime willFireAt
+  ) {
+    return createFiredEventWithUserAndContext(
+        receiverId,
+        NotificationEventTypeCode.DDUDU,
+        dduduId,
+        willFireAt
+    );
+  }
+
+  public static NotificationEvent createValidDduduEventWithUserAndContext(
+      Long receiverId,
+      Long dduduId,
+      LocalDateTime willFireAt
+  ) {
+    return createValidEventWithUserAndContext(
+        receiverId,
+        NotificationEventTypeCode.DDUDU,
+        dduduId,
+        willFireAt
+    );
+  }
+
+  public static NotificationEvent createFiredEventWithUserAndContext(
+      Long receiverId,
+      NotificationEventTypeCode typeCode,
+      Long contextId,
+      LocalDateTime willFireAt
+  ) {
+    LocalDateTime firedAt = getPastDateTime(10, TimeUnit.DAYS);
+
+    return createNotificationEventWithUserAndContext(
+        receiverId,
+        typeCode,
+        contextId,
+        willFireAt,
+        firedAt
+    );
+  }
+
+  public static NotificationEvent createValidEventWithUserAndContext(
+      Long receiverId,
+      NotificationEventTypeCode typeCode,
+      Long contextId,
+      LocalDateTime willFireAt
+  ) {
+    return createNotificationEventWithUserAndContext(
+        receiverId,
+        typeCode,
+        contextId,
+        willFireAt,
+        null
+    );
+  }
+
+  public static NotificationEvent createNotificationEventWithUserAndContext(
+      Long receiverId,
+      NotificationEventTypeCode typeCode,
+      Long contextId,
+      LocalDateTime willFireAt,
+      LocalDateTime firedAt
+  ) {
+    return createNotificationEvent(
+        typeCode,
+        receiverId,
+        receiverId,
+        contextId,
+        willFireAt,
+        firedAt
+    );
+  }
+
+  public static NotificationEvent createNotificationEvent(
+      NotificationEventTypeCode typeCode,
+      Long senderId,
+      Long receiverId,
+      Long contextId,
+      LocalDateTime willFireAt,
+      LocalDateTime firedAt
+  ) {
+    return NotificationEvent.builder()
+        .typeCode(typeCode)
+        .senderId(senderId)
+        .receiverId(receiverId)
+        .contextId(contextId)
+        .willFireAt(willFireAt)
+        .firedAt(firedAt)
+        .build();
+  }
+
+}

--- a/domain/stats-domain/src/test/java/com/ddudu/aggregate/MonthlyStatsTest.java
+++ b/domain/stats-domain/src/test/java/com/ddudu/aggregate/MonthlyStatsTest.java
@@ -89,7 +89,7 @@ class MonthlyStatsTest {
       MonthlyStats empty = MonthlyStats.empty(userId, YearMonth.now());
 
       // when
-      ThrowingCallable getGoalId = () -> empty.getGoalId();
+      ThrowingCallable getGoalId = empty::getGoalId;
 
       // then
       assertThatRuntimeException().isThrownBy(getGoalId)
@@ -114,7 +114,7 @@ class MonthlyStatsTest {
       MonthlyStats empty = MonthlyStats.empty(userId, YearMonth.now());
 
       // when
-      ThrowingCallable getGoalName = () -> empty.getGoalName();
+      ThrowingCallable getGoalName = empty::getGoalName;
 
       // then
       assertThatRuntimeException().isThrownBy(getGoalName)

--- a/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/event/adapter/NotificationEventCommandPersistenceAdapter.java
+++ b/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/event/adapter/NotificationEventCommandPersistenceAdapter.java
@@ -1,0 +1,63 @@
+package com.ddudu.infra.mysql.notification.event.adapter;
+
+import com.ddudu.application.common.port.notification.out.NotificationEventLoaderPort;
+import com.ddudu.application.common.port.notification.out.NotificationEventCommandPort;
+import com.ddudu.common.annotation.DrivenAdapter;
+import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import com.ddudu.infra.mysql.notification.event.entity.NotificationEventEntity;
+import com.ddudu.infra.mysql.notification.event.repository.NotificationEventRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@DrivenAdapter
+@RequiredArgsConstructor
+public class NotificationEventCommandPersistenceAdapter implements NotificationEventLoaderPort,
+    NotificationEventCommandPort {
+
+  private final NotificationEventRepository notificationEventRepository;
+
+  @Override
+  public NotificationEvent save(NotificationEvent event) {
+    Optional<NotificationEventEntity> optionalEvent = notificationEventRepository.findByTypeCodeAndContextId(
+        event.getTypeCode(),
+        event.getContextId()
+    );
+
+    if (optionalEvent.isEmpty()) {
+      return notificationEventRepository.save(NotificationEventEntity.from(event))
+          .toDomain();
+    }
+
+    NotificationEventEntity eventEntity = optionalEvent.get();
+
+    eventEntity.update(event);
+
+    return eventEntity.toDomain();
+  }
+
+  @Override
+  public void delete(NotificationEvent event) {
+    notificationEventRepository.deleteById(event.getId());
+  }
+
+  @Override
+  public void deleteAllByContext(NotificationEventTypeCode typeCode, Long contextId) {
+    notificationEventRepository.deleteAllByTypeCodeAndContextId(typeCode, contextId);
+  }
+
+  @Override
+  public boolean existsByContext(NotificationEventTypeCode typeCode, Long contextId) {
+    return notificationEventRepository.existsByTypeCodeAndContextId(typeCode, contextId);
+  }
+
+  @Override
+  public Optional<NotificationEvent> getOptionalEventByContext(
+      NotificationEventTypeCode typeCode,
+      Long contextId
+  ) {
+    return notificationEventRepository.findByTypeCodeAndContextId(typeCode, contextId)
+        .map(NotificationEventEntity::toDomain);
+  }
+
+}

--- a/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/event/entity/NotificationEventEntity.java
+++ b/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/event/entity/NotificationEventEntity.java
@@ -1,9 +1,12 @@
 package com.ddudu.infra.mysql.notification.event.entity;
 
 import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
 import com.ddudu.infra.mysql.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,9 +34,11 @@ public class NotificationEventEntity extends BaseEntity {
   @Column(
       name = "type_code",
       nullable = false,
-      length = 20
+      length = 20,
+      columnDefinition = "VARCHAR"
   )
-  private String typeCode;
+  @Enumerated(EnumType.STRING)
+  private NotificationEventTypeCode typeCode;
 
   @Column(name = "sender_id")
   private Long senderId;
@@ -51,6 +56,12 @@ public class NotificationEventEntity extends BaseEntity {
   private Long contextId;
 
   @Column(
+      name = "will_fire_at",
+      nullable = false
+  )
+  private LocalDateTime willFireAt;
+
+  @Column(
       name = "fired_at",
       columnDefinition = "TIMESTAMP"
   )
@@ -63,6 +74,7 @@ public class NotificationEventEntity extends BaseEntity {
         .senderId(domain.getSenderId())
         .receiverId(domain.getReceiverId())
         .contextId(domain.getContextId())
+        .willFireAt(domain.getWillFireAt())
         .firedAt(domain.getFiredAt())
         .build();
   }
@@ -75,7 +87,17 @@ public class NotificationEventEntity extends BaseEntity {
         .receiverId(receiverId)
         .contextId(contextId)
         .firedAt(firedAt)
+        .willFireAt(willFireAt)
         .build();
+  }
+
+  public void update(NotificationEvent domain) {
+    this.typeCode = domain.getTypeCode();
+    this.contextId = domain.getContextId();
+    this.senderId = domain.getSenderId();
+    this.receiverId = domain.getReceiverId();
+    this.firedAt = domain.getFiredAt();
+    this.willFireAt = domain.getWillFireAt();
   }
 
 }

--- a/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/event/repository/NotificationEventRepository.java
+++ b/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/event/repository/NotificationEventRepository.java
@@ -1,0 +1,19 @@
+package com.ddudu.infra.mysql.notification.event.repository;
+
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import com.ddudu.infra.mysql.notification.event.entity.NotificationEventEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationEventRepository extends JpaRepository<NotificationEventEntity, Long> {
+
+  boolean existsByTypeCodeAndContextId(NotificationEventTypeCode typeCode, Long contextId);
+
+  Optional<NotificationEventEntity> findByTypeCodeAndContextId(
+      NotificationEventTypeCode typeCode,
+      Long contextId
+  );
+
+  void deleteAllByTypeCodeAndContextId(NotificationEventTypeCode typeCode, Long contextId);
+
+}


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
- Resolves #273 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 알림 이벤트 도메인 생성 검증 추가
- 미리알림 설정/취소, 뚜두 삭제 등 기존 서비스에 알림 이벤트 트랜잭션 추가
- 에러코드 파싱 추가