### PR TITLE
Feat: 데일리 요약 요청 구현

### DIFF
--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/notification/DailyBriefingDto.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/notification/DailyBriefingDto.java
@@ -1,0 +1,5 @@
+package com.ddudu.application.common.dto.notification;
+
+public record DailyBriefingDto(int count) {
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/notification/response/DailyBriefingResponse.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/notification/response/DailyBriefingResponse.java
@@ -1,0 +1,22 @@
+package com.ddudu.application.common.dto.notification.response;
+
+import com.ddudu.application.common.dto.notification.DailyBriefingDto;
+import lombok.Builder;
+
+@Builder
+public record DailyBriefingResponse(boolean isFirst, DailyBriefingDto content) {
+
+  public static DailyBriefingResponse notFirst() {
+    return DailyBriefingResponse.builder()
+        .isFirst(false)
+        .build();
+  }
+
+  public static DailyBriefingResponse from(DailyBriefingDto content) {
+    return DailyBriefingResponse.builder()
+        .isFirst(true)
+        .content(content)
+        .build();
+  }
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/stats/response/MonthlyStatsReportResponse.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/stats/response/MonthlyStatsReportResponse.java
@@ -10,7 +10,8 @@ public record MonthlyStatsReportResponse(
 ) {
 
   public static MonthlyStatsReportResponse from(
-      MonthlyStatsReportDto lastMonth, MonthlyStatsReportDto thisMonth
+      MonthlyStatsReportDto lastMonth,
+      MonthlyStatsReportDto thisMonth
   ) {
     return MonthlyStatsReportResponse.builder()
         .lastMonth(lastMonth)

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/ddudu/out/DduduLoaderPort.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/ddudu/out/DduduLoaderPort.java
@@ -17,4 +17,6 @@ public interface DduduLoaderPort {
 
   List<Ddudu> getDailyDdudus(LocalDate date, Long userId, List<PrivacyType> accessiblePrivacyTypes);
 
+  int countTodayDdudu(Long userId);
+
 }

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/notification/in/BriefTodayPlanningUseCase.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/notification/in/BriefTodayPlanningUseCase.java
@@ -1,0 +1,9 @@
+package com.ddudu.application.common.port.notification.in;
+
+import com.ddudu.application.common.dto.notification.response.DailyBriefingResponse;
+
+public interface BriefTodayPlanningUseCase {
+
+  DailyBriefingResponse getDailyBriefing(Long loginId);
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/DailyBriefingCommandPort.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/DailyBriefingCommandPort.java
@@ -1,0 +1,9 @@
+package com.ddudu.application.common.port.notification.out;
+
+import com.ddudu.domain.notification.briefing.aggregate.DailyBriefingLog;
+
+public interface DailyBriefingCommandPort {
+
+  DailyBriefingLog save(DailyBriefingLog dailyBriefingLog);
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/DailyBriefingLoaderPort.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/DailyBriefingLoaderPort.java
@@ -1,0 +1,7 @@
+package com.ddudu.application.common.port.notification.out;
+
+public interface DailyBriefingLoaderPort {
+
+  boolean existsByUser(Long userId);
+
+}

--- a/application/notification-application/build.gradle.kts
+++ b/application/notification-application/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(project(":application:application-common"))
     implementation(project(":common"))
     implementation(project(":domain:notification-domain"))
+    implementation(project(":domain:user-domain"))
 
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework:spring-tx")
@@ -15,6 +16,13 @@ dependencies {
     // application test fixtures
     testImplementation(testFixtures(project(":common")))
     testImplementation(testFixtures(project(":domain:user-domain")))
+    testImplementation(testFixtures(project(":domain:planning-domain")))
+    testImplementation(testFixtures(project(":domain:notification-domain")))
+
+    // For integration test, instead of mocking
+    testImplementation(project(":infra:user-infra-mysql"))
+    testImplementation(project(":infra:planning-infra-mysql"))
+    testImplementation(project(":infra:notification-infra-mysql"))
 }
 
 val copyTestSecret by tasks.registering(Copy::class) {

--- a/application/notification-application/src/main/java/com/ddudu/application/notification/dailybriefing/BriefTodayPlanningService.java
+++ b/application/notification-application/src/main/java/com/ddudu/application/notification/dailybriefing/BriefTodayPlanningService.java
@@ -1,0 +1,50 @@
+package com.ddudu.application.notification.dailybriefing;
+
+import com.ddudu.application.common.dto.notification.DailyBriefingDto;
+import com.ddudu.application.common.dto.notification.response.DailyBriefingResponse;
+import com.ddudu.application.common.port.ddudu.out.DduduLoaderPort;
+import com.ddudu.application.common.port.notification.in.BriefTodayPlanningUseCase;
+import com.ddudu.application.common.port.notification.out.DailyBriefingCommandPort;
+import com.ddudu.application.common.port.notification.out.DailyBriefingLoaderPort;
+import com.ddudu.application.common.port.user.out.UserLoaderPort;
+import com.ddudu.common.annotation.UseCase;
+import com.ddudu.common.exception.DailyBriefingLogErrorCode;
+import com.ddudu.domain.notification.briefing.aggregate.DailyBriefingLog;
+import com.ddudu.domain.user.user.aggregate.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class BriefTodayPlanningService implements BriefTodayPlanningUseCase {
+
+  private final UserLoaderPort userLoaderPort;
+  private final DailyBriefingLoaderPort dailyBriefingLoaderPort;
+  private final DailyBriefingCommandPort dailyBriefingCommandPort;
+  private final DduduLoaderPort dduduLoaderPort;
+
+  @Override
+  public DailyBriefingResponse getDailyBriefing(Long loginId) {
+    User user = userLoaderPort.getUserOrElseThrow(
+        loginId,
+        DailyBriefingLogErrorCode.LOGIN_USER_NOT_EXISTING.getCodeName()
+    );
+
+    boolean alreadyBriefed = dailyBriefingLoaderPort.existsByUser(user.getId());
+
+    if (alreadyBriefed) {
+      return DailyBriefingResponse.notFirst();
+    }
+
+    int count = dduduLoaderPort.countTodayDdudu(user.getId());
+    DailyBriefingLog dailyBriefingLog = DailyBriefingLog.builder()
+        .userId(user.getId())
+        .build();
+
+    dailyBriefingCommandPort.save(dailyBriefingLog);
+
+    return DailyBriefingResponse.from(new DailyBriefingDto(count));
+  }
+
+}

--- a/application/notification-application/src/test/java/com/ddudu/NotificationApplicationTestConfig.java
+++ b/application/notification-application/src/test/java/com/ddudu/NotificationApplicationTestConfig.java
@@ -1,0 +1,14 @@
+package com.ddudu;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(
+    scanBasePackages = {
+        "com.ddudu.application.notification",
+        "com.ddudu.infra",
+        "com.ddudu.domain"
+    }
+)
+public class NotificationApplicationTestConfig {
+
+}

--- a/application/notification-application/src/test/java/com/ddudu/application/notification/dailybriefing/BriefTodayPlanningServiceTest.java
+++ b/application/notification-application/src/test/java/com/ddudu/application/notification/dailybriefing/BriefTodayPlanningServiceTest.java
@@ -1,0 +1,113 @@
+package com.ddudu.application.notification.dailybriefing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.ddudu.application.common.dto.notification.response.DailyBriefingResponse;
+import com.ddudu.application.common.port.auth.out.SignUpPort;
+import com.ddudu.application.common.port.ddudu.out.SaveDduduPort;
+import com.ddudu.application.common.port.goal.out.SaveGoalPort;
+import com.ddudu.application.common.port.notification.out.DailyBriefingCommandPort;
+import com.ddudu.common.exception.DailyBriefingLogErrorCode;
+import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
+import com.ddudu.domain.planning.goal.aggregate.Goal;
+import com.ddudu.domain.user.user.aggregate.User;
+import com.ddudu.fixture.DailyBriefingLogFixture;
+import com.ddudu.fixture.DduduFixture;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.UserFixture;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.MissingResourceException;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class BriefTodayPlanningServiceTest {
+
+  @Autowired
+  BriefTodayPlanningService briefTodayPlanningService;
+
+  @Autowired
+  DailyBriefingCommandPort dailyBriefingCommandPort;
+
+  @Autowired
+  SaveDduduPort saveDduduPort;
+
+  @Autowired
+  SaveGoalPort saveGoalPort;
+
+  @Autowired
+  SignUpPort signUpPort;
+
+  User user;
+  int dduduCount;
+  List<Ddudu> ddudus;
+
+  @BeforeEach
+  void setUp() {
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    Goal goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user.getId()));
+    ddudus = new ArrayList<>();
+    dduduCount = DduduFixture.getRandomInt(1, 10);
+
+    for (int i = 0; i < dduduCount; i++) {
+      ddudus.add(DduduFixture.createRandomDduduWithSchedule(
+          user.getId(),
+          goal.getId(),
+          LocalDate.now()
+      ));
+    }
+
+    saveDduduPort.saveAll(ddudus);
+  }
+
+  @Test
+  void 오늘_처음_조회하는_경우_뚜두_개수와_함께_응답을_반환한다() {
+    // given
+
+    // when
+    DailyBriefingResponse actual = briefTodayPlanningService.getDailyBriefing(user.getId());
+
+    // then
+    assertThat(actual.isFirst()).isTrue();
+    assertThat(actual.content()
+        .count()).isEqualTo(dduduCount);
+  }
+
+  @Test
+  void 이미_오늘_조회한_경우_첫_조회가_아님을_표시한_응답을_반환한다() {
+    // given
+    dailyBriefingCommandPort.save(DailyBriefingLogFixture.createTodayBriefing(user.getId()));
+
+    // when
+    DailyBriefingResponse actual = briefTodayPlanningService.getDailyBriefing(user.getId());
+
+    // then
+    assertThat(actual.isFirst()).isFalse();
+    assertThat(actual.content()).isNull();
+  }
+
+  @Test
+  void 존재하지_않는_사용자인_경우_예외가_발생한다() {
+    // given
+    Long invalidId = UserFixture.getRandomId();
+
+    // when
+    ThrowingCallable brief = () -> briefTodayPlanningService.getDailyBriefing(invalidId);
+
+    // then
+    assertThatExceptionOfType(MissingResourceException.class).isThrownBy(brief)
+        .withMessage(DailyBriefingLogErrorCode.LOGIN_USER_NOT_EXISTING.getCodeName());
+  }
+
+}

--- a/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/DailyBriefingErrorExamples.java
+++ b/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/DailyBriefingErrorExamples.java
@@ -1,0 +1,19 @@
+package com.ddudu.bootstrap.common.doc.examples;
+
+public final class DailyBriefingErrorExamples {
+
+  public static final String NULL_USER_ID = """
+      {
+        "code": 11001,
+        "message": "데일리 사전 요약 발송 대상 유저는 필수값입니다."
+      }
+      """;
+
+  public static final String LOGIN_USER_NOT_EXISTING = """
+      {
+        "code": 11002,
+        "message": "로그인 사용자를 찾을 수 없습니다."
+      }
+      """;
+
+}

--- a/bootstrap/bootstrap-gateway/src/main/resources/db/data/afterMigrate.sql
+++ b/bootstrap/bootstrap-gateway/src/main/resources/db/data/afterMigrate.sql
@@ -7,6 +7,11 @@ TRUNCATE auth_providers;
 TRUNCATE goals;
 TRUNCATE ddudus;
 TRUNCATE repeat_ddudus;
+TRUNCATE notification_events;
+TRUNCATE daily_briefing_logs;
+TRUNCATE period_goals;
+TRUNCATE notification_inboxes;
+TRUNCATE notification_device_tokens;
 
 SET foreign_key_checks = 1;
 

--- a/bootstrap/notification-api/src/main/java/com/ddudu/api/notification/dailybriefing/controller/DailyBriefingController.java
+++ b/bootstrap/notification-api/src/main/java/com/ddudu/api/notification/dailybriefing/controller/DailyBriefingController.java
@@ -1,0 +1,29 @@
+package com.ddudu.api.notification.dailybriefing.controller;
+
+import com.ddudu.api.notification.dailybriefing.doc.DailyBriefingControllerDoc;
+import com.ddudu.application.common.dto.notification.response.DailyBriefingResponse;
+import com.ddudu.application.common.port.notification.in.BriefTodayPlanningUseCase;
+import com.ddudu.bootstrap.common.annotation.Login;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/briefings")
+@RequiredArgsConstructor
+public class DailyBriefingController implements DailyBriefingControllerDoc {
+
+  private final BriefTodayPlanningUseCase briefTodayPlanningUseCase;
+
+  @Override
+  @PostMapping
+  public ResponseEntity<DailyBriefingResponse> getDailyBriefing(@Login Long loginId) {
+    DailyBriefingResponse response = briefTodayPlanningUseCase.getDailyBriefing(loginId);
+
+    return ResponseEntity.created(null)
+        .body(response);
+  }
+
+}

--- a/bootstrap/notification-api/src/main/java/com/ddudu/api/notification/dailybriefing/doc/DailyBriefingControllerDoc.java
+++ b/bootstrap/notification-api/src/main/java/com/ddudu/api/notification/dailybriefing/doc/DailyBriefingControllerDoc.java
@@ -1,0 +1,53 @@
+package com.ddudu.api.notification.dailybriefing.doc;
+
+import com.ddudu.application.common.dto.notification.response.DailyBriefingResponse;
+import com.ddudu.bootstrap.common.doc.examples.DailyBriefingErrorExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(
+    name = "Daily Briefing",
+    description = "데일리 요약 관련 API"
+)
+public interface DailyBriefingControllerDoc {
+
+  @Operation(summary = "데일리 브리핑")
+  @ApiResponses(
+      {
+          @ApiResponse(
+              responseCode = "201",
+              description = "CREATED",
+              useReturnTypeSchema = true
+          ),
+          @ApiResponse(
+              responseCode = "400",
+              description = "BAD_REQUEST",
+              content = @Content(
+                  examples = {
+                      @ExampleObject(
+                          name = "11001",
+                          value = DailyBriefingErrorExamples.NULL_USER_ID
+                      )
+                  }
+              )
+          ),
+          @ApiResponse(
+              responseCode = "404",
+              description = "NOT_FOUND",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "11002",
+                      value = DailyBriefingErrorExamples.LOGIN_USER_NOT_EXISTING
+                  )
+              )
+          )
+      }
+  )
+  ResponseEntity<DailyBriefingResponse> getDailyBriefing(Long loginId);
+
+}

--- a/common/src/main/java/com/ddudu/common/exception/DailyBriefingLogErrorCode.java
+++ b/common/src/main/java/com/ddudu/common/exception/DailyBriefingLogErrorCode.java
@@ -1,0 +1,19 @@
+package com.ddudu.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum DailyBriefingLogErrorCode implements ErrorCode {
+  NULL_USER_ID(11001, "데일리 사전 요약 발송 대상 유저는 필수값입니다.");
+
+  private final int code;
+  private final String message;
+
+  @Override
+  public String getCodeName() {
+    return this.code + " " + this.name();
+  }
+
+}

--- a/common/src/main/java/com/ddudu/common/exception/DailyBriefingLogErrorCode.java
+++ b/common/src/main/java/com/ddudu/common/exception/DailyBriefingLogErrorCode.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum DailyBriefingLogErrorCode implements ErrorCode {
-  NULL_USER_ID(11001, "데일리 사전 요약 발송 대상 유저는 필수값입니다.");
+  NULL_USER_ID(11001, "데일리 사전 요약 발송 대상 유저는 필수값입니다."),
+  LOGIN_USER_NOT_EXISTING(11002, "로그인 사용자를 찾을 수 없습니다");
 
   private final int code;
   private final String message;

--- a/common/src/main/java/com/ddudu/common/exception/DailyBriefingLogErrorCode.java
+++ b/common/src/main/java/com/ddudu/common/exception/DailyBriefingLogErrorCode.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum DailyBriefingLogErrorCode implements ErrorCode {
   NULL_USER_ID(11001, "데일리 사전 요약 발송 대상 유저는 필수값입니다."),
-  LOGIN_USER_NOT_EXISTING(11002, "로그인 사용자를 찾을 수 없습니다");
+  LOGIN_USER_NOT_EXISTING(11002, "로그인 사용자를 찾을 수 없습니다.");
 
   private final int code;
   private final String message;

--- a/common/src/main/java/com/ddudu/common/exception/ErrorCodeParser.java
+++ b/common/src/main/java/com/ddudu/common/exception/ErrorCodeParser.java
@@ -28,6 +28,7 @@ public class ErrorCodeParser {
       case 9 ->
           code.charAt(1) != '9' ? StatsErrorCode.valueOf(name) : new DefaultErrorCode(message);
       case 10 -> NotificationEventErrorCode.valueOf(name);
+      case 11 -> DailyBriefingLogErrorCode.valueOf(name);
       default -> new DefaultErrorCode(message);
     };
   }

--- a/domain/notification-domain/src/main/java/com/ddudu/domain/notification/briefing/aggregate/DailyBriefingLog.java
+++ b/domain/notification-domain/src/main/java/com/ddudu/domain/notification/briefing/aggregate/DailyBriefingLog.java
@@ -1,20 +1,37 @@
 package com.ddudu.domain.notification.briefing.aggregate;
 
-import java.time.LocalDate;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import static com.google.common.base.Preconditions.checkArgument;
 
+import com.ddudu.common.exception.DailyBriefingLogErrorCode;
+import java.time.LocalDate;
+import java.util.Objects;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Getter
-@Builder
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DailyBriefingLog {
 
-  private Long id;
-  private Long userId;
-  private LocalDate briefingDate;
+  @EqualsAndHashCode.Include
+  private final Long id;
+  private final Long userId;
+  private final LocalDate briefingDate;
+
+  @Builder
+  private DailyBriefingLog(Long id, Long userId, LocalDate briefingDate) {
+    validate(userId);
+
+    this.id = id;
+    this.userId = userId;
+    this.briefingDate = Objects.requireNonNullElse(briefingDate, LocalDate.now());
+  }
+
+  private void validate(Long userId) {
+    checkArgument(
+        Objects.nonNull(userId),
+        DailyBriefingLogErrorCode.NULL_USER_ID.getCodeName()
+    );
+  }
 
 }

--- a/domain/notification-domain/src/test/java/com/ddudu/domain/notification/briefing/aggregate/DailyBriefingLogTest.java
+++ b/domain/notification-domain/src/test/java/com/ddudu/domain/notification/briefing/aggregate/DailyBriefingLogTest.java
@@ -1,0 +1,78 @@
+package com.ddudu.domain.notification.briefing.aggregate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import com.ddudu.common.exception.DailyBriefingLogErrorCode;
+import com.ddudu.domain.notification.briefing.aggregate.DailyBriefingLog.DailyBriefingLogBuilder;
+import com.ddudu.fixture.DailyBriefingLogFixture;
+import java.time.LocalDate;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DailyBriefingLogTest {
+
+  Long userId;
+  LocalDate briefingDate;
+
+  @BeforeEach
+  void setUp() {
+    userId = DailyBriefingLogFixture.getRandomId();
+    briefingDate = DailyBriefingLogFixture.getFutureDateTime(1, TimeUnit.MINUTES)
+        .toLocalDate();
+  }
+
+  @Nested
+  class 생성_테스트 {
+
+    @Test
+    void 데일리_사전_요약을_생성한다() {
+      // given
+      DailyBriefingLogBuilder builder = DailyBriefingLog.builder()
+          .userId(userId)
+          .briefingDate(briefingDate);
+
+      // when
+      DailyBriefingLog actual = builder.build();
+
+      // then
+      assertThat(actual.getUserId()).isEqualTo(userId);
+      assertThat(actual.getBriefingDate()).isEqualTo(briefingDate);
+    }
+
+    @Test
+    void 사전_요약_날짜가_없으면_오늘의_데일리_요약을_생성한다() {
+      // given
+      DailyBriefingLogBuilder builder = DailyBriefingLog.builder()
+          .userId(userId);
+
+      // when
+      DailyBriefingLog actual = builder.build();
+
+      // then
+      assertThat(actual.getBriefingDate()).isToday();
+    }
+
+    @Test
+    void 유저가_없으면_데일리_요약_생성을_실패한다() {
+      // given
+      DailyBriefingLogBuilder builder = DailyBriefingLog.builder()
+          .briefingDate(briefingDate);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(DailyBriefingLogErrorCode.NULL_USER_ID.getCodeName());
+    }
+
+  }
+
+}

--- a/domain/notification-domain/src/testFixtures/java/com/ddudu/fixture/DailyBriefingLogFixture.java
+++ b/domain/notification-domain/src/testFixtures/java/com/ddudu/fixture/DailyBriefingLogFixture.java
@@ -1,0 +1,5 @@
+package com.ddudu.fixture;
+
+public final class DailyBriefingLogFixture extends BaseFixture {
+
+}

--- a/domain/notification-domain/src/testFixtures/java/com/ddudu/fixture/DailyBriefingLogFixture.java
+++ b/domain/notification-domain/src/testFixtures/java/com/ddudu/fixture/DailyBriefingLogFixture.java
@@ -1,5 +1,19 @@
 package com.ddudu.fixture;
 
+import com.ddudu.domain.notification.briefing.aggregate.DailyBriefingLog;
+import java.time.LocalDate;
+
 public final class DailyBriefingLogFixture extends BaseFixture {
+
+  public static DailyBriefingLog createTodayBriefing(Long userId) {
+    return createDailyBriefingLog(userId, LocalDate.now());
+  }
+
+  public static DailyBriefingLog createDailyBriefingLog(Long userId, LocalDate briefingDate) {
+    return DailyBriefingLog.builder()
+        .userId(userId)
+        .briefingDate(briefingDate)
+        .build();
+  }
 
 }

--- a/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/briefing/adapter/DailyBriefingAdapter.java
+++ b/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/briefing/adapter/DailyBriefingAdapter.java
@@ -1,0 +1,28 @@
+package com.ddudu.infra.mysql.notification.briefing.adapter;
+
+import com.ddudu.application.common.port.notification.out.DailyBriefingCommandPort;
+import com.ddudu.application.common.port.notification.out.DailyBriefingLoaderPort;
+import com.ddudu.common.annotation.DrivenAdapter;
+import com.ddudu.domain.notification.briefing.aggregate.DailyBriefingLog;
+import com.ddudu.infra.mysql.notification.briefing.entity.DailyBriefingLogEntity;
+import com.ddudu.infra.mysql.notification.briefing.repository.DailyBriefingRepository;
+import lombok.RequiredArgsConstructor;
+
+@DrivenAdapter
+@RequiredArgsConstructor
+public class DailyBriefingAdapter implements DailyBriefingLoaderPort, DailyBriefingCommandPort {
+
+  private final DailyBriefingRepository dailyBriefingRepository;
+
+  @Override
+  public DailyBriefingLog save(DailyBriefingLog dailyBriefingLog) {
+    return dailyBriefingRepository.save(DailyBriefingLogEntity.from(dailyBriefingLog))
+        .toDomain();
+  }
+
+  @Override
+  public boolean existsByUser(Long userId) {
+    return dailyBriefingRepository.existsByUserId(userId);
+  }
+
+}

--- a/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/briefing/repository/DailyBriefingRepository.java
+++ b/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/briefing/repository/DailyBriefingRepository.java
@@ -1,0 +1,10 @@
+package com.ddudu.infra.mysql.notification.briefing.repository;
+
+import com.ddudu.infra.mysql.notification.briefing.entity.DailyBriefingLogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyBriefingRepository extends JpaRepository<DailyBriefingLogEntity, Long> {
+
+  boolean existsByUserId(Long userId);
+
+}

--- a/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/adapter/DduduPersistenceAdapter.java
+++ b/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/adapter/DduduPersistenceAdapter.java
@@ -79,6 +79,11 @@ public class DduduPersistenceAdapter implements DduduLoaderPort, DduduUpdatePort
   }
 
   @Override
+  public int countTodayDdudu(Long userId) {
+    return dduduRepository.countTodayByUserId(userId);
+  }
+
+  @Override
   public Ddudu update(Ddudu ddudu) {
     DduduEntity dduduEntity = dduduRepository.findById(ddudu.getId())
         .orElseThrow(EntityNotFoundException::new);

--- a/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/repository/DduduQueryRepository.java
+++ b/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/repository/DduduQueryRepository.java
@@ -51,4 +51,6 @@ public interface DduduQueryRepository {
       LocalDate to
   );
 
+  int countTodayByUserId(Long userId);
+
 }

--- a/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/repository/DduduQueryRepositoryImpl.java
+++ b/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/repository/DduduQueryRepositoryImpl.java
@@ -28,6 +28,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
@@ -223,6 +224,14 @@ public class DduduQueryRepositoryImpl implements DduduQueryRepository {
         .groupBy(dduduEntity.repeatDduduId)
         .orderBy(completedCount.desc(), totalCount.desc())
         .fetch();
+  }
+
+  @Override
+  public int countTodayByUserId(Long userId) {
+    return jpaQueryFactory.select(Wildcard.countAsInt)
+        .from(dduduEntity)
+        .where(dduduEntity.userId.eq(userId), dduduEntity.scheduledOn.eq(LocalDate.now()))
+        .fetchOne();
   }
 
   private Predicate getOpenness(boolean isMine, boolean isFollower) {


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
- Resolves #275 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 데일리 요약 도메인 검증
- 데일리 요약 요청 서비스
- 금일 뚜두 카운트 쿼리
- 데일리 요약 save/query 구현
