### PR TITLE
Refactor: 알림 이벤트 서비스 분리

### DIFF
--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/interim/InterimCancelReminderEvent.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/interim/InterimCancelReminderEvent.java
@@ -1,0 +1,24 @@
+package com.ddudu.application.common.dto.interim;
+
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record InterimCancelReminderEvent(
+    Long userId,
+    NotificationEventTypeCode typeCode,
+    Long contextId,
+    LocalDateTime willFireAt
+) implements InterimNotificationEvent {
+
+  public static InterimCancelReminderEvent from(Long userId, Ddudu ddudu) {
+    return InterimCancelReminderEvent.builder()
+        .userId(userId)
+        .typeCode(NotificationEventTypeCode.DDUDU)
+        .contextId(ddudu.getId())
+        .build();
+  }
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/interim/InterimDeleteDduduEvent.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/interim/InterimDeleteDduduEvent.java
@@ -1,0 +1,24 @@
+package com.ddudu.application.common.dto.interim;
+
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record InterimDeleteDduduEvent(
+    Long userId,
+    NotificationEventTypeCode typeCode,
+    Long contextId,
+    LocalDateTime willFireAt
+) implements InterimNotificationEvent {
+
+  public static InterimDeleteDduduEvent from(Long userId, Ddudu ddudu) {
+    return InterimDeleteDduduEvent.builder()
+        .userId(userId)
+        .typeCode(NotificationEventTypeCode.DDUDU)
+        .contextId(ddudu.getId())
+        .build();
+  }
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/interim/InterimNotificationEvent.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/interim/InterimNotificationEvent.java
@@ -1,0 +1,16 @@
+package com.ddudu.application.common.dto.interim;
+
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import java.time.LocalDateTime;
+
+public interface InterimNotificationEvent {
+
+  Long userId();
+
+  NotificationEventTypeCode typeCode();
+
+  Long contextId();
+
+  LocalDateTime willFireAt();
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/interim/InterimSetReminderEvent.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/interim/InterimSetReminderEvent.java
@@ -1,0 +1,25 @@
+package com.ddudu.application.common.dto.interim;
+
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record InterimSetReminderEvent(
+    Long userId,
+    NotificationEventTypeCode typeCode,
+    Long contextId,
+    LocalDateTime willFireAt
+) implements InterimNotificationEvent {
+
+  public static InterimSetReminderEvent from(Long userId, Ddudu ddudu) {
+    return InterimSetReminderEvent.builder()
+        .userId(userId)
+        .typeCode(NotificationEventTypeCode.DDUDU)
+        .contextId(ddudu.getId())
+        .willFireAt(ddudu.getRemindAt())
+        .build();
+  }
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/notification/event/NotificationEventRemoveEvent.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/notification/event/NotificationEventRemoveEvent.java
@@ -1,0 +1,22 @@
+package com.ddudu.application.common.dto.notification.event;
+
+import com.ddudu.application.common.dto.interim.InterimNotificationEvent;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import lombok.Builder;
+
+@Builder
+public record NotificationEventRemoveEvent(
+    Long userId,
+    NotificationEventTypeCode typeCode,
+    Long contextId
+) {
+
+  public static NotificationEventRemoveEvent from(InterimNotificationEvent event) {
+    return NotificationEventRemoveEvent.builder()
+        .userId(event.userId())
+        .typeCode(event.typeCode())
+        .contextId(event.contextId())
+        .build();
+  }
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/notification/event/NotificationEventSaveEvent.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/notification/event/NotificationEventSaveEvent.java
@@ -1,0 +1,25 @@
+package com.ddudu.application.common.dto.notification.event;
+
+import com.ddudu.application.common.dto.interim.InterimNotificationEvent;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record NotificationEventSaveEvent(
+    Long userId,
+    NotificationEventTypeCode typeCode,
+    Long contextId,
+    LocalDateTime willFireAt
+) {
+
+  public static NotificationEventSaveEvent from(InterimNotificationEvent event) {
+    return NotificationEventSaveEvent.builder()
+        .userId(event.userId())
+        .typeCode(event.typeCode())
+        .contextId(event.contextId())
+        .willFireAt(event.willFireAt())
+        .build();
+  }
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/notification/in/RemoveNotificationEventUseCase.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/notification/in/RemoveNotificationEventUseCase.java
@@ -1,0 +1,9 @@
+package com.ddudu.application.common.port.notification.in;
+
+import com.ddudu.application.common.dto.notification.event.NotificationEventRemoveEvent;
+
+public interface RemoveNotificationEventUseCase {
+
+  void remove(NotificationEventRemoveEvent event);
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/notification/in/SaveNotificationEventUseCase.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/notification/in/SaveNotificationEventUseCase.java
@@ -1,0 +1,9 @@
+package com.ddudu.application.common.port.notification.in;
+
+import com.ddudu.application.common.dto.notification.event.NotificationEventSaveEvent;
+
+public interface SaveNotificationEventUseCase {
+
+  void save(NotificationEventSaveEvent event);
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/NotificationEventCommandPort.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/NotificationEventCommandPort.java
@@ -1,14 +1,13 @@
 package com.ddudu.application.common.port.notification.out;
 
 import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
-import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
 
 public interface NotificationEventCommandPort {
 
   NotificationEvent save(NotificationEvent event);
 
-  void delete(NotificationEvent event);
+  NotificationEvent update(NotificationEvent event);
 
-  void deleteAllByContext(NotificationEventTypeCode typeCode, Long contextId);
+  void delete(NotificationEvent event);
 
 }

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/NotificationEventLoaderPort.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/NotificationEventLoaderPort.java
@@ -6,9 +6,10 @@ import java.util.Optional;
 
 public interface NotificationEventLoaderPort {
 
-  boolean existsByContext(NotificationEventTypeCode typeCode, Long contextId);
+  boolean existsByContext(Long userId, NotificationEventTypeCode typeCode, Long contextId);
 
   Optional<NotificationEvent> getOptionalEventByContext(
+      Long userId,
       NotificationEventTypeCode typeCode,
       Long contextId
   );

--- a/application/notification-application/src/main/java/com/ddudu/application/notification/event/RemoveNotificationEventService.java
+++ b/application/notification-application/src/main/java/com/ddudu/application/notification/event/RemoveNotificationEventService.java
@@ -1,0 +1,46 @@
+package com.ddudu.application.notification.event;
+
+import com.ddudu.application.common.dto.notification.event.NotificationEventRemoveEvent;
+import com.ddudu.application.common.port.notification.in.RemoveNotificationEventUseCase;
+import com.ddudu.application.common.port.notification.out.NotificationEventCommandPort;
+import com.ddudu.application.common.port.notification.out.NotificationEventLoaderPort;
+import com.ddudu.common.annotation.UseCase;
+import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class RemoveNotificationEventService implements RemoveNotificationEventUseCase {
+
+  private final NotificationEventLoaderPort notificationEventLoaderPort;
+  private final NotificationEventCommandPort notificationEventCommandPort;
+
+  @Override
+  public void remove(NotificationEventRemoveEvent event) {
+    Optional<NotificationEvent> optionalEvent = notificationEventLoaderPort.getOptionalEventByContext(
+        event.userId(),
+        event.typeCode(),
+        event.contextId()
+    );
+
+    if (optionalEvent.isEmpty()) {
+      return;
+    }
+
+    NotificationEvent notificationEvent = optionalEvent.get();
+
+    if (notificationEvent.isAlreadyFired()) {
+      return;
+    }
+
+    notificationEventCommandPort.delete(notificationEvent);
+
+    if (notificationEvent.isPlannedToday()) {
+      // TODO: Task Scheduler 구현 후 예약 취소 구현
+    }
+  }
+
+}

--- a/application/notification-application/src/main/java/com/ddudu/application/notification/event/SaveNotificationEventService.java
+++ b/application/notification-application/src/main/java/com/ddudu/application/notification/event/SaveNotificationEventService.java
@@ -1,0 +1,55 @@
+package com.ddudu.application.notification.event;
+
+import com.ddudu.application.common.dto.notification.event.NotificationEventSaveEvent;
+import com.ddudu.application.common.port.notification.in.SaveNotificationEventUseCase;
+import com.ddudu.application.common.port.notification.out.NotificationEventCommandPort;
+import com.ddudu.application.common.port.notification.out.NotificationEventLoaderPort;
+import com.ddudu.common.annotation.UseCase;
+import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class SaveNotificationEventService implements SaveNotificationEventUseCase {
+
+  private final NotificationEventCommandPort notificationEventCommandPort;
+  private final NotificationEventLoaderPort notificationEventLoaderPort;
+
+  @Override
+  public void save(NotificationEventSaveEvent event) {
+    NotificationEvent notificationEvent = upsertEvent(event);
+
+    if (notificationEvent.isPlannedToday()) {
+      // TODO: Task Scheduler 구현 후 예약 구현
+    }
+  }
+
+  private NotificationEvent upsertEvent(NotificationEventSaveEvent event) {
+    Optional<NotificationEvent> optionalEvent = notificationEventLoaderPort.getOptionalEventByContext(
+        event.userId(),
+        event.typeCode(),
+        event.contextId()
+    );
+
+    if (optionalEvent.isEmpty()) {
+      NotificationEvent notificationEvent = NotificationEvent.builder()
+          .contextId(event.contextId())
+          .typeCode(event.typeCode())
+          .receiverId(event.userId())
+          .senderId(event.userId())
+          .willFireAt(event.willFireAt())
+          .build();
+
+      return notificationEventCommandPort.save(notificationEvent);
+    }
+
+    NotificationEvent notificationEvent = optionalEvent.get()
+        .updateFireTime(event.willFireAt());
+
+    return notificationEventCommandPort.update(notificationEvent);
+  }
+
+}

--- a/application/notification-application/src/test/java/com/ddudu/application/notification/event/RemoveNotificationEventServiceTest.java
+++ b/application/notification-application/src/test/java/com/ddudu/application/notification/event/RemoveNotificationEventServiceTest.java
@@ -1,0 +1,163 @@
+package com.ddudu.application.notification.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddudu.application.common.dto.notification.event.NotificationEventRemoveEvent;
+import com.ddudu.application.common.port.auth.out.SignUpPort;
+import com.ddudu.application.common.port.ddudu.out.SaveDduduPort;
+import com.ddudu.application.common.port.goal.out.SaveGoalPort;
+import com.ddudu.application.common.port.notification.in.RemoveNotificationEventUseCase;
+import com.ddudu.application.common.port.notification.out.NotificationEventCommandPort;
+import com.ddudu.application.common.port.notification.out.NotificationEventLoaderPort;
+import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
+import com.ddudu.domain.planning.goal.aggregate.Goal;
+import com.ddudu.domain.user.user.aggregate.User;
+import com.ddudu.fixture.DduduFixture;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.NotificationEventFixture;
+import com.ddudu.fixture.UserFixture;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Transactional
+class RemoveNotificationEventServiceTest {
+
+  @Autowired
+  RemoveNotificationEventUseCase removeNotificationEventUseCase;
+
+  @Autowired
+  SignUpPort signUpPort;
+
+  @Autowired
+  SaveGoalPort saveGoalPort;
+
+  @Autowired
+  SaveDduduPort saveDduduPort;
+
+  @Autowired
+  NotificationEventCommandPort notificationEventCommandPort;
+
+  @Autowired
+  NotificationEventLoaderPort notificationEventLoaderPort;
+
+  User user;
+  Goal goal;
+  Ddudu ddudu;
+  LocalDateTime willFireAt;
+  NotificationEvent notificationEvent;
+
+  @BeforeEach
+  void setUp() {
+    willFireAt = NotificationEventFixture.getFutureDateTime(10, TimeUnit.DAYS);
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user.getId()));
+    ddudu = saveDduduPort.save(DduduFixture.createRandomDduduWithGoal(goal));
+    notificationEvent = NotificationEventFixture.createValidDduduEventWithUserAndContext(
+        user.getId(),
+        ddudu.getId(),
+        willFireAt
+    );
+  }
+
+  @Test
+  void 알림_이벤트_기록을_성공적으로_삭제한다() {
+    // given
+    notificationEventCommandPort.save(notificationEvent);
+
+    NotificationEventRemoveEvent removeEvent = NotificationEventRemoveEvent.builder()
+        .userId(user.getId())
+        .typeCode(NotificationEventTypeCode.DDUDU)
+        .contextId(ddudu.getId())
+        .build();
+    boolean expected = notificationEventLoaderPort.existsByContext(
+        user.getId(),
+        NotificationEventTypeCode.DDUDU,
+        ddudu.getId()
+    );
+
+    // when
+    removeNotificationEventUseCase.remove(removeEvent);
+
+    // then
+    boolean actual = notificationEventLoaderPort.existsByContext(
+        user.getId(),
+        NotificationEventTypeCode.DDUDU,
+        ddudu.getId()
+    );
+
+    assertThat(actual).isNotEqualTo(expected);
+  }
+
+  @Test
+  void 알림이_존재하지_않으면_삭제하지_않는다() {
+    // given
+    long invalidId = NotificationEventFixture.getRandomId();
+    NotificationEventRemoveEvent removeEvent = NotificationEventRemoveEvent.builder()
+        .userId(user.getId())
+        .typeCode(NotificationEventTypeCode.DDUDU)
+        .contextId(invalidId)
+        .build();
+    boolean expected = notificationEventLoaderPort.existsByContext(
+        user.getId(),
+        NotificationEventTypeCode.DDUDU,
+        invalidId
+    );
+
+    // when
+    removeNotificationEventUseCase.remove(removeEvent);
+
+    // then
+    boolean actual = notificationEventLoaderPort.existsByContext(
+        user.getId(),
+        NotificationEventTypeCode.DDUDU,
+        invalidId
+    );
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void 알림이_이미_발송됐으면_삭제하지_않는다() {
+    // given
+    notificationEvent = notificationEventCommandPort.save(
+        NotificationEventFixture.createFiredDduduEventNowWithUserAndContext(
+            user.getId(),
+            ddudu.getId()
+        )
+    );
+    NotificationEventRemoveEvent removeEvent = NotificationEventRemoveEvent.builder()
+        .userId(user.getId())
+        .typeCode(NotificationEventTypeCode.DDUDU)
+        .contextId(ddudu.getId())
+        .build();
+    boolean expected = notificationEventLoaderPort.existsByContext(
+        user.getId(),
+        NotificationEventTypeCode.DDUDU,
+        ddudu.getId()
+    );
+
+    // when
+    removeNotificationEventUseCase.remove(removeEvent);
+
+    // then
+    boolean actual = notificationEventLoaderPort.existsByContext(
+        user.getId(),
+        NotificationEventTypeCode.DDUDU,
+        ddudu.getId()
+    );
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+}

--- a/application/notification-application/src/test/java/com/ddudu/application/notification/event/SaveNotificationEventServiceTest.java
+++ b/application/notification-application/src/test/java/com/ddudu/application/notification/event/SaveNotificationEventServiceTest.java
@@ -1,0 +1,125 @@
+package com.ddudu.application.notification.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddudu.application.common.dto.notification.event.NotificationEventSaveEvent;
+import com.ddudu.application.common.port.auth.out.SignUpPort;
+import com.ddudu.application.common.port.ddudu.out.SaveDduduPort;
+import com.ddudu.application.common.port.goal.out.SaveGoalPort;
+import com.ddudu.application.common.port.notification.in.SaveNotificationEventUseCase;
+import com.ddudu.application.common.port.notification.out.NotificationEventCommandPort;
+import com.ddudu.application.common.port.notification.out.NotificationEventLoaderPort;
+import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
+import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
+import com.ddudu.domain.planning.goal.aggregate.Goal;
+import com.ddudu.domain.user.user.aggregate.User;
+import com.ddudu.fixture.DduduFixture;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.NotificationEventFixture;
+import com.ddudu.fixture.UserFixture;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Transactional
+class SaveNotificationEventServiceTest {
+
+  @Autowired
+  SaveNotificationEventUseCase saveNotificationEventUseCase;
+
+  @Autowired
+  SignUpPort signUpPort;
+
+  @Autowired
+  SaveGoalPort saveGoalPort;
+
+  @Autowired
+  SaveDduduPort saveDduduPort;
+
+  @Autowired
+  NotificationEventCommandPort notificationEventCommandPort;
+
+  @Autowired
+  NotificationEventLoaderPort notificationEventLoaderPort;
+
+  User user;
+  Goal goal;
+  Ddudu ddudu;
+  LocalDateTime willFireAt;
+
+  @BeforeEach
+  void setUp() {
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user.getId()));
+    ddudu = saveDduduPort.save(DduduFixture.createRandomDduduWithGoal(goal));
+    willFireAt = NotificationEventFixture.getFutureDateTime(10, TimeUnit.DAYS);
+  }
+
+  @Test
+  void 알림_이벤트_기록을_성공적으로_저장한다() {
+    // given
+    NotificationEventSaveEvent saveEvent = NotificationEventSaveEvent.builder()
+        .userId(user.getId())
+        .contextId(ddudu.getId())
+        .typeCode(NotificationEventTypeCode.DDUDU)
+        .willFireAt(willFireAt)
+        .build();
+
+    // when
+    saveNotificationEventUseCase.save(saveEvent);
+
+    // then
+    Optional<NotificationEvent> actual = notificationEventLoaderPort.getOptionalEventByContext(
+        user.getId(),
+        NotificationEventTypeCode.DDUDU,
+        ddudu.getId()
+    );
+
+    assertThat(actual).isPresent();
+    assertThat(actual.get()
+        .getWillFireAt()).isEqualTo(willFireAt);
+  }
+
+  @Test
+  void 이미_존재하는_알림_컨텍스트면_발송_예정_시간을_수정한다() {
+    // given
+    NotificationEvent savedNotificationEvent = notificationEventCommandPort.save(
+        NotificationEventFixture.createValidDduduEventNowWithUserAndContext(
+            user.getId(),
+            ddudu.getId()
+        )
+    );
+
+    NotificationEventSaveEvent saveEvent = NotificationEventSaveEvent.builder()
+        .userId(user.getId())
+        .contextId(ddudu.getId())
+        .typeCode(NotificationEventTypeCode.DDUDU)
+        .willFireAt(willFireAt)
+        .build();
+
+    // when
+    saveNotificationEventUseCase.save(saveEvent);
+
+    // then
+    NotificationEvent actual = notificationEventLoaderPort.getOptionalEventByContext(
+            user.getId(),
+            NotificationEventTypeCode.DDUDU,
+            ddudu.getId()
+        )
+        .orElseThrow();
+
+    assertThat(actual.getId()).isEqualTo(savedNotificationEvent.getId());
+    assertThat(actual.getWillFireAt()).isEqualTo(willFireAt);
+  }
+
+}

--- a/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/DeleteDduduService.java
+++ b/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/DeleteDduduService.java
@@ -1,26 +1,31 @@
 package com.ddudu.application.planning.ddudu.service;
 
+import com.ddudu.application.common.dto.interim.InterimCancelReminderEvent;
+import com.ddudu.application.common.dto.interim.InterimDeleteDduduEvent;
+import com.ddudu.application.common.dto.notification.event.NotificationEventRemoveEvent;
 import com.ddudu.application.common.port.ddudu.in.DeleteDduduUseCase;
 import com.ddudu.application.common.port.ddudu.out.DduduLoaderPort;
 import com.ddudu.application.common.port.ddudu.out.DeleteDduduPort;
-import com.ddudu.application.common.port.notification.out.NotificationEventCommandPort;
 import com.ddudu.common.annotation.UseCase;
-import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
 import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @UseCase
 @RequiredArgsConstructor
-@Transactional
 public class DeleteDduduService implements DeleteDduduUseCase {
 
   private final DduduLoaderPort dduduLoaderPort;
   private final DeleteDduduPort deleteDduduPort;
-  private final NotificationEventCommandPort notificationEventCommandPort;
+  private final ApplicationEventPublisher applicationEventPublisher;
 
   @Override
+  @Transactional
   public void delete(Long loginId, Long dduduId) {
     Optional<Ddudu> optionalDdudu = dduduLoaderPort.getOptionalDdudu(dduduId);
 
@@ -32,7 +37,21 @@ public class DeleteDduduService implements DeleteDduduUseCase {
 
     ddudu.validateDduduCreator(loginId);
     deleteDduduPort.delete(ddudu);
-    notificationEventCommandPort.deleteAllByContext(NotificationEventTypeCode.DDUDU, ddudu.getId());
+
+    InterimCancelReminderEvent interimEvent = InterimCancelReminderEvent.from(
+        loginId,
+        ddudu
+    );
+
+    applicationEventPublisher.publishEvent(interimEvent);
+  }
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  void publishNotificationEventAfterCommit(InterimDeleteDduduEvent event) {
+    NotificationEventRemoveEvent removeEvent = NotificationEventRemoveEvent.from(event);
+
+    applicationEventPublisher.publishEvent(removeEvent);
   }
 
 }

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/CancelReminderServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/CancelReminderServiceTest.java
@@ -10,7 +10,6 @@ import com.ddudu.application.common.port.notification.out.NotificationEventComma
 import com.ddudu.application.common.port.notification.out.NotificationEventLoaderPort;
 import com.ddudu.common.exception.DduduErrorCode;
 import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
-import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
 import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
 import com.ddudu.domain.planning.goal.aggregate.Goal;
 import com.ddudu.domain.user.user.aggregate.User;
@@ -91,13 +90,8 @@ class CancelReminderServiceTest {
 
     // then
     Ddudu actual = dduduLoaderPort.getDduduOrElseThrow(ddudu.getId(), "not found");
-    boolean actualEventExists = notificationEventLoaderPort.existsByContext(
-        NotificationEventTypeCode.DDUDU,
-        ddudu.getId()
-    );
 
     assertThat(actual.getRemindAt()).isNull();
-    assertThat(actualEventExists).isFalse();
   }
 
   @Test

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/DeleteDduduServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/DeleteDduduServiceTest.java
@@ -10,16 +10,12 @@ import com.ddudu.application.common.port.goal.out.SaveGoalPort;
 import com.ddudu.application.common.port.notification.out.NotificationEventCommandPort;
 import com.ddudu.application.common.port.notification.out.NotificationEventLoaderPort;
 import com.ddudu.common.exception.DduduErrorCode;
-import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
-import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
 import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
 import com.ddudu.domain.planning.goal.aggregate.Goal;
 import com.ddudu.domain.user.user.aggregate.User;
 import com.ddudu.fixture.DduduFixture;
 import com.ddudu.fixture.GoalFixture;
-import com.ddudu.fixture.NotificationEventFixture;
 import com.ddudu.fixture.UserFixture;
-import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
@@ -99,28 +95,6 @@ class DeleteDduduServiceTest {
     Assertions.assertThatExceptionOfType(SecurityException.class)
         .isThrownBy(delete)
         .withMessage(DduduErrorCode.INVALID_AUTHORITY.getCodeName());
-  }
-
-  @Test
-  void 뚜두_삭제_시_연관된_알림도_삭제된다() {
-    // given: register a notification event for this ddudu context
-    NotificationEvent event = NotificationEventFixture.createValidDduduEventNowWithUserAndContext(
-        user.getId(),
-        ddudu.getId()
-    );
-
-    notificationEventCommandPort.save(event);
-
-    // when
-    deleteDduduService.delete(user.getId(), ddudu.getId());
-
-    // then
-    Optional<NotificationEvent> actual = notificationEventLoaderPort.getOptionalEventByContext(
-        NotificationEventTypeCode.DDUDU,
-        ddudu.getId()
-    );
-
-    assertThat(actual).isEmpty();
   }
 
 }

--- a/bootstrap/bootstrap-gateway/build.gradle.kts
+++ b/bootstrap/bootstrap-gateway/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(project(":bootstrap:planning-api"))
     implementation(project(":bootstrap:stats-api"))
     implementation(project(":bootstrap:notification-api"))
+    implementation(project(":bootstrap:notification-inmemory-listener"))
 
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 }

--- a/bootstrap/notification-inmemory-listener/build.gradle.kts
+++ b/bootstrap/notification-inmemory-listener/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    id("ddudu.java-conventions")
+    id("ddudu.spring-conventions")
+}
+
+dependencies {
+    implementation(project(":bootstrap:bootstrap-common"))
+    implementation(project(":application:application-common"))
+    implementation(project(":common"))
+    implementation(project(":application:notification-application"))
+}

--- a/bootstrap/notification-inmemory-listener/src/main/java/com/ddudu/listener/notification/event/listener/NotificationEventListener.java
+++ b/bootstrap/notification-inmemory-listener/src/main/java/com/ddudu/listener/notification/event/listener/NotificationEventListener.java
@@ -1,0 +1,28 @@
+package com.ddudu.listener.notification.event.listener;
+
+import com.ddudu.application.common.dto.notification.event.NotificationEventRemoveEvent;
+import com.ddudu.application.common.dto.notification.event.NotificationEventSaveEvent;
+import com.ddudu.application.common.port.notification.in.RemoveNotificationEventUseCase;
+import com.ddudu.application.common.port.notification.in.SaveNotificationEventUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+  private final SaveNotificationEventUseCase saveNotificationEventUseCase;
+  private final RemoveNotificationEventUseCase removeNotificationEventUseCase;
+
+  @EventListener
+  public void saveNotificationEvent(NotificationEventSaveEvent notificationEventSaveEvent) {
+    saveNotificationEventUseCase.save(notificationEventSaveEvent);
+  }
+
+  @EventListener
+  public void removeNotificationEvent(NotificationEventRemoveEvent notificationEventRemoveEvent) {
+    removeNotificationEventUseCase.remove(notificationEventRemoveEvent);
+  }
+
+}

--- a/common/src/main/java/com/ddudu/common/exception/NotificationEventErrorCode.java
+++ b/common/src/main/java/com/ddudu/common/exception/NotificationEventErrorCode.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 public enum NotificationEventErrorCode implements ErrorCode {
   NULL_TYPE_CODE(10001, "알림 유형은 필수값입니다."),
   NULL_RECEIVER_ID(10002, "알림 수신자는 필수값입니다."),
-  NULL_CONTEXT_ID(10003, "알림 대상 컨텍스트는 필수값입니다.");
+  NULL_CONTEXT_ID(10003, "알림 대상 컨텍스트는 필수값입니다."),
+  CANNOT_MODIFY_FIRED_EVENT(10004, "이미 발송된 알림은 수정할 수 없습니다."),
+  CANNOT_FIRE_AT_PAST(10005, "발송 예정 시간은 현재시간보다 뒤여야 합니다.");
 
   private final int code;
   private final String message;

--- a/domain/notification-domain/src/main/java/com/ddudu/domain/notification/event/aggregate/NotificationEvent.java
+++ b/domain/notification-domain/src/main/java/com/ddudu/domain/notification/event/aggregate/NotificationEvent.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.ddudu.common.exception.NotificationEventErrorCode;
 import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.Builder;
@@ -42,6 +43,13 @@ public class NotificationEvent {
     this.contextId = contextId;
     this.willFireAt = Objects.requireNonNullElse(willFireAt, LocalDateTime.now());
     this.firedAt = firedAt;
+  }
+
+  public boolean isPlannedToday() {
+    LocalDate today = LocalDate.now();
+
+    return willFireAt.toLocalDate()
+        .isEqual(today);
   }
 
   public boolean isAlreadyFired() {

--- a/domain/notification-domain/src/test/java/com/ddudu/domain/notification/event/aggregate/NotificationEventTest.java
+++ b/domain/notification-domain/src/test/java/com/ddudu/domain/notification/event/aggregate/NotificationEventTest.java
@@ -1,6 +1,7 @@
 package com.ddudu.domain.notification.event.aggregate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import com.ddudu.common.exception.NotificationEventErrorCode;
 import com.ddudu.domain.notification.event.aggregate.NotificationEvent.NotificationEventBuilder;
@@ -8,6 +9,7 @@ import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventType
 import com.ddudu.fixture.NotificationEventFixture;
 import java.time.LocalDateTime;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
@@ -102,19 +104,77 @@ class NotificationEventTest {
           .withMessage(NotificationEventErrorCode.NULL_CONTEXT_ID.getCodeName());
     }
 
+    @Test
+    void 발송_예정_시간이_오늘보다_이전이면_생성을_실패한다() {
+      // given
+      LocalDateTime willFireAt = NotificationEventFixture.getPastDateTime(1, TimeUnit.DAYS);
+      NotificationEventBuilder builder = NotificationEvent.builder()
+          .contextId(contextId)
+          .typeCode(typeCode)
+          .receiverId(userId)
+          .willFireAt(willFireAt);
+
+      // when
+      ThrowingCallable create = builder::build;
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(create)
+          .withMessage(NotificationEventErrorCode.CANNOT_FIRE_AT_PAST.getCodeName());
+    }
+
   }
 
   @Nested
-  class 기능_테스트 {
+  class 금일_발송_예정_테스트 {
 
     @Test
-    void 이미_발송된_이벤트는_true를_반환한다() {
+    void 오늘_발송_예정인_이벤트면_true를_반환한다() {
       // given
-      NotificationEvent fired = NotificationEventFixture.createFiredEventWithUserAndContext(
+      NotificationEvent event = NotificationEventFixture.createValidEventWithUserAndContext(
           userId,
           typeCode,
           contextId,
           LocalDateTime.now()
+      );
+
+      // when
+      boolean actual = event.isPlannedToday();
+
+      // then
+      assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 오늘_발송_예정이_아니면_false를_반환한다() {
+      // given
+      LocalDateTime tomorrow = LocalDateTime.now()
+          .plusDays(1);
+      NotificationEvent event = NotificationEventFixture.createValidEventWithUserAndContext(
+          userId,
+          typeCode,
+          contextId,
+          tomorrow
+      );
+
+      // when
+      boolean actual = event.isPlannedToday();
+
+      // then
+      assertThat(actual).isFalse();
+    }
+
+  }
+
+  @Nested
+  class 발송_여부_테스트 {
+
+    @Test
+    void 이미_발송된_이벤트는_true를_반환한다() {
+      // given
+      NotificationEvent fired = NotificationEventFixture.createFiredEventNowWithUserAndContext(
+          userId,
+          typeCode,
+          contextId
       );
 
       // when
@@ -139,6 +199,67 @@ class NotificationEventTest {
 
       // then
       assertThat(actual).isFalse();
+    }
+
+  }
+
+  @Nested
+  class 발송_예정_시간_수정_테스트 {
+
+    @Test
+    void 발송_예정_시간_수정을_성공한다() {
+      // given
+      LocalDateTime tomorrow = LocalDateTime.now()
+          .plusDays(1);
+      NotificationEvent notificationEvent = NotificationEventFixture.createValidEventWithUserAndContext(
+          userId,
+          typeCode,
+          contextId,
+          tomorrow
+      );
+      LocalDateTime expected = NotificationEventFixture.getFutureDateTime(1, TimeUnit.DAYS);
+
+      // when
+      NotificationEvent actual = notificationEvent.updateFireTime(expected);
+
+      // then
+      assertThat(actual.getWillFireAt()).isEqualTo(expected);
+    }
+
+    @Test
+    void 이미_발송된_경우_시간_수정을_실패한다() {
+      // given
+      NotificationEvent notificationEvent = NotificationEventFixture.createFiredEventNowWithUserAndContext(
+          userId,
+          typeCode,
+          contextId
+      );
+      LocalDateTime willFireAt = NotificationEventFixture.getFutureDateTime(1, TimeUnit.DAYS);
+
+      // when
+      ThrowingCallable update = () -> notificationEvent.updateFireTime(willFireAt);
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(update)
+          .withMessage(NotificationEventErrorCode.CANNOT_MODIFY_FIRED_EVENT.getCodeName());
+    }
+
+    @Test
+    void 발송_예정_시간이_현재시간보다_이전이면_시간_수정을_실패한다() {
+      // given
+      NotificationEvent notificationEvent = NotificationEventFixture.createValidEventNowWithUserAndContext(
+          userId,
+          typeCode,
+          contextId
+      );
+      LocalDateTime willFireAt = NotificationEventFixture.getPastDateTime(1, TimeUnit.DAYS);
+
+      // when
+      ThrowingCallable update = () -> notificationEvent.updateFireTime(willFireAt);
+
+      // then
+      assertThatIllegalArgumentException().isThrownBy(update)
+          .withMessage(NotificationEventErrorCode.CANNOT_FIRE_AT_PAST.getCodeName());
     }
 
   }

--- a/domain/notification-domain/src/testFixtures/java/com/ddudu/fixture/NotificationEventFixture.java
+++ b/domain/notification-domain/src/testFixtures/java/com/ddudu/fixture/NotificationEventFixture.java
@@ -10,18 +10,24 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NotificationEventFixture extends BaseFixture {
 
-  private static NotificationEvent createFiredDduduEventNowWithUserAndContext(
+  public static NotificationEvent createFiredDduduEventNowWithUserAndContext(
       Long receiverId,
       Long dduduId
   ) {
-    return createFiredDduduEventWithUserAndContext(receiverId, dduduId, LocalDateTime.now());
+    LocalDateTime nearNow = LocalDateTime.now()
+        .plusSeconds(10);
+
+    return createFiredDduduEventWithUserAndContext(receiverId, dduduId, nearNow);
   }
 
   public static NotificationEvent createValidDduduEventNowWithUserAndContext(
       Long receiverId,
       Long dduduId
   ) {
-    return createValidDduduEventWithUserAndContext(receiverId, dduduId, LocalDateTime.now());
+    LocalDateTime nearNow = LocalDateTime.now()
+        .plusSeconds(10);
+
+    return createValidDduduEventWithUserAndContext(receiverId, dduduId, nearNow);
   }
 
   public static NotificationEvent createFiredDduduEventWithUserAndContext(
@@ -50,6 +56,17 @@ public class NotificationEventFixture extends BaseFixture {
     );
   }
 
+  public static NotificationEvent createFiredEventNowWithUserAndContext(
+      Long receiverId,
+      NotificationEventTypeCode typeCode,
+      Long contextId
+  ) {
+    LocalDateTime nearNow = LocalDateTime.now()
+        .plusSeconds(10);
+
+    return createFiredEventWithUserAndContext(receiverId, typeCode, contextId, nearNow);
+  }
+
   public static NotificationEvent createFiredEventWithUserAndContext(
       Long receiverId,
       NotificationEventTypeCode typeCode,
@@ -65,6 +82,17 @@ public class NotificationEventFixture extends BaseFixture {
         willFireAt,
         firedAt
     );
+  }
+
+  public static NotificationEvent createValidEventNowWithUserAndContext(
+      Long receiverId,
+      NotificationEventTypeCode typeCode,
+      Long contextId
+  ) {
+    LocalDateTime nearNow = LocalDateTime.now()
+        .plusSeconds(10);
+
+    return createValidEventWithUserAndContext(receiverId, typeCode, contextId, nearNow);
   }
 
   public static NotificationEvent createValidEventWithUserAndContext(

--- a/domain/planning-domain/src/main/java/com/ddudu/domain/planning/ddudu/aggregate/Ddudu.java
+++ b/domain/planning-domain/src/main/java/com/ddudu/domain/planning/ddudu/aggregate/Ddudu.java
@@ -148,10 +148,6 @@ public class Ddudu {
         .build();
   }
 
-  public boolean isScheduledToday() {
-    return scheduledOn.isEqual(LocalDate.now());
-  }
-
   public Ddudu cancelReminder() {
     return getFullBuilder()
         .remindAt(null)

--- a/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/event/repository/NotificationEventRepository.java
+++ b/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/event/repository/NotificationEventRepository.java
@@ -7,13 +7,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationEventRepository extends JpaRepository<NotificationEventEntity, Long> {
 
-  boolean existsByTypeCodeAndContextId(NotificationEventTypeCode typeCode, Long contextId);
-
-  Optional<NotificationEventEntity> findByTypeCodeAndContextId(
+  boolean existsByReceiverIdAndTypeCodeAndContextId(
+      Long receiverId,
       NotificationEventTypeCode typeCode,
       Long contextId
   );
 
-  void deleteAllByTypeCodeAndContextId(NotificationEventTypeCode typeCode, Long contextId);
+  Optional<NotificationEventEntity> findByReceiverIdAndTypeCodeAndContextId(
+      Long userId,
+      NotificationEventTypeCode typeCode,
+      Long contextId
+  );
 
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ include(
     "bootstrap:stats-api",
     "bootstrap:planning-api",
     "bootstrap:notification-api",
+    "bootstrap:notification-inmemory-listener",
 
     // application
     "application:application-common",


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
- Resolves #277 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 미리알림 관련 알림 발생 필요한 서비스에서 알림 이벤트 영속성 의존 제거
- 스프링 이벤트 퍼블리싱으로 본 트랜잭션 후 알림 이벤트 발행
- 알림 이벤트의 Driving Adapter인 Inmemory Listener 추가
  - 추후 external consumer 가능성 고려
- 알림 이벤트 save/remove 서비스 구현