### PR TITLE
Feat: FCM 알림 발송 구현

### DIFF
--- a/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/NotificationDeviceTokenLoaderPort.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/NotificationDeviceTokenLoaderPort.java
@@ -1,0 +1,10 @@
+package com.ddudu.application.common.port.notification.out;
+
+import com.ddudu.domain.notification.device.aggregate.NotificationDeviceToken;
+import java.util.List;
+
+public interface NotificationDeviceTokenLoaderPort {
+
+  List<NotificationDeviceToken> getAllTokensOfUser(Long userId);
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/NotificationSendPort.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/notification/out/NotificationSendPort.java
@@ -1,0 +1,9 @@
+package com.ddudu.application.common.port.notification.out;
+
+import java.util.List;
+
+public interface NotificationSendPort {
+
+  void sendToDevices(List<String> deviceTokens, String title, String body);
+
+}

--- a/application/notification-application/src/test/java/com/ddudu/NotificationApplicationTestConfig.java
+++ b/application/notification-application/src/test/java/com/ddudu/NotificationApplicationTestConfig.java
@@ -1,6 +1,8 @@
 package com.ddudu;
 
+import com.ddudu.application.common.port.notification.out.NotificationSendPort;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication(
     scanBasePackages = {
@@ -10,5 +12,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
     }
 )
 public class NotificationApplicationTestConfig {
+
+  @Bean
+  public NotificationSendPort notificationSendPort() {
+    return (deviceTokens, title, body) -> {};
+  }
 
 }

--- a/application/notification-application/src/test/java/com/ddudu/application/notification/device/SaveDeviceTokenServiceTest.java
+++ b/application/notification-application/src/test/java/com/ddudu/application/notification/device/SaveDeviceTokenServiceTest.java
@@ -7,11 +7,12 @@ import com.ddudu.application.common.dto.notification.request.SaveDeviceTokenRequ
 import com.ddudu.application.common.dto.notification.response.SaveDeviceTokenResponse;
 import com.ddudu.application.common.port.auth.out.SignUpPort;
 import com.ddudu.application.common.port.notification.in.SaveDeviceTokenUseCase;
+import com.ddudu.application.common.port.notification.out.NotificationDeviceTokenLoaderPort;
 import com.ddudu.common.exception.NotificationDeviceTokenErrorCode;
+import com.ddudu.domain.notification.device.aggregate.NotificationDeviceToken;
 import com.ddudu.domain.user.user.aggregate.User;
 import com.ddudu.fixture.NotificationDeviceTokenFixture;
 import com.ddudu.fixture.UserFixture;
-import com.ddudu.infra.mysql.notification.device.repository.NotificationDeviceTokenRepository;
 import java.util.MissingResourceException;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +35,7 @@ class SaveDeviceTokenServiceTest {
   SignUpPort signUpPort;
 
   @Autowired
-  NotificationDeviceTokenRepository notificationDeviceTokenRepository;
+  NotificationDeviceTokenLoaderPort notificationDeviceTokenLoaderPort;
 
   User user;
   String channel;
@@ -54,11 +55,15 @@ class SaveDeviceTokenServiceTest {
     SaveDeviceTokenRequest request = new SaveDeviceTokenRequest(channel, token);
 
     // when
-    SaveDeviceTokenResponse response = saveDeviceTokenUseCase.save(user.getId(), request);
+    SaveDeviceTokenResponse actual = saveDeviceTokenUseCase.save(user.getId(), request);
 
     // then
-    assertThat(response.id()).isNotNull();
-    // TODO: add actual data after implementing loader port
+    NotificationDeviceToken expected = notificationDeviceTokenLoaderPort.getAllTokensOfUser(user.getId())
+        .stream()
+        .findFirst()
+        .orElseThrow();
+
+    assertThat(actual.id()).isEqualTo(expected.getId());
   }
 
   @Test

--- a/application/notification-application/src/test/java/com/ddudu/application/notification/event/SendNotificationEventServiceTest.java
+++ b/application/notification-application/src/test/java/com/ddudu/application/notification/event/SendNotificationEventServiceTest.java
@@ -2,9 +2,6 @@ package com.ddudu.application.notification.event;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 
 import com.ddudu.application.common.dto.notification.event.NotificationSendEvent;
 import com.ddudu.application.common.port.auth.out.SignUpPort;
@@ -14,7 +11,6 @@ import com.ddudu.application.common.port.notification.in.SendNotificationEventUs
 import com.ddudu.application.common.port.notification.out.NotificationDeviceTokenCommandPort;
 import com.ddudu.application.common.port.notification.out.NotificationEventCommandPort;
 import com.ddudu.application.common.port.notification.out.NotificationEventLoaderPort;
-import com.ddudu.application.common.port.notification.out.NotificationSendPort;
 import com.ddudu.common.exception.NotificationEventErrorCode;
 import com.ddudu.domain.notification.event.aggregate.NotificationEvent;
 import com.ddudu.domain.notification.event.aggregate.enums.NotificationEventTypeCode;
@@ -35,7 +31,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -64,9 +59,6 @@ class SendNotificationEventServiceTest {
   @Autowired
   NotificationDeviceTokenCommandPort notificationDeviceTokenCommandPort;
 
-  @MockBean
-  NotificationSendPort notificationSendPort;
-
   User user;
   Goal goal;
   Ddudu ddudu;
@@ -94,8 +86,6 @@ class SendNotificationEventServiceTest {
     notificationEvent = notificationEventCommandPort.save(notificationEvent);
 
     notificationDeviceTokenCommandPort.save(NotificationDeviceTokenFixture.createWithUser(user.getId()));
-    doNothing().when(notificationSendPort)
-        .sendToDevices(anyList(), anyString(), anyString());
   }
 
   @Test

--- a/bootstrap/bootstrap-gateway/build.gradle.kts
+++ b/bootstrap/bootstrap-gateway/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(project(":infra:user-infra-external-api"))
     implementation(project(":infra:notification-infra-mysql"))
     implementation(project(":infra:notification-infra-inmemory-scheduler"))
+    implementation(project(":infra:notification-infra-fcm"))
     implementation(project(":bootstrap:bootstrap-common"))
     implementation(project(":bootstrap:user-api"))
     implementation(project(":bootstrap:planning-api"))
@@ -45,12 +46,8 @@ flyway {
 
 val copyMainSecret by tasks.registering(Copy::class) {
     from("${rootProject.projectDir}/secrets/main")
-    include("application*.yaml")
+    include(listOf("application*.yaml", "*.json"))
     into(layout.buildDirectory.dir("resources/main"))
-}
-
-tasks.named("processResources") {
-    dependsOn(copyMainSecret)
 }
 
 val copyTestSecret by tasks.registering(Copy::class) {
@@ -60,5 +57,6 @@ val copyTestSecret by tasks.registering(Copy::class) {
 }
 
 tasks.named("processResources") {
+    dependsOn(copyMainSecret)
     dependsOn(copyTestSecret)
 }

--- a/domain/notification-domain/src/testFixtures/java/com/ddudu/fixture/NotificationDeviceTokenFixture.java
+++ b/domain/notification-domain/src/testFixtures/java/com/ddudu/fixture/NotificationDeviceTokenFixture.java
@@ -34,6 +34,15 @@ public final class NotificationDeviceTokenFixture extends BaseFixture {
     return builder().build();
   }
 
+  public static NotificationDeviceToken createWithUser(Long userId) {
+    return NotificationDeviceToken.builder()
+        .id(null)
+        .userId(userId)
+        .channel(getRandomChannel())
+        .token(getRandomToken())
+        .build();
+  }
+
   public static Long getRandomUserId() {
     return getRandomId();
   }

--- a/domain/planning-domain/src/testFixtures/java/com/ddudu/fixture/DduduFixture.java
+++ b/domain/planning-domain/src/testFixtures/java/com/ddudu/fixture/DduduFixture.java
@@ -200,6 +200,18 @@ public class DduduFixture extends BaseFixture {
         .build();
   }
 
+  public static Ddudu createDduduWithReminderFor(Long userId, Long goalId, LocalDateTime remindAt) {
+    LocalDateTime scheduledAt = remindAt.plusSeconds(1);
+
+    return createDduduWithReminder(
+        userId,
+        goalId,
+        scheduledAt.toLocalDate(),
+        scheduledAt.toLocalTime(),
+        remindAt
+    );
+  }
+
   public static Ddudu createRandomDduduWithGoalAndTime(
       Goal goal,
       LocalTime beginAt,

--- a/infra/notification-infra-fcm/build.gradle.kts
+++ b/infra/notification-infra-fcm/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("ddudu.java-conventions")
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+}
+
+tasks.bootJar {
+    enabled = false
+}
+
+tasks.jar {
+    enabled = true
+}
+
+dependencies {
+    implementation(project(":common"))
+    implementation(project(":application:application-common"))
+    implementation(project(":application:notification-application"))
+
+    implementation("org.springframework.boot:spring-boot-starter")
+    implementation("com.google.firebase:firebase-admin:9.6.0")
+}

--- a/infra/notification-infra-fcm/src/main/java/com/ddudu/infra/fcm/notification/adapter/NotificationFcmAdapter.java
+++ b/infra/notification-infra-fcm/src/main/java/com/ddudu/infra/fcm/notification/adapter/NotificationFcmAdapter.java
@@ -1,0 +1,81 @@
+package com.ddudu.infra.fcm.notification.adapter;
+
+import com.ddudu.application.common.port.notification.out.NotificationSendPort;
+import com.ddudu.common.annotation.DrivenAdapter;
+import com.ddudu.infra.fcm.notification.config.FcmProperties;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.SendResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@DrivenAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationFcmAdapter implements NotificationSendPort {
+
+  private final FirebaseMessaging firebaseMessaging;
+  private final FcmProperties fcmProperties;
+
+  @Override
+  public void sendToDevices(
+      List<String> deviceTokens,
+      String title,
+      String body
+  ) {
+    Notification notification = Notification.builder()
+        .setTitle(title)
+        .setBody(body)
+        .build();
+    MulticastMessage multicastMessage = MulticastMessage.builder()
+        .setNotification(notification)
+        .addAllTokens(deviceTokens)
+        .build();
+    BatchResponse batchResponse = sendMulticast(multicastMessage);
+
+    handlePartialException(batchResponse);
+  }
+
+  private BatchResponse sendMulticast(MulticastMessage message) {
+    try {
+      return firebaseMessaging.sendEachForMulticast(
+          message,
+          fcmProperties.validateOnly()
+      );
+    } catch (FirebaseMessagingException e) {
+      log.warn(
+          "All of firebase multicast failed: [{}] {}",
+          e.getMessagingErrorCode(),
+          e.getMessage()
+      );
+
+      throw new IllegalStateException();
+    }
+  }
+
+  private void handlePartialException(BatchResponse batchResponse) {
+    int failureCount = batchResponse.getFailureCount();
+
+    if (failureCount == 0) {
+      return;
+    }
+
+    log.warn("{} of firebase multicast failed", failureCount);
+
+    batchResponse.getResponses()
+        .stream()
+        .map(SendResponse::getException)
+        .forEach(exception -> log.warn(
+            "[{}] {}",
+            exception.getMessagingErrorCode(),
+            exception.getMessage()
+        ));
+
+    // TODO: Retry 로직 등 추후 고려 필요
+  }
+
+}

--- a/infra/notification-infra-fcm/src/main/java/com/ddudu/infra/fcm/notification/config/FcmConfig.java
+++ b/infra/notification-infra-fcm/src/main/java/com/ddudu/infra/fcm/notification/config/FcmConfig.java
@@ -1,0 +1,43 @@
+package com.ddudu.infra.fcm.notification.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import java.io.IOException;
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+@Configuration
+@ConfigurationPropertiesScan
+@RequiredArgsConstructor
+public class FcmConfig {
+
+  private final FcmProperties fcmProperties;
+
+  @PostConstruct
+  public void init() throws IOException {
+    ClassPathResource resource = new ClassPathResource(fcmProperties.filePath());
+    FirebaseOptions options = FirebaseOptions.builder()
+        .setCredentials(GoogleCredentials.fromStream(resource.getInputStream()))
+        .setProjectId(fcmProperties.projectId())
+        .build();
+
+    FirebaseApp.initializeApp(options);
+  }
+
+  @Bean
+  public FirebaseApp firebaseApp() {
+    return FirebaseApp.getInstance();
+  }
+
+  @Bean
+  public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+    return FirebaseMessaging.getInstance(firebaseApp);
+  }
+
+}

--- a/infra/notification-infra-fcm/src/main/java/com/ddudu/infra/fcm/notification/config/FcmProperties.java
+++ b/infra/notification-infra-fcm/src/main/java/com/ddudu/infra/fcm/notification/config/FcmProperties.java
@@ -1,0 +1,8 @@
+package com.ddudu.infra.fcm.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("fcm")
+public record FcmProperties(String filePath, String projectId, boolean validateOnly) {
+
+}

--- a/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/device/adapter/NotificationDeviceTokenAdapter.java
+++ b/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/device/adapter/NotificationDeviceTokenAdapter.java
@@ -1,15 +1,18 @@
 package com.ddudu.infra.mysql.notification.device.adapter;
 
 import com.ddudu.application.common.port.notification.out.NotificationDeviceTokenCommandPort;
+import com.ddudu.application.common.port.notification.out.NotificationDeviceTokenLoaderPort;
 import com.ddudu.common.annotation.DrivenAdapter;
 import com.ddudu.domain.notification.device.aggregate.NotificationDeviceToken;
 import com.ddudu.infra.mysql.notification.device.entity.NotificationDeviceTokenEntity;
 import com.ddudu.infra.mysql.notification.device.repository.NotificationDeviceTokenRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @DrivenAdapter
 @RequiredArgsConstructor
-public class NotificationDeviceTokenAdapter implements NotificationDeviceTokenCommandPort {
+public class NotificationDeviceTokenAdapter implements NotificationDeviceTokenCommandPort,
+    NotificationDeviceTokenLoaderPort {
 
   private final NotificationDeviceTokenRepository notificationDeviceTokenRepository;
 
@@ -17,6 +20,14 @@ public class NotificationDeviceTokenAdapter implements NotificationDeviceTokenCo
   public NotificationDeviceToken save(NotificationDeviceToken deviceToken) {
     return notificationDeviceTokenRepository.save(NotificationDeviceTokenEntity.from(deviceToken))
         .toDomain();
+  }
+
+  @Override
+  public List<NotificationDeviceToken> getAllTokensOfUser(Long userId) {
+    return notificationDeviceTokenRepository.findAllByUserId(userId)
+        .stream()
+        .map(NotificationDeviceTokenEntity::toDomain)
+        .toList();
   }
 
 }

--- a/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/device/repository/NotificationDeviceTokenRepository.java
+++ b/infra/notification-infra-mysql/src/main/java/com/ddudu/infra/mysql/notification/device/repository/NotificationDeviceTokenRepository.java
@@ -1,9 +1,12 @@
 package com.ddudu.infra.mysql.notification.device.repository;
 
 import com.ddudu.infra.mysql.notification.device.entity.NotificationDeviceTokenEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationDeviceTokenRepository extends
     JpaRepository<NotificationDeviceTokenEntity, Long> {
+
+  List<NotificationDeviceTokenEntity> findAllByUserId(Long userId);
 
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,7 @@ include(
     "infra:user-infra-external-api",
     "infra:notification-infra-mysql",
     "infra:notification-infra-inmemory-scheduler",
+    "infra:notification-infra-fcm",
 
     // common
     "common",


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
- Resolves #281 

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- Firebase 인프라 모듈 추가 및 발송 어댑터 로직 구현
- 알림 발송 서비스에 알림 발송 추가