### PR TITLE
Fix: 공지사항 API 비인증 공개 및 CORS 설정 수정

### DIFF
--- a/bootstrap/user-api/src/main/java/com/ddudu/api/user/auth/config/WebSecurityConfig.java
+++ b/bootstrap/user-api/src/main/java/com/ddudu/api/user/auth/config/WebSecurityConfig.java
@@ -6,6 +6,8 @@ import com.ddudu.api.user.auth.jwt.converter.JwtConverter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -16,15 +18,24 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AndRequestMatcher;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
   private static final String ALL_RESOURCES = "/api/**";
+  private static final String ANNOUNCEMENTS_PATH = "/api/announcements";
+  private static final String ANNOUNCEMENT_DETAIL_PATH = "/api/announcements/*";
+  private static final String LOGIN_PATH = "/api/auth/login/**";
 
   @Bean
   public SecurityFilterChain restFilterChain(
@@ -35,9 +46,9 @@ public class WebSecurityConfig {
   )
       throws Exception {
     return http
-        .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+        .cors(Customizer.withDefaults())
         .securityMatchers(matcher -> matcher
-            .requestMatchers(ALL_RESOURCES))
+            .requestMatchers(protectedApiRequestMatcher()))
         .sessionManagement(session -> session
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .requestCache(RequestCacheConfigurer::disable)
@@ -58,6 +69,21 @@ public class WebSecurityConfig {
         .build();
   }
 
+  private RequestMatcher protectedApiRequestMatcher() {
+    return new AndRequestMatcher(
+        new AntPathRequestMatcher(ALL_RESOURCES),
+        new NegatedRequestMatcher(excludedApiRequestMatcher())
+    );
+  }
+
+  private RequestMatcher excludedApiRequestMatcher() {
+    return new OrRequestMatcher(
+        new AntPathRequestMatcher(ANNOUNCEMENTS_PATH, HttpMethod.GET.name()),
+        new AntPathRequestMatcher(ANNOUNCEMENT_DETAIL_PATH, HttpMethod.GET.name()),
+        new AntPathRequestMatcher(LOGIN_PATH, HttpMethod.POST.name())
+    );
+  }
+
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
@@ -74,6 +100,11 @@ public class WebSecurityConfig {
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", configuration);
     return source;
+  }
+
+  @Bean
+  public CorsFilter corsFilter(CorsConfigurationSource corsConfigurationSource) {
+    return new CorsFilter(corsConfigurationSource);
   }
 
 }

--- a/bootstrap/user-api/src/main/java/com/ddudu/api/user/auth/filter/IgnoreBearerAuthenticationFilter.java
+++ b/bootstrap/user-api/src/main/java/com/ddudu/api/user/auth/filter/IgnoreBearerAuthenticationFilter.java
@@ -9,6 +9,9 @@ import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -17,8 +20,8 @@ public class IgnoreBearerAuthenticationFilter extends OncePerRequestFilter {
 
   private static final String BEARER = "Bearer";
   private static final String IGNORE = "Ignore";
-  private static final String LOGIN_PATH = "/auth/login";
-  private static final String REFRESH_PATH = "/auth/token";
+  private static final RequestMatcher REFRESH_REQUEST_MATCHER =
+      new AntPathRequestMatcher("/api/auth/token", HttpMethod.POST.name());
 
   @Override
   protected void doFilterInternal(
@@ -26,10 +29,9 @@ public class IgnoreBearerAuthenticationFilter extends OncePerRequestFilter {
       HttpServletResponse response,
       FilterChain filterChain
   ) throws ServletException, IOException {
-    String requestUri = request.getRequestURI();
     String token = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-    if (isIgnorable(requestUri) && token != null && token.startsWith(BEARER)) {
+    if (isIgnorable(request) && token != null && token.startsWith(BEARER)) {
       MutableRequest mutableRequest = new MutableRequest(request);
 
       mutableRequest.setHeader(HttpHeaders.AUTHORIZATION, token.replace(BEARER, IGNORE));
@@ -39,8 +41,8 @@ public class IgnoreBearerAuthenticationFilter extends OncePerRequestFilter {
     }
   }
 
-  private boolean isIgnorable(String requestUri) {
-    return requestUri.contains(LOGIN_PATH) || requestUri.contains(REFRESH_PATH);
+  private boolean isIgnorable(HttpServletRequest request) {
+    return REFRESH_REQUEST_MATCHER.matches(request);
   }
 
   private class MutableRequest extends HttpServletRequestWrapper {


### PR DESCRIPTION
## 🎫관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
- hotfix

## 🎊구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 공지사항 목록조회, 상세조회 API 비인증 허용
- CORS Config Source를 rest filter에 직접 적용 시, Matcher에 포함되는 API만 CORS에 허용되는 버그 수정
