### PR TITLE
Follow-up: add hasNext to ScrollResponse and validate in scroll service tests

### DIFF
--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/scroll/response/ScrollResponse.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/scroll/response/ScrollResponse.java
@@ -5,11 +5,12 @@ import java.util.List;
 public record ScrollResponse<T>(
     boolean isEmpty,
     List<T> contents,
-    String nextCursor
+    String nextCursor,
+    boolean hasNext
 ) {
 
   public static <T> ScrollResponse<T> from(List<T> contents, String nextCursor) {
-    return new ScrollResponse<T>(contents.isEmpty(), contents, nextCursor);
+    return new ScrollResponse<T>(contents.isEmpty(), contents, nextCursor, nextCursor != null);
   }
 
 }

--- a/application/notification-application/src/test/java/com/ddudu/application/notification/announcement/AnnouncementSearchServiceTest.java
+++ b/application/notification-application/src/test/java/com/ddudu/application/notification/announcement/AnnouncementSearchServiceTest.java
@@ -82,6 +82,7 @@ class AnnouncementSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(size);
     assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+    assertThat(response.hasNext()).isTrue();
     assertThat(response.contents().get(0).id()).isEqualTo(latestId);
     assertThat(response.contents().get(0).author()).isEqualTo(expectedAuthor);
     assertThat(response.contents()).isSortedAccordingTo((a, b) -> Long.compare(b.id(), a.id()));
@@ -104,6 +105,7 @@ class AnnouncementSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(defaultSize);
     assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+    assertThat(response.hasNext()).isTrue();
   }
 
   @Test
@@ -141,6 +143,7 @@ class AnnouncementSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(expectedSize);
     assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+    assertThat(response.hasNext()).isTrue();
     assertThat(response.contents())
         .allMatch(announcement -> announcement.id() < firstPageLastId);
   }
@@ -161,10 +164,11 @@ class AnnouncementSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(size);
     assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+    assertThat(response.hasNext()).isTrue();
   }
 
   @Test
-  void 마지막_페이지면_nextCursor는_null이다() {
+  void 마지막_페이지면_nextCursor는_null이고_hasNext는_false다() {
     // given
     int totalSize = savedAnnouncements.size();
     AnnouncementSearchRequest request = new AnnouncementSearchRequest(null, "0", totalSize + 10);
@@ -176,6 +180,7 @@ class AnnouncementSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(totalSize);
     assertThat(response.nextCursor()).isNull();
+    assertThat(response.hasNext()).isFalse();
   }
 
 }

--- a/application/notification-application/src/test/java/com/ddudu/application/notification/inbox/NotificationInboxSearchServiceTest.java
+++ b/application/notification-application/src/test/java/com/ddudu/application/notification/inbox/NotificationInboxSearchServiceTest.java
@@ -121,6 +121,7 @@ class NotificationInboxSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(size);
     assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+    assertThat(response.hasNext()).isTrue();
 
     NotificationInboxSearchResponse firstInbox = response.contents()
         .get(0);
@@ -152,6 +153,7 @@ class NotificationInboxSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(defaultSize);
     assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+    assertThat(response.hasNext()).isTrue();
   }
 
   @Test
@@ -184,6 +186,7 @@ class NotificationInboxSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(expectedSize);
     assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+    assertThat(response.hasNext()).isTrue();
   }
 
   @Test
@@ -205,6 +208,26 @@ class NotificationInboxSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(size);
     assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+    assertThat(response.hasNext()).isTrue();
+  }
+
+  @Test
+  void 마지막_페이지면_nextCursor는_null이고_hasNext는_false다() {
+    // given
+    int totalSize = size + 1;
+    NotificationInboxSearchRequest request = new NotificationInboxSearchRequest("0", totalSize + 10);
+
+    // when
+    ScrollResponse<NotificationInboxSearchResponse> response = notificationInboxSearchService.search(
+        user.getId(),
+        request
+    );
+
+    // then
+    assertThat(response.isEmpty()).isFalse();
+    assertThat(response.contents()).hasSize(totalSize);
+    assertThat(response.nextCursor()).isNull();
+    assertThat(response.hasNext()).isFalse();
   }
 
   @Test

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/DduduSearchServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/DduduSearchServiceTest.java
@@ -82,6 +82,7 @@ class DduduSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(size);
     assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+    assertThat(response.hasNext()).isTrue();
   }
 
   @Test
@@ -104,6 +105,7 @@ class DduduSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(defaultSize);
     assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+    assertThat(response.hasNext()).isTrue();
   }
 
   @Test
@@ -127,6 +129,7 @@ class DduduSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(expectedSize);
     assertThat(response.nextCursor()).isEqualTo(String.valueOf(expectedNextCursor));
+    assertThat(response.hasNext()).isTrue();
   }
 
   @Test
@@ -145,6 +148,7 @@ class DduduSearchServiceTest {
     assertThat(response.isEmpty()).isFalse();
     assertThat(response.contents()).hasSize(1);
     assertThat(response.nextCursor()).isNull();
+    assertThat(response.hasNext()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
### Motivation
- Clients could not reliably detect last-page responses from cursor pagination because `ScrollResponse` lacked an explicit `hasNext` flag, causing duplicate/infinite fetches in some flows.
- The change centralizes the next-page semantics in the shared DTO so all services using `ScrollResponse` behave consistently.

### Description
- Added `boolean hasNext` to the `ScrollResponse` record and set it in `from(List<T>, String)` as `nextCursor != null` to derive next-page semantics from existing cursor logic.  
- Updated service tests that produce/consume `ScrollResponse` to assert `hasNext` semantics in paging scenarios for both pageable and last-page cases.  
- Test files updated: `DduduSearchServiceTest`, `AnnouncementSearchServiceTest`, and `NotificationInboxSearchServiceTest` to include `hasNext=true` for pageable paths and `hasNext=false` for last-page/single-result cases.  
- Kept `nextCursor` behavior unchanged and computed `hasNext` from it, minimizing changes to service implementation logic.

### Testing
- Ran compile checks: `./gradlew :application:application-common:compileJava :application:notification-application:compileTestJava :application:planning-application:compileTestJava` which completed successfully.  
- Attempted targeted test execution with `./gradlew :application:planning-application:test --tests "*DduduSearchServiceTest" :application:notification-application:test --tests "*AnnouncementSearchServiceTest" --tests "*NotificationInboxSearchServiceTest"` which ultimately failed in this environment due to test environment datasource/Bean creation issues and JaCoCo coverage verification failures.  
- Verified that test source compilation for the affected modules succeeded with `./gradlew :application:notification-application:compileTestJava :application:planning-application:compileTestJava`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3617f4eb0832db72655176faf2862)