### PR TITLE
Expand User options with display/menu/app-connection VOs, DB migration, persistence mapping and tests

### DIFF
--- a/bootstrap/bootstrap-gateway/src/main/resources/db/data/afterMigrate.sql
+++ b/bootstrap/bootstrap-gateway/src/main/resources/db/data/afterMigrate.sql
@@ -18,15 +18,19 @@ SET foreign_key_checks = 1;
 
 -- USERS
 INSERT INTO users(id, nickname, username, introduction, profile_image_url, authority, status,
-                  follows_after_approval, template_notification, ddudu_notification, created_at,
-                  updated_at)
+                  follows_after_approval, template_notification, ddudu_notification, week_start_day,
+                  dark_mode, active_calendar, priority_calendar, active_dashboard,
+                  priority_dashboard, active_stats, priority_stats, realtime_sync_notion,
+                  realtime_sync_google_calendar, realtime_sync_microsoft_todo, created_at, updated_at)
 VALUES (1, '결단력있는 딩고', 'determineddingoda25c93c', null, null, 'ADMIN', 'ACTIVE', 0, 1, 1,
-        '2024-05-17T16:13:48', '2024-05-17T16:13:48');
+        'SUN', 0, 1, 1, 1, 2, 1, 3, 0, 0, 0, '2024-05-17T16:13:48', '2024-05-17T16:13:48');
 INSERT INTO users(id, nickname, username, introduction, profile_image_url, authority, status,
-                  follows_after_approval, template_notification, ddudu_notification, created_at,
-                  updated_at)
+                  follows_after_approval, template_notification, ddudu_notification, week_start_day,
+                  dark_mode, active_calendar, priority_calendar, active_dashboard,
+                  priority_dashboard, active_stats, priority_stats, realtime_sync_notion,
+                  realtime_sync_google_calendar, realtime_sync_microsoft_todo, created_at, updated_at)
 VALUES (2, '짜증난 강아지', 'irritatedpuppy30b6f3ed', null, null, 'ADMIN', 'ACTIVE', 0, 1, 1,
-        '2024-08-18T21:13:02', '2024-08-18T21:13:02');
+        'SUN', 0, 1, 1, 1, 2, 1, 3, 0, 0, 0, '2024-08-18T21:13:02', '2024-08-18T21:13:02');
 # 뚜두 구글 계정
 
 -- REFRESH TOKEN

--- a/bootstrap/bootstrap-gateway/src/main/resources/db/migration/V14__add_user_setting_options.sql
+++ b/bootstrap/bootstrap-gateway/src/main/resources/db/migration/V14__add_user_setting_options.sql
@@ -1,0 +1,12 @@
+ALTER TABLE users
+    ADD COLUMN week_start_day VARCHAR(3) NOT NULL DEFAULT 'SUN' AFTER ddudu_notification,
+    ADD COLUMN dark_mode TINYINT(1) NOT NULL DEFAULT 0 AFTER week_start_day,
+    ADD COLUMN active_calendar TINYINT(1) NOT NULL DEFAULT 1 AFTER dark_mode,
+    ADD COLUMN priority_calendar INT NOT NULL DEFAULT 1 AFTER active_calendar,
+    ADD COLUMN active_dashboard TINYINT(1) NOT NULL DEFAULT 1 AFTER priority_calendar,
+    ADD COLUMN priority_dashboard INT NOT NULL DEFAULT 2 AFTER active_dashboard,
+    ADD COLUMN active_stats TINYINT(1) NOT NULL DEFAULT 1 AFTER priority_dashboard,
+    ADD COLUMN priority_stats INT NOT NULL DEFAULT 3 AFTER active_stats,
+    ADD COLUMN realtime_sync_notion TINYINT(1) NOT NULL DEFAULT 0 AFTER priority_stats,
+    ADD COLUMN realtime_sync_google_calendar TINYINT(1) NOT NULL DEFAULT 0 AFTER realtime_sync_notion,
+    ADD COLUMN realtime_sync_microsoft_todo TINYINT(1) NOT NULL DEFAULT 0 AFTER realtime_sync_google_calendar;

--- a/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/User.java
+++ b/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/User.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.ddudu.common.dto.Authority;
 import com.ddudu.common.exception.UserErrorCode;
 import com.ddudu.domain.user.user.aggregate.enums.UserStatus;
+import com.ddudu.domain.user.user.aggregate.enums.WeekStartDay;
 import com.ddudu.domain.user.user.aggregate.vo.AuthProvider;
 import com.ddudu.domain.user.user.aggregate.vo.Options;
 import java.util.Collections;
@@ -58,15 +59,14 @@ public class User {
     this.id = id;
     this.username = username;
     this.nickname = nickname;
-    this.authority = Objects.requireNonNullElse(authority, Authority.NORMAL);
+    this.authority = Objects.isNull(authority) ? Authority.NORMAL : authority;
     this.introduction = Objects.nonNull(introduction) ? introduction.strip() : null;
-    this.status = Objects.requireNonNullElse(status, UserStatus.ACTIVE);
+    this.status = Objects.isNull(status) ? UserStatus.ACTIVE : status;
     this.profileImageUrl = profileImageUrl;
-    this.options = Objects.requireNonNullElse(
-        options,
-        buildOptions(allowingFollowsAfterApproval, templateNotification, dduduNotification)
-    );
-    this.authProviders = Objects.requireNonNullElse(authProviders, Collections.emptyList());
+    this.options = Objects.isNull(options)
+        ? buildOptions(allowingFollowsAfterApproval, templateNotification, dduduNotification)
+        : options;
+    this.authProviders = Objects.isNull(authProviders) ? Collections.emptyList() : authProviders;
   }
 
   public boolean isAllowingFollowsAfterApproval() {
@@ -79,6 +79,50 @@ public class User {
 
   public boolean isNotifyingDdudu() {
     return this.options.isDduduNotification();
+  }
+
+  public WeekStartDay getWeekStartDay() {
+    return this.options.getDisplay().getWeekStartDay();
+  }
+
+  public boolean isDarkMode() {
+    return this.options.getDisplay().isDarkMode();
+  }
+
+  public boolean isActiveCalendar() {
+    return this.options.getMenuActivation().getCalendar().isActive();
+  }
+
+  public int getPriorityCalendar() {
+    return this.options.getMenuActivation().getCalendar().getPriority();
+  }
+
+  public boolean isActiveDashboard() {
+    return this.options.getMenuActivation().getDashboard().isActive();
+  }
+
+  public int getPriorityDashboard() {
+    return this.options.getMenuActivation().getDashboard().getPriority();
+  }
+
+  public boolean isActiveStats() {
+    return this.options.getMenuActivation().getStats().isActive();
+  }
+
+  public int getPriorityStats() {
+    return this.options.getMenuActivation().getStats().getPriority();
+  }
+
+  public boolean isRealtimeSyncNotion() {
+    return this.options.getAppConnection().getRealtimeSync().isNotion();
+  }
+
+  public boolean isRealtimeSyncGoogleCalendar() {
+    return this.options.getAppConnection().getRealtimeSync().isGoogleCalendar();
+  }
+
+  public boolean isRealtimeSyncMicrosoftTodo() {
+    return this.options.getAppConnection().getRealtimeSync().isMicrosoftTodo();
   }
 
   public boolean isAdmin() {

--- a/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/enums/WeekStartDay.java
+++ b/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/enums/WeekStartDay.java
@@ -1,0 +1,6 @@
+package com.ddudu.domain.user.user.aggregate.enums;
+
+public enum WeekStartDay {
+  SUN,
+  MON
+}

--- a/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/AppConnectionOptions.java
+++ b/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/AppConnectionOptions.java
@@ -1,0 +1,18 @@
+package com.ddudu.domain.user.user.aggregate.vo;
+
+import java.util.Objects;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AppConnectionOptions {
+
+  private final RealtimeSyncOptions realtimeSync;
+
+  @Builder
+  private AppConnectionOptions(RealtimeSyncOptions realtimeSync) {
+    this.realtimeSync = Objects.isNull(realtimeSync) ? RealtimeSyncOptions.builder().build()
+        : realtimeSync;
+  }
+
+}

--- a/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/DisplayOptions.java
+++ b/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/DisplayOptions.java
@@ -1,0 +1,20 @@
+package com.ddudu.domain.user.user.aggregate.vo;
+
+import com.ddudu.domain.user.user.aggregate.enums.WeekStartDay;
+import java.util.Objects;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DisplayOptions {
+
+  private final WeekStartDay weekStartDay;
+  private final boolean darkMode;
+
+  @Builder
+  private DisplayOptions(WeekStartDay weekStartDay, Boolean darkMode) {
+    this.weekStartDay = Objects.isNull(weekStartDay) ? WeekStartDay.SUN : weekStartDay;
+    this.darkMode = Objects.nonNull(darkMode) && darkMode;
+  }
+
+}

--- a/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/MenuActivationItem.java
+++ b/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/MenuActivationItem.java
@@ -1,0 +1,19 @@
+package com.ddudu.domain.user.user.aggregate.vo;
+
+import java.util.Objects;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MenuActivationItem {
+
+  private final boolean active;
+  private final int priority;
+
+  @Builder
+  private MenuActivationItem(Boolean active, Integer priority) {
+    this.active = Objects.isNull(active) || active;
+    this.priority = Objects.isNull(priority) ? 1 : priority;
+  }
+
+}

--- a/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/MenuActivationOptions.java
+++ b/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/MenuActivationOptions.java
@@ -1,0 +1,34 @@
+package com.ddudu.domain.user.user.aggregate.vo;
+
+import java.util.Objects;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MenuActivationOptions {
+
+  private final MenuActivationItem calendar;
+  private final MenuActivationItem dashboard;
+  private final MenuActivationItem stats;
+
+  @Builder
+  private MenuActivationOptions(
+      MenuActivationItem calendar,
+      MenuActivationItem dashboard,
+      MenuActivationItem stats
+  ) {
+    this.calendar = Objects.isNull(calendar) ? MenuActivationItem.builder()
+        .active(true)
+        .priority(1)
+        .build() : calendar;
+    this.dashboard = Objects.isNull(dashboard) ? MenuActivationItem.builder()
+        .active(true)
+        .priority(2)
+        .build() : dashboard;
+    this.stats = Objects.isNull(stats) ? MenuActivationItem.builder()
+        .active(true)
+        .priority(3)
+        .build() : stats;
+  }
+
+}

--- a/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/Options.java
+++ b/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/Options.java
@@ -10,19 +10,53 @@ public class Options {
   private final boolean allowingFollowsAfterApproval;
   private final boolean templateNotification;
   private final boolean dduduNotification;
+  private final DisplayOptions display;
+  private final MenuActivationOptions menuActivation;
+  private final AppConnectionOptions appConnection;
 
   @Builder
   private Options(
       Boolean allowingFollowsAfterApproval,
       Boolean templateNotification,
-      Boolean dduduNotification
+      Boolean dduduNotification,
+      DisplayOptions display,
+      MenuActivationOptions menuActivation,
+      AppConnectionOptions appConnection
   ) {
-    this.allowingFollowsAfterApproval = Objects.requireNonNullElse(
-        allowingFollowsAfterApproval,
-        false
-    );
-    this.templateNotification = Objects.requireNonNullElse(templateNotification, true);
-    this.dduduNotification = Objects.requireNonNullElse(dduduNotification, true);
+    this.allowingFollowsAfterApproval =
+        Objects.nonNull(allowingFollowsAfterApproval) && allowingFollowsAfterApproval;
+    this.templateNotification = Objects.isNull(templateNotification) || templateNotification;
+    this.dduduNotification = Objects.isNull(dduduNotification) || dduduNotification;
+    this.display = createDisplay(display);
+    this.menuActivation = createMenuActivation(menuActivation);
+    this.appConnection = createAppConnection(appConnection);
+  }
+
+  private DisplayOptions createDisplay(DisplayOptions display) {
+    if (Objects.nonNull(display)) {
+      return display;
+    }
+
+    return DisplayOptions.builder()
+        .build();
+  }
+
+  private MenuActivationOptions createMenuActivation(MenuActivationOptions menuActivation) {
+    if (Objects.nonNull(menuActivation)) {
+      return menuActivation;
+    }
+
+    return MenuActivationOptions.builder()
+        .build();
+  }
+
+  private AppConnectionOptions createAppConnection(AppConnectionOptions appConnection) {
+    if (Objects.nonNull(appConnection)) {
+      return appConnection;
+    }
+
+    return AppConnectionOptions.builder()
+        .build();
   }
 
 }

--- a/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/RealtimeSyncOptions.java
+++ b/domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/RealtimeSyncOptions.java
@@ -1,0 +1,21 @@
+package com.ddudu.domain.user.user.aggregate.vo;
+
+import java.util.Objects;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class RealtimeSyncOptions {
+
+  private final boolean notion;
+  private final boolean googleCalendar;
+  private final boolean microsoftTodo;
+
+  @Builder
+  private RealtimeSyncOptions(Boolean notion, Boolean googleCalendar, Boolean microsoftTodo) {
+    this.notion = Objects.nonNull(notion) && notion;
+    this.googleCalendar = Objects.nonNull(googleCalendar) && googleCalendar;
+    this.microsoftTodo = Objects.nonNull(microsoftTodo) && microsoftTodo;
+  }
+
+}

--- a/domain/user-domain/src/test/java/com/ddudu/domain/user/user/aggregate/UserTest.java
+++ b/domain/user-domain/src/test/java/com/ddudu/domain/user/user/aggregate/UserTest.java
@@ -195,4 +195,33 @@ class UserTest {
 
   }
 
+  @Nested
+  class 기본_옵션_생성_테스트 {
+
+    @Test
+    void options가_null이면_신규_기본_옵션까지_함께_생성된다() {
+      // given
+      User user = UserFixture.createRandomUserWithNullOptions(1L);
+
+      // when
+
+      // then
+      assertThat(user.isAllowingFollowsAfterApproval()).isFalse();
+      assertThat(user.isNotifyingTemplate()).isTrue();
+      assertThat(user.isNotifyingDdudu()).isTrue();
+      assertThat(user.getWeekStartDay().name()).isEqualTo("SUN");
+      assertThat(user.isDarkMode()).isFalse();
+      assertThat(user.isActiveCalendar()).isTrue();
+      assertThat(user.getPriorityCalendar()).isEqualTo(1);
+      assertThat(user.isActiveDashboard()).isTrue();
+      assertThat(user.getPriorityDashboard()).isEqualTo(2);
+      assertThat(user.isActiveStats()).isTrue();
+      assertThat(user.getPriorityStats()).isEqualTo(3);
+      assertThat(user.isRealtimeSyncNotion()).isFalse();
+      assertThat(user.isRealtimeSyncGoogleCalendar()).isFalse();
+      assertThat(user.isRealtimeSyncMicrosoftTodo()).isFalse();
+    }
+
+  }
+
 }

--- a/domain/user-domain/src/test/java/com/ddudu/domain/user/user/aggregate/vo/OptionSubVoTest.java
+++ b/domain/user-domain/src/test/java/com/ddudu/domain/user/user/aggregate/vo/OptionSubVoTest.java
@@ -1,0 +1,54 @@
+package com.ddudu.domain.user.user.aggregate.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddudu.domain.user.user.aggregate.enums.WeekStartDay;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class OptionSubVoTest {
+
+  @Test
+  void DisplayOptions의_기본값을_생성한다() {
+    // given
+
+    // when
+    DisplayOptions actual = DisplayOptions.builder().build();
+
+    // then
+    assertThat(actual.getWeekStartDay()).isEqualTo(WeekStartDay.SUN);
+    assertThat(actual.isDarkMode()).isFalse();
+  }
+
+  @Test
+  void MenuActivationOptions의_기본값을_생성한다() {
+    // given
+
+    // when
+    MenuActivationOptions actual = MenuActivationOptions.builder().build();
+
+    // then
+    assertThat(actual.getCalendar().isActive()).isTrue();
+    assertThat(actual.getCalendar().getPriority()).isEqualTo(1);
+    assertThat(actual.getDashboard().isActive()).isTrue();
+    assertThat(actual.getDashboard().getPriority()).isEqualTo(2);
+    assertThat(actual.getStats().isActive()).isTrue();
+    assertThat(actual.getStats().getPriority()).isEqualTo(3);
+  }
+
+  @Test
+  void AppConnectionOptions의_기본값을_생성한다() {
+    // given
+
+    // when
+    AppConnectionOptions actual = AppConnectionOptions.builder().build();
+
+    // then
+    assertThat(actual.getRealtimeSync().isNotion()).isFalse();
+    assertThat(actual.getRealtimeSync().isGoogleCalendar()).isFalse();
+    assertThat(actual.getRealtimeSync().isMicrosoftTodo()).isFalse();
+  }
+
+}

--- a/domain/user-domain/src/test/java/com/ddudu/domain/user/user/aggregate/vo/OptionsTest.java
+++ b/domain/user-domain/src/test/java/com/ddudu/domain/user/user/aggregate/vo/OptionsTest.java
@@ -2,6 +2,7 @@ package com.ddudu.domain.user.user.aggregate.vo;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.ddudu.domain.user.user.aggregate.enums.WeekStartDay;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
@@ -25,12 +26,44 @@ class OptionsTest {
           .allowingFollowsAfterApproval(allowFollowsAfterApproval)
           .templateNotification(templateNotification)
           .dduduNotification(dduduNotification)
+          .display(DisplayOptions.builder()
+              .weekStartDay(WeekStartDay.MON)
+              .darkMode(true)
+              .build())
+          .menuActivation(MenuActivationOptions.builder()
+              .calendar(MenuActivationItem.builder()
+                  .active(false)
+                  .priority(4)
+                  .build())
+              .dashboard(MenuActivationItem.builder()
+                  .active(true)
+                  .priority(5)
+                  .build())
+              .stats(MenuActivationItem.builder()
+                  .active(false)
+                  .priority(6)
+                  .build())
+              .build())
+          .appConnection(AppConnectionOptions.builder()
+              .realtimeSync(RealtimeSyncOptions.builder()
+                  .notion(true)
+                  .googleCalendar(true)
+                  .microsoftTodo(true)
+                  .build())
+              .build())
           .build();
 
       // then
       assertThat(actual.isAllowingFollowsAfterApproval()).isTrue();
       assertThat(actual.isTemplateNotification()).isFalse();
       assertThat(actual.isDduduNotification()).isFalse();
+      assertThat(actual.getDisplay().getWeekStartDay()).isEqualTo(WeekStartDay.MON);
+      assertThat(actual.getDisplay().isDarkMode()).isTrue();
+      assertThat(actual.getMenuActivation().getCalendar().isActive()).isFalse();
+      assertThat(actual.getMenuActivation().getCalendar().getPriority()).isEqualTo(4);
+      assertThat(actual.getAppConnection().getRealtimeSync().isNotion()).isTrue();
+      assertThat(actual.getAppConnection().getRealtimeSync().isGoogleCalendar()).isTrue();
+      assertThat(actual.getAppConnection().getRealtimeSync().isMicrosoftTodo()).isTrue();
     }
 
     @Test
@@ -45,6 +78,17 @@ class OptionsTest {
       assertThat(actual.isAllowingFollowsAfterApproval()).isFalse();
       assertThat(actual.isTemplateNotification()).isTrue();
       assertThat(actual.isDduduNotification()).isTrue();
+      assertThat(actual.getDisplay().getWeekStartDay()).isEqualTo(WeekStartDay.SUN);
+      assertThat(actual.getDisplay().isDarkMode()).isFalse();
+      assertThat(actual.getMenuActivation().getCalendar().isActive()).isTrue();
+      assertThat(actual.getMenuActivation().getCalendar().getPriority()).isEqualTo(1);
+      assertThat(actual.getMenuActivation().getDashboard().isActive()).isTrue();
+      assertThat(actual.getMenuActivation().getDashboard().getPriority()).isEqualTo(2);
+      assertThat(actual.getMenuActivation().getStats().isActive()).isTrue();
+      assertThat(actual.getMenuActivation().getStats().getPriority()).isEqualTo(3);
+      assertThat(actual.getAppConnection().getRealtimeSync().isNotion()).isFalse();
+      assertThat(actual.getAppConnection().getRealtimeSync().isGoogleCalendar()).isFalse();
+      assertThat(actual.getAppConnection().getRealtimeSync().isMicrosoftTodo()).isFalse();
     }
 
   }

--- a/domain/user-domain/src/testFixtures/java/com/ddudu/fixture/UserFixture.java
+++ b/domain/user-domain/src/testFixtures/java/com/ddudu/fixture/UserFixture.java
@@ -43,6 +43,29 @@ public class UserFixture extends BaseFixture {
         .build();
   }
 
+  public static User createRandomUserWithNullOptions(long id) {
+    String lowTime = UUID.randomUUID()
+        .toString()
+        .substring(0, 8);
+    RandomUserAdjective adjective = RandomUserAdjective.getRandom();
+    RandomUserAnimal animal = RandomUserAnimal.getRandom();
+    String username = adjective.getUsername() + animal.getUsername() + lowTime;
+    String nickname = adjective.getNickname() + " " + animal.getNickname();
+
+    return User.builder()
+        .id(id)
+        .nickname(nickname)
+        .username(username)
+        .authority(Authority.NORMAL)
+        .authProviders(Collections.singletonList(createRandomAuthProvider()))
+        .status(UserStatus.ACTIVE)
+        .options(null)
+        .allowingFollowsAfterApproval(null)
+        .templateNotification(null)
+        .dduduNotification(null)
+        .build();
+  }
+
   public static User createRandomSocialUser(AuthProvider authProvider) {
     return createRandomUser(getRandomId(), null, authProvider, null, null, null, null);
   }

--- a/infra/user-infra-mysql/src/main/java/com/ddudu/infra/mysql/user/user/entity/UserEntity.java
+++ b/infra/user-infra-mysql/src/main/java/com/ddudu/infra/mysql/user/user/entity/UserEntity.java
@@ -4,7 +4,14 @@ import com.ddudu.common.dto.Authority;
 import com.ddudu.domain.user.user.aggregate.User;
 import com.ddudu.domain.user.user.aggregate.User.UserBuilder;
 import com.ddudu.domain.user.user.aggregate.enums.UserStatus;
+import com.ddudu.domain.user.user.aggregate.enums.WeekStartDay;
+import com.ddudu.domain.user.user.aggregate.vo.AppConnectionOptions;
 import com.ddudu.domain.user.user.aggregate.vo.AuthProvider;
+import com.ddudu.domain.user.user.aggregate.vo.DisplayOptions;
+import com.ddudu.domain.user.user.aggregate.vo.MenuActivationItem;
+import com.ddudu.domain.user.user.aggregate.vo.MenuActivationOptions;
+import com.ddudu.domain.user.user.aggregate.vo.Options;
+import com.ddudu.domain.user.user.aggregate.vo.RealtimeSyncOptions;
 import com.ddudu.infra.mysql.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -94,6 +101,75 @@ public class UserEntity extends BaseEntity {
   )
   private boolean dduduNotification;
 
+  @Column(
+      name = "week_start_day",
+      columnDefinition = "VARCHAR",
+      length = 3,
+      nullable = false
+  )
+  @Enumerated(EnumType.STRING)
+  private WeekStartDay weekStartDay;
+
+  @Column(
+      name = "dark_mode",
+      nullable = false
+  )
+  private boolean darkMode;
+
+  @Column(
+      name = "active_calendar",
+      nullable = false
+  )
+  private boolean activeCalendar;
+
+  @Column(
+      name = "priority_calendar",
+      nullable = false
+  )
+  private int priorityCalendar;
+
+  @Column(
+      name = "active_dashboard",
+      nullable = false
+  )
+  private boolean activeDashboard;
+
+  @Column(
+      name = "priority_dashboard",
+      nullable = false
+  )
+  private int priorityDashboard;
+
+  @Column(
+      name = "active_stats",
+      nullable = false
+  )
+  private boolean activeStats;
+
+  @Column(
+      name = "priority_stats",
+      nullable = false
+  )
+  private int priorityStats;
+
+  @Column(
+      name = "realtime_sync_notion",
+      nullable = false
+  )
+  private boolean realtimeSyncNotion;
+
+  @Column(
+      name = "realtime_sync_google_calendar",
+      nullable = false
+  )
+  private boolean realtimeSyncGoogleCalendar;
+
+  @Column(
+      name = "realtime_sync_microsoft_todo",
+      nullable = false
+  )
+  private boolean realtimeSyncMicrosoftTodo;
+
   public static UserEntity from(User user) {
     return UserEntity.builder()
         .id(user.getId())
@@ -106,6 +182,17 @@ public class UserEntity extends BaseEntity {
         .allowingFollowsAfterApproval(user.isAllowingFollowsAfterApproval())
         .templateNotification(user.isNotifyingTemplate())
         .dduduNotification(user.isNotifyingDdudu())
+        .weekStartDay(user.getWeekStartDay())
+        .darkMode(user.isDarkMode())
+        .activeCalendar(user.isActiveCalendar())
+        .priorityCalendar(user.getPriorityCalendar())
+        .activeDashboard(user.isActiveDashboard())
+        .priorityDashboard(user.getPriorityDashboard())
+        .activeStats(user.isActiveStats())
+        .priorityStats(user.getPriorityStats())
+        .realtimeSyncNotion(user.isRealtimeSyncNotion())
+        .realtimeSyncGoogleCalendar(user.isRealtimeSyncGoogleCalendar())
+        .realtimeSyncMicrosoftTodo(user.isRealtimeSyncMicrosoftTodo())
         .build();
   }
 
@@ -128,9 +215,52 @@ public class UserEntity extends BaseEntity {
         .authority(authority)
         .status(status)
         .profileImageUrl(profileImageUrl)
+        .options(buildOptions());
+  }
+
+  private Options buildOptions() {
+    return Options.builder()
         .allowingFollowsAfterApproval(allowingFollowsAfterApproval)
         .templateNotification(templateNotification)
-        .dduduNotification(dduduNotification);
+        .dduduNotification(dduduNotification)
+        .display(buildDisplayOptions())
+        .menuActivation(buildMenuActivationOptions())
+        .appConnection(buildAppConnectionOptions())
+        .build();
+  }
+
+  private DisplayOptions buildDisplayOptions() {
+    return DisplayOptions.builder()
+        .weekStartDay(weekStartDay)
+        .darkMode(darkMode)
+        .build();
+  }
+
+  private MenuActivationOptions buildMenuActivationOptions() {
+    return MenuActivationOptions.builder()
+        .calendar(MenuActivationItem.builder()
+            .active(activeCalendar)
+            .priority(priorityCalendar)
+            .build())
+        .dashboard(MenuActivationItem.builder()
+            .active(activeDashboard)
+            .priority(priorityDashboard)
+            .build())
+        .stats(MenuActivationItem.builder()
+            .active(activeStats)
+            .priority(priorityStats)
+            .build())
+        .build();
+  }
+
+  private AppConnectionOptions buildAppConnectionOptions() {
+    return AppConnectionOptions.builder()
+        .realtimeSync(RealtimeSyncOptions.builder()
+            .notion(realtimeSyncNotion)
+            .googleCalendar(realtimeSyncGoogleCalendar)
+            .microsoftTodo(realtimeSyncMicrosoftTodo)
+            .build())
+        .build();
   }
 
 }

--- a/plans/user-option-확장-구현-플랜.md
+++ b/plans/user-option-확장-구현-플랜.md
@@ -1,0 +1,95 @@
+# User Option 확장 구현 플랜
+
+## 1) 목표
+
+- 로그인 시 `User` 생성/복원 과정에서 `option`이 `null`이면, 기존 기본 옵션 + 신규 기본 옵션을 함께 채워 저장한다.
+- 외부 로그인 API의 요청/응답 스펙은 변경하지 않는다.
+- `User` 하위 `Options`를 JSON Object 구조와 유사한 계층형 VO로 확장한다.
+
+## 2) 신규/영향 클래스 및 패키지 위치
+
+### 영향 클래스
+
+- `domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/User.java`
+  - `options == null` 시 기본값 생성 로직 확장
+  - 기존 `buildOptions(...)` 시그니처/생성 흐름 조정
+- `domain/user-domain/src/main/java/com/ddudu/domain/user/user/aggregate/vo/Options.java`
+  - 기존 평면 필드 + 신규 하위 VO 필드 포함하도록 구조 확장
+- `domain/user-domain/src/test/java/com/ddudu/domain/user/user/aggregate/UserTest.java`
+  - `option null`인 경우의 초기값 검증 강화
+- `domain/user-domain/src/test/java/com/ddudu/domain/user/user/aggregate/vo/OptionsTest.java`
+  - 확장된 기본값/하위 VO 검증 추가
+- `domain/user-domain/src/testFixtures/java/com/ddudu/fixture/UserFixture.java`
+  - 신규 옵션 기본값과 부분 변경 케이스를 쉽게 생성하도록 fixture 메서드 추가
+
+### 신규 클래스 (VO)
+
+- 패키지: `com.ddudu.domain.user.user.aggregate.vo`
+  - `DisplayOptions`
+  - `MenuActivationOptions`
+  - `MenuActivationItem`
+  - `AppConnectionOptions`
+  - `RealtimeSyncOptions`
+- 패키지: `com.ddudu.domain.user.user.aggregate.enums`
+  - `WeekStartDay` (`SUN`, `MON`)
+
+> 참고: VO는 `Options` 내부 정적 클래스로 둘 수도 있으나, 테스트 가독성과 재사용성을 위해 독립 클래스 분리를 우선 권장.
+
+## 3) 도메인 모델 설계안
+
+- `Options`
+  - 기존: `allowingFollowsAfterApproval`, `templateNotification`, `dduduNotification`
+  - 신규:
+    - `DisplayOptions display`
+    - `MenuActivationOptions menuActivation`
+    - `AppConnectionOptions appConnection`
+- `DisplayOptions`
+  - `WeekStartDay weekStartDay` (기본값 `SUN`)
+  - `boolean darkMode` (기본값 `false`)
+- `MenuActivationOptions`
+  - `MenuActivationItem calendar` (기본값 `isActive=true`, `priority=1`)
+  - `MenuActivationItem dashboard` (기본값 `isActive=true`, `priority=2`)
+  - `MenuActivationItem stats` (기본값 `isActive=true`, `priority=3`)
+- `AppConnectionOptions`
+  - `RealtimeSyncOptions realtimeSync`
+- `RealtimeSyncOptions`
+  - `boolean notion` (기본값 `false`)
+  - `boolean googleCalendar` (기본값 `false`)
+  - `boolean microsoftTodo` (기본값 `false`)
+
+## 4) 구현 단계
+
+1. `WeekStartDay` enum 및 신규 VO 클래스 생성
+   - 각 VO에 빌더/생성자 기본값 주입 (`Objects.requireNonNullElse` 패턴 유지)
+2. `Options` 확장
+   - 신규 VO 필드 추가
+   - `builder` 입력이 `null`인 경우 신규 기본값 자동 세팅
+3. `User` 기본 옵션 생성 경로 갱신
+   - `options == null`이면 확장된 `Options` 기본값을 생성
+   - 기존 로그인 흐름 호출부 변경 없이 동작하도록 `User.builder()` 구성 유지
+4. 테스트 fixture 확장
+   - `createValidUser()`는 확장 옵션 기본값을 내장
+   - 타깃 필드만 주입 가능한 메서드 추가 (예: `createUserWithWeekStartDay(...)`)
+5. 단위 테스트 추가/보강
+   - `OptionsTest`: 기본값/개별 VO 기본값/priority 순서 검증
+   - `UserTest`: `options null` 입력 시 전체 기본값 구성 검증
+
+## 5) 테스트 플랜
+
+- 대상 모듈
+  - `domain/user-domain`
+- 권장 케이스
+  - 성공
+    - `Options` 생성 시 기본값이 스펙과 일치
+    - 각 신규 VO 생성 시 기본값/명시값 적용 정상
+    - `User` 생성 시 `options == null`이면 확장 기본 옵션 자동 구성
+  - 실패
+    - 현재 스펙상 별도 실패 케이스 없음 (필요 시 priority 음수 같은 유효성 규칙 도입 후 추가)
+
+## 6) 리스크 및 확인 포인트
+
+- 직렬화/역직렬화 경로(인프라)에서 `Options` 구조 변경 영향 확인 필요
+- 기존 DB JSON 컬럼을 사용 중이라면, 누락 필드는 기본값으로 보정되도록 매핑 전략 점검
+- API 계약 무변경 요구사항 확인
+  - 로그인 요청/응답 DTO 변경 금지
+  - 내부 저장값만 확장


### PR DESCRIPTION
### Motivation

- Introduce richer user setting options (display, menu activation, app connections/realtime sync) and ensure default values are applied when `options` is `null` during `User` creation/restoration.
- Persist the new option fields in the database and provide a migration script to add the new columns to the `users` table.

### Description

- Added new value objects and enum: `DisplayOptions`, `MenuActivationOptions`, `MenuActivationItem`, `AppConnectionOptions`, `RealtimeSyncOptions` and `WeekStartDay` and extended `Options` to contain these sub-VOs with sensible defaults.
- Updated `User` to build default `Options` when `options == null` and added convenience accessors for the new option fields (week start day, dark mode, menu activation priorities, and realtime sync flags).
- Extended persistence mapping in `UserEntity` to include new columns and implemented `from(User)` and `toDomain()` paths to convert between domain `Options` and individual DB columns.
- Added a Flyway migration `V14__add_user_setting_options.sql` and updated the seed file `afterMigrate.sql` to populate new fields, plus a design/plan doc `plans/user-option-확장-구현-플랜.md`.
- Added and updated tests and fixtures: `OptionsTest`, `OptionSubVoTest`, `UserTest` (added default-options test), and `UserFixture` helper to produce users with `null` options.

### Testing

- Ran unit tests for the `domain/user-domain` module including `OptionsTest`, `OptionSubVoTest`, and `UserTest`, and all tests passed. 
- Verified that the project compiles with the new persistence mappings and migration present by running the module test/build, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56d5e0db8832dac96760f3f71cada)