### PR TITLE
Switch ddudu postpone flag to `postponedAt` timestamp and add `postpone` option to move-date API

### DIFF
--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/ddudu/request/MoveDateRequest.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/ddudu/request/MoveDateRequest.java
@@ -5,7 +5,8 @@ import java.time.LocalDate;
 
 public record MoveDateRequest(
     @NotNull(message = "2011 NULL_DATE_TO_MOVE")
-    LocalDate newDate
+    LocalDate newDate,
+    boolean postpone
 ) {
 
 }

--- a/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/MoveDateService.java
+++ b/application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/MoveDateService.java
@@ -27,7 +27,7 @@ public class MoveDateService implements MoveDateUseCase {
 
     ddudu.validateDduduCreator(loginId);
 
-    Ddudu movedDdudu = ddudu.moveDate(request.newDate());
+    Ddudu movedDdudu = ddudu.moveDate(request.newDate(), request.postpone());
 
     dduduUpdatePort.update(movedDdudu);
   }

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/CreateDduduServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/CreateDduduServiceTest.java
@@ -87,7 +87,7 @@ class CreateDduduServiceTest {
             "goalId",
             "userId",
             "status",
-            "isPostponed"
+            "postponedAt"
         )
         .containsExactly(
             name,
@@ -95,7 +95,7 @@ class CreateDduduServiceTest {
             goal.getId(),
             user.getId(),
             DduduStatus.UNCOMPLETED,
-            false);
+            null);
   }
 
   @Test

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/MoveDateServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/MoveDateServiceTest.java
@@ -9,6 +9,7 @@ import com.ddudu.application.common.port.ddudu.out.SaveDduduPort;
 import com.ddudu.application.common.port.goal.out.SaveGoalPort;
 import com.ddudu.common.exception.DduduErrorCode;
 import com.ddudu.domain.planning.ddudu.aggregate.Ddudu;
+import com.ddudu.domain.planning.ddudu.aggregate.enums.DduduStatus;
 import com.ddudu.domain.planning.goal.aggregate.Goal;
 import com.ddudu.domain.user.user.aggregate.User;
 import com.ddudu.fixture.DduduFixture;
@@ -63,7 +64,7 @@ class MoveDateServiceTest {
   @Test
   void 뚜두를_미루기_한다() {
     // given
-    MoveDateRequest request = new MoveDateRequest(tomorrow);
+    MoveDateRequest request = new MoveDateRequest(tomorrow, true);
 
     // when
     moveDateService.moveDate(user.getId(), ddudu.getId(), request);
@@ -85,7 +86,7 @@ class MoveDateServiceTest {
         goal.getId(),
         yesterday
     ));
-    MoveDateRequest request = new MoveDateRequest(LocalDate.now());
+    MoveDateRequest request = new MoveDateRequest(LocalDate.now(), false);
 
     // when
     moveDateService.moveDate(user.getId(), pastDdudu.getId(), request);
@@ -108,7 +109,12 @@ class MoveDateServiceTest {
     ));
     LocalDate yesterday = LocalDate.now()
         .minusDays(1);
-    MoveDateRequest request = new MoveDateRequest(yesterday);
+    pastDdudu = saveDduduPort.save(DduduFixture.createRandomDduduWithStatusAndSchedule(
+        goal,
+        DduduStatus.COMPLETE,
+        twoDaysAgo
+    ));
+    MoveDateRequest request = new MoveDateRequest(yesterday, false);
 
     // when
     moveDateService.moveDate(user.getId(), pastDdudu.getId(), request);
@@ -120,10 +126,29 @@ class MoveDateServiceTest {
   }
 
   @Test
+  void 완료된_뚜두에_미루기_요청을_하면_실패한다() {
+    // given
+    Ddudu completedDdudu = saveDduduPort.save(DduduFixture.createRandomDduduWithStatus(
+        goal,
+        DduduStatus.COMPLETE
+    ));
+    MoveDateRequest request = new MoveDateRequest(tomorrow, true);
+
+    // when
+    ThrowingCallable moveDate = () -> moveDateService.moveDate(user.getId(), completedDdudu.getId(),
+        request);
+
+    // then
+    Assertions.assertThatIllegalArgumentException()
+        .isThrownBy(moveDate)
+        .withMessage(DduduErrorCode.UNABLE_TO_POSTPONE_COMPLETED_DDUDU.getCodeName());
+  }
+
+  @Test
   void 뚜두가_존재하지_않으면_날짜_변경을_실패한다() {
     // given
     long invalidId = DduduFixture.getRandomId();
-    MoveDateRequest request = new MoveDateRequest(tomorrow);
+    MoveDateRequest request = new MoveDateRequest(tomorrow, true);
 
     // when
     ThrowingCallable moveDate = () -> moveDateService.moveDate(user.getId(), invalidId, request);

--- a/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/DduduErrorExamples.java
+++ b/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/DduduErrorExamples.java
@@ -86,6 +86,13 @@ public final class DduduErrorExamples {
       }
       """;
 
+  public static final String DDUDU_UNABLE_TO_POSTPONE_COMPLETED_DDUDU = """
+      {
+        "code": 2022,
+        "message": "완료된 뚜두는 미루기 처리할 수 없습니다."
+      }
+      """;
+
   public static final String DDUDU_UNABLE_TO_REPRODUCE_ON_SAME_DATE = """
       {
         "code": 2013,

--- a/bootstrap/bootstrap-gateway/src/main/resources/db/data/afterMigrate.sql
+++ b/bootstrap/bootstrap-gateway/src/main/resources/db/data/afterMigrate.sql
@@ -23,14 +23,14 @@ INSERT INTO users(id, nickname, username, introduction, profile_image_url, autho
                   priority_dashboard, active_stats, priority_stats, realtime_sync_notion,
                   realtime_sync_google_calendar, realtime_sync_microsoft_todo, created_at, updated_at)
 VALUES (1, '결단력있는 딩고', 'determineddingoda25c93c', null, null, 'ADMIN', 'ACTIVE', 0, 1, 1,
-        'SUN', 0, 1, 1, 1, 2, 1, 3, 0, 0, 0, '2024-05-17T16:13:48', '2024-05-17T16:13:48');
+        'SUN', 0, 1, 1, 1, 2, 1, 3, 0, 0, null, '2024-05-17T16:13:48', '2024-05-17T16:13:48');
 INSERT INTO users(id, nickname, username, introduction, profile_image_url, authority, status,
                   follows_after_approval, template_notification, ddudu_notification, week_start_day,
                   dark_mode, active_calendar, priority_calendar, active_dashboard,
                   priority_dashboard, active_stats, priority_stats, realtime_sync_notion,
                   realtime_sync_google_calendar, realtime_sync_microsoft_todo, created_at, updated_at)
 VALUES (2, '짜증난 강아지', 'irritatedpuppy30b6f3ed', null, null, 'ADMIN', 'ACTIVE', 0, 1, 1,
-        'SUN', 0, 1, 1, 1, 2, 1, 3, 0, 0, 0, '2024-08-18T21:13:02', '2024-08-18T21:13:02');
+        'SUN', 0, 1, 1, 1, 2, 1, 3, 0, 0, null, '2024-08-18T21:13:02', '2024-08-18T21:13:02');
 # 뚜두 구글 계정
 
 -- REFRESH TOKEN
@@ -48,418 +48,418 @@ VALUES (2, 2, 'KAKAO', '3473310045', '2024-08-18T12:13:02', '2024-08-18T12:13:02
 
 -- GOALS
 INSERT INTO goals(id, user_id, name, color, privacy, status, priority, created_at, updated_at)
-VALUES (1, 1, '프로젝트', '191919', 'PUBLIC', 'IN_PROGRESS', 1, '2024-05-17T07:13:48',
+VALUES (1, 1, '프로젝트', '191919', 'PUBLIC', 'IN_PROGRESS', '2024-05-17T07:13:48',
         '2024-05-17T07:13:48');
 INSERT INTO goals(id, user_id, name, color, privacy, status, priority, created_at, updated_at)
 VALUES (2, 1, 'Study', '999999', 'PRIVATE', 'IN_PROGRESS', 2, '2024-05-18T07:13:48',
         '2024-05-17T07:13:48');
 INSERT INTO goals(id, user_id, name, color, privacy, status, priority, created_at, updated_at)
-VALUES (3, 2, '프로젝트', '191919', 'PUBLIC', 'IN_PROGRESS', 1, '2024-08-18T21:13:02',
+VALUES (3, 2, '프로젝트', '191919', 'PUBLIC', 'IN_PROGRESS', '2024-08-18T21:13:02',
         '2024-08-18T21:13:02');
 INSERT INTO goals(id, user_id, name, color, privacy, status, priority, created_at, updated_at)
 VALUES (4, 2, '프로젝트2', '191919', 'PUBLIC', 'IN_PROGRESS', 2, '2024-08-18T21:13:02',
         '2024-08-18T21:13:02');
 
 -- DDUDUS
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (1, 1, 1, '데일리 스크럼', 'COMPLETE', '11:00:00', '11:30:00', 0, '2024-05-17T06:30:48',
+VALUES (1, 1, 1, '데일리 스크럼', 'COMPLETE', '11:00:00', '11:30:00', null, '2024-05-17T06:30:48',
         '2024-05-17T06:30:48', '2024-05-17');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (2, 1, 1, '뚜두뚜두 배포하기', 'UNCOMPLETED', null, null, 0, '2024-05-17T07:13:48',
+VALUES (2, 1, 1, '뚜두뚜두 배포하기', 'UNCOMPLETED', null, null, null, '2024-05-17T07:13:48',
         '2024-05-17T07:13:48', '2024-05-17');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (3, 1, 1, '목표 도메인 리팩토링', 'UNCOMPLETED', null, null, 0, '2024-05-17T07:30:48',
+VALUES (3, 1, 1, '목표 도메인 리팩토링', 'UNCOMPLETED', null, null, null, '2024-05-17T07:30:48',
         '2024-05-17T07:30:48', '2024-05-17');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (4, 1, 2, '알고리즘 스터디1', 'UNCOMPLETED', '20:00:00', '21:00:00', 0, '2024-05-17T07:30:48',
+VALUES (4, 1, 2, '알고리즘 스터디1', 'UNCOMPLETED', '20:00:00', '21:00:00', null, '2024-05-17T07:30:48',
         '2024-05-17T07:30:48', '2024-05-17');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (5, 1, 2, '알고리즘 스터디2', 'UNCOMPLETED', '20:00:00', '21:00:00', 0, '2024-05-17T07:30:48',
+VALUES (5, 1, 2, '알고리즘 스터디2', 'UNCOMPLETED', '20:00:00', '21:00:00', null, '2024-05-17T07:30:48',
         '2024-05-17T07:30:48', '2024-05-17');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (6, 2, 3, '데일리 스크럼', 'COMPLETE', '09:00:00', '09:30:00', 0, '2024-08-01T08:15:00',
+VALUES (6, 2, 3, '데일리 스크럼', 'COMPLETE', '09:00:00', '09:30:00', null, '2024-08-01T08:15:00',
         '2024-08-01T08:15:00', '2024-08-01');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (7, 2, 3, '주간 회의', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-23T09:45:00', '2024-07-23T09:45:00', '2024-07-23');
+VALUES (7, 2, 3, '주간 회의', 'UNCOMPLETED', '10:00:00', null, '2024-07-23T09:45:00', '2024-07-23T09:45:00', '2024-07-23');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (8, 2, 3, '코드 리뷰', 'COMPLETE', '14:00:00', '14:30:00', 0, '2024-08-05T12:30:00',
+VALUES (8, 2, 3, '코드 리뷰', 'COMPLETE', '14:00:00', '14:30:00', null, '2024-08-05T12:30:00',
         '2024-08-05T12:30:00', '2024-08-05');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (9, 2, 3, '팀 회의 준비', 'COMPLETE', '13:00:00', '13:30:00', 0, '2024-08-06T13:00:00',
+VALUES (9, 2, 3, '팀 회의 준비', 'COMPLETE', '13:00:00', '13:30:00', null, '2024-08-06T13:00:00',
         '2024-08-06T13:00:00', '2024-08-06');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (10, 2, 3, '기술 블로그 작성', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-18T11:00:00', '2024-07-18T11:00:00', '2024-07-18');
+VALUES (10, 2, 3, '기술 블로그 작성', 'UNCOMPLETED', '10:00:00', null, '2024-07-18T11:00:00', '2024-07-18T11:00:00', '2024-07-18');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (11, 2, 3, '프로젝트 미팅', 'COMPLETE', '10:00:00', '10:30:00', 1, '2024-07-15T10:15:00',
+VALUES (11, 2, 3, '프로젝트 미팅', 'COMPLETE', '10:00:00', '10:30:00', '2024-07-15T10:15:00',
         '2024-07-15T10:15:00', '2024-07-15');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (12, 2, 3, '데일리 체크인', 'COMPLETE', '11:00:00', '11:15:00', 0, '2024-08-11T11:00:00',
+VALUES (12, 2, 3, '데일리 체크인', 'COMPLETE', '11:00:00', '11:15:00', null, '2024-08-11T11:00:00',
         '2024-08-11T11:00:00', '2024-08-11');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (13, 2, 3, '코드 리뷰', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-30T12:00:00', '2024-07-30T12:00:00', '2024-07-30');
+VALUES (13, 2, 3, '코드 리뷰', 'UNCOMPLETED', '10:00:00', null, '2024-07-30T12:00:00', '2024-07-30T12:00:00', '2024-07-30');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (14, 2, 3, '기술 문서 작성', 'COMPLETE', '15:00:00', '15:45:00', 0, '2024-08-14T15:00:00',
+VALUES (14, 2, 3, '기술 문서 작성', 'COMPLETE', '15:00:00', '15:45:00', null, '2024-08-14T15:00:00',
         '2024-08-14T15:00:00', '2024-08-14');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (15, 2, 3, '팀 피드백', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-22T16:00:00', '2024-07-22T16:00:00', '2024-07-22');
+VALUES (15, 2, 3, '팀 피드백', 'UNCOMPLETED', '10:00:00', null, '2024-07-22T16:00:00', '2024-07-22T16:00:00', '2024-07-22');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (16, 2, 3, '데일리 스크럼', 'COMPLETE', '09:30:00', '10:00:00', 0, '2024-08-12T09:30:00',
+VALUES (16, 2, 3, '데일리 스크럼', 'COMPLETE', '09:30:00', '10:00:00', null, '2024-08-12T09:30:00',
         '2024-08-12T09:30:00', '2024-08-12');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (17, 2, 3, '주간 계획 수립', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-16T10:45:00', '2024-07-16T10:45:00', '2024-07-16');
+VALUES (17, 2, 3, '주간 계획 수립', 'UNCOMPLETED', '10:00:00', null, '2024-07-16T10:45:00', '2024-07-16T10:45:00', '2024-07-16');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (18, 2, 3, '코드 리뷰', 'COMPLETE', '11:30:00', '12:00:00', 0, '2024-08-03T11:30:00',
+VALUES (18, 2, 3, '코드 리뷰', 'COMPLETE', '11:30:00', '12:00:00', null, '2024-08-03T11:30:00',
         '2024-08-03T11:30:00', '2024-08-03');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (19, 2, 3, '팀 회의', 'COMPLETE', '14:00:00', '14:30:00', 0, '2024-08-04T14:00:00',
+VALUES (19, 2, 3, '팀 회의', 'COMPLETE', '14:00:00', '14:30:00', null, '2024-08-04T14:00:00',
         '2024-08-04T14:00:00', '2024-08-04');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (20, 2, 3, '기술 블로그 작성', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-26T15:30:00', '2024-07-26T15:30:00', '2024-07-26');
+VALUES (20, 2, 3, '기술 블로그 작성', 'UNCOMPLETED', '10:00:00', null, '2024-07-26T15:30:00', '2024-07-26T15:30:00', '2024-07-26');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (21, 2, 3, '주간 회의', 'COMPLETE', '10:00:00', '10:30:00', 0, '2024-08-02T10:00:00',
+VALUES (21, 2, 3, '주간 회의', 'COMPLETE', '10:00:00', '10:30:00', null, '2024-08-02T10:00:00',
         '2024-08-02T10:00:00', '2024-08-02');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (22, 2, 3, '코드 리뷰', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-28T13:00:00', '2024-07-28T13:00:00', '2024-07-28');
+VALUES (22, 2, 3, '코드 리뷰', 'UNCOMPLETED', '10:00:00', null, '2024-07-28T13:00:00', '2024-07-28T13:00:00', '2024-07-28');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (23, 2, 3, '기술 문서 작성', 'COMPLETE', '13:30:00', '14:00:00', 0, '2024-08-10T13:30:00',
+VALUES (23, 2, 3, '기술 문서 작성', 'COMPLETE', '13:30:00', '14:00:00', null, '2024-08-10T13:30:00',
         '2024-08-10T13:30:00', '2024-08-10');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (24, 2, 3, '팀 피드백', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-25T11:00:00', '2024-07-25T11:00:00', '2024-07-25');
+VALUES (24, 2, 3, '팀 피드백', 'UNCOMPLETED', '10:00:00', null, '2024-07-25T11:00:00', '2024-07-25T11:00:00', '2024-07-25');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (25, 2, 3, '데일리 스크럼', 'COMPLETE', '09:00:00', '09:30:00', 0, '2024-08-07T08:15:00',
+VALUES (25, 2, 3, '데일리 스크럼', 'COMPLETE', '09:00:00', '09:30:00', null, '2024-08-07T08:15:00',
         '2024-08-07T08:15:00', '2024-08-07');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (26, 2, 3, '주간 회의', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-29T09:45:00', '2024-07-29T09:45:00', '2024-07-29');
+VALUES (26, 2, 3, '주간 회의', 'UNCOMPLETED', '10:00:00', null, '2024-07-29T09:45:00', '2024-07-29T09:45:00', '2024-07-29');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (27, 2, 3, '코드 리뷰', 'COMPLETE', '14:00:00', '14:30:00', 0, '2024-08-05T12:30:00',
+VALUES (27, 2, 3, '코드 리뷰', 'COMPLETE', '14:00:00', '14:30:00', null, '2024-08-05T12:30:00',
         '2024-08-05T12:30:00', '2024-08-05');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (28, 2, 3, '팀 회의 준비', 'COMPLETE', '13:00:00', '13:30:00', 0, '2024-08-06T13:00:00',
+VALUES (28, 2, 3, '팀 회의 준비', 'COMPLETE', '13:00:00', '13:30:00', null, '2024-08-06T13:00:00',
         '2024-08-06T13:00:00', '2024-08-06');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (29, 2, 3, '기술 블로그 작성', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-18T11:00:00', '2024-07-18T11:00:00', '2024-07-18');
+VALUES (29, 2, 3, '기술 블로그 작성', 'UNCOMPLETED', '10:00:00', null, '2024-07-18T11:00:00', '2024-07-18T11:00:00', '2024-07-18');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (30, 2, 3, '프로젝트 미팅', 'COMPLETE', '10:00:00', '10:30:00', 1, '2024-07-15T10:15:00',
+VALUES (30, 2, 3, '프로젝트 미팅', 'COMPLETE', '10:00:00', '10:30:00', '2024-07-15T10:15:00',
         '2024-07-15T10:15:00', '2024-07-15');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (31, 2, 3, '데일리 체크인', 'COMPLETE', '11:00:00', '11:15:00', 0, '2024-08-11T11:00:00',
+VALUES (31, 2, 3, '데일리 체크인', 'COMPLETE', '11:00:00', '11:15:00', null, '2024-08-11T11:00:00',
         '2024-08-11T11:00:00', '2024-08-11');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (32, 2, 3, '코드 리뷰', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-30T12:00:00', '2024-07-30T12:00:00', '2024-07-30');
+VALUES (32, 2, 3, '코드 리뷰', 'UNCOMPLETED', '10:00:00', null, '2024-07-30T12:00:00', '2024-07-30T12:00:00', '2024-07-30');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (33, 2, 3, '기술 문서 작성', 'COMPLETE', '15:00:00', '15:45:00', 0, '2024-08-14T15:00:00',
+VALUES (33, 2, 3, '기술 문서 작성', 'COMPLETE', '15:00:00', '15:45:00', null, '2024-08-14T15:00:00',
         '2024-08-14T15:00:00', '2024-08-14');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (34, 2, 3, '팀 피드백', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-22T16:00:00', '2024-07-22T16:00:00', '2024-07-22');
+VALUES (34, 2, 3, '팀 피드백', 'UNCOMPLETED', '10:00:00', null, '2024-07-22T16:00:00', '2024-07-22T16:00:00', '2024-07-22');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (35, 2, 3, '데일리 스크럼', 'COMPLETE', '09:30:00', '10:00:00', 0, '2024-08-12T09:30:00',
+VALUES (35, 2, 3, '데일리 스크럼', 'COMPLETE', '09:30:00', '10:00:00', null, '2024-08-12T09:30:00',
         '2024-08-12T09:30:00', '2024-08-12');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (36, 2, 3, '주간 계획 수립', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-16T10:45:00', '2024-07-16T10:45:00', '2024-07-16');
+VALUES (36, 2, 3, '주간 계획 수립', 'UNCOMPLETED', '10:00:00', null, '2024-07-16T10:45:00', '2024-07-16T10:45:00', '2024-07-16');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (37, 2, 3, '코드 리뷰', 'COMPLETE', '11:30:00', '12:00:00', 0, '2024-08-03T11:30:00',
+VALUES (37, 2, 3, '코드 리뷰', 'COMPLETE', '11:30:00', '12:00:00', null, '2024-08-03T11:30:00',
         '2024-08-03T11:30:00', '2024-08-03');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (38, 2, 3, '팀 회의', 'COMPLETE', '14:00:00', '14:30:00', 0, '2024-08-04T14:00:00',
+VALUES (38, 2, 3, '팀 회의', 'COMPLETE', '14:00:00', '14:30:00', null, '2024-08-04T14:00:00',
         '2024-08-04T14:00:00', '2024-08-04');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (39, 2, 3, '기술 블로그 작성', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-26T15:30:00', '2024-07-26T15:30:00', '2024-07-26');
+VALUES (39, 2, 3, '기술 블로그 작성', 'UNCOMPLETED', '10:00:00', null, '2024-07-26T15:30:00', '2024-07-26T15:30:00', '2024-07-26');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (40, 2, 3, '주간 회의', 'COMPLETE', '10:00:00', '10:30:00', 0, '2024-08-02T10:00:00',
+VALUES (40, 2, 3, '주간 회의', 'COMPLETE', '10:00:00', '10:30:00', null, '2024-08-02T10:00:00',
         '2024-08-02T10:00:00', '2024-08-02');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (41, 2, 3, '코드 리뷰', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-28T13:00:00', '2024-07-28T13:00:00', '2024-07-28');
+VALUES (41, 2, 3, '코드 리뷰', 'UNCOMPLETED', '10:00:00', null, '2024-07-28T13:00:00', '2024-07-28T13:00:00', '2024-07-28');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (42, 2, 3, '기술 문서 작성', 'COMPLETE', '13:30:00', '14:00:00', 0, '2024-08-10T13:30:00',
+VALUES (42, 2, 3, '기술 문서 작성', 'COMPLETE', '13:30:00', '14:00:00', null, '2024-08-10T13:30:00',
         '2024-08-10T13:30:00', '2024-08-10');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (43, 2, 3, '팀 피드백', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-25T11:00:00', '2024-07-25T11:00:00', '2024-07-25');
+VALUES (43, 2, 3, '팀 피드백', 'UNCOMPLETED', '10:00:00', null, '2024-07-25T11:00:00', '2024-07-25T11:00:00', '2024-07-25');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (44, 2, 3, '데일리 스크럼', 'COMPLETE', '09:00:00', '09:30:00', 0, '2024-08-01T08:15:00',
+VALUES (44, 2, 3, '데일리 스크럼', 'COMPLETE', '09:00:00', '09:30:00', null, '2024-08-01T08:15:00',
         '2024-08-01T08:15:00', '2024-08-01');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (45, 2, 3, '주간 회의', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-23T09:45:00', '2024-07-23T09:45:00', '2024-07-23');
+VALUES (45, 2, 3, '주간 회의', 'UNCOMPLETED', '10:00:00', null, '2024-07-23T09:45:00', '2024-07-23T09:45:00', '2024-07-23');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (46, 2, 3, '코드 리뷰', 'COMPLETE', '14:00:00', '14:30:00', 0, '2024-08-05T12:30:00',
+VALUES (46, 2, 3, '코드 리뷰', 'COMPLETE', '14:00:00', '14:30:00', null, '2024-08-05T12:30:00',
         '2024-08-05T12:30:00', '2024-08-05');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (47, 2, 3, '팀 회의 준비', 'COMPLETE', '13:00:00', '13:30:00', 0, '2024-08-06T13:00:00',
+VALUES (47, 2, 3, '팀 회의 준비', 'COMPLETE', '13:00:00', '13:30:00', null, '2024-08-06T13:00:00',
         '2024-08-06T13:00:00', '2024-08-06');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (48, 2, 3, '기술 블로그 작성', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-18T11:00:00', '2024-07-18T11:00:00', '2024-07-18');
+VALUES (48, 2, 3, '기술 블로그 작성', 'UNCOMPLETED', '10:00:00', null, '2024-07-18T11:00:00', '2024-07-18T11:00:00', '2024-07-18');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (49, 2, 3, '프로젝트 미팅', 'COMPLETE', '10:00:00', '10:30:00', 1, '2024-07-15T10:15:00',
+VALUES (49, 2, 3, '프로젝트 미팅', 'COMPLETE', '10:00:00', '10:30:00', '2024-07-15T10:15:00',
         '2024-07-15T10:15:00', '2024-07-15');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (50, 2, 3, '데일리 체크인', 'COMPLETE', '11:00:00', '11:15:00', 0, '2024-08-11T11:00:00',
+VALUES (50, 2, 3, '데일리 체크인', 'COMPLETE', '11:00:00', '11:15:00', null, '2024-08-11T11:00:00',
         '2024-08-11T11:00:00', '2024-08-11');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (51, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-01T07:00:00',
+VALUES (51, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-01T07:00:00',
         '2024-08-01T08:00:00', '2024-08-01');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (52, 2, 4, '요가 클래스', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-23T08:15:00', '2024-07-23T08:15:00', '2024-07-23');
+VALUES (52, 2, 4, '요가 클래스', 'UNCOMPLETED', '10:00:00', null, '2024-07-23T08:15:00', '2024-07-23T08:15:00', '2024-07-23');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (53, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-05T06:30:00',
+VALUES (53, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-05T06:30:00',
         '2024-08-05T07:00:00', '2024-08-05');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (54, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-02T07:00:00',
+VALUES (54, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-02T07:00:00',
         '2024-08-02T08:00:00', '2024-08-02');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (55, 2, 4, '요가 클래스', 'UNCOMPLETED', '10:00:00', null, 1, '2024-07-25T08:15:00', '2024-07-25T08:15:00', '2024-07-25');
+VALUES (55, 2, 4, '요가 클래스', 'UNCOMPLETED', '10:00:00', null, '2024-07-25T08:15:00', '2024-07-25T08:15:00', '2024-07-25');
 
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (56, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-03T06:30:00',
+VALUES (56, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-03T06:30:00',
         '2024-08-03T07:00:00', '2024-08-03');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (57, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-06T07:00:00',
+VALUES (57, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-06T07:00:00',
         '2024-08-06T08:00:00', '2024-08-06');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (58, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-27T08:15:00',
+VALUES (58, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-27T08:15:00',
         '2024-07-27T08:15:00', '2024-07-27');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (59, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-07T06:30:00',
+VALUES (59, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-07T06:30:00',
         '2024-08-07T07:00:00', '2024-08-07');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (60, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-08T07:00:00',
+VALUES (60, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-08T07:00:00',
         '2024-08-08T08:00:00', '2024-08-08');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (61, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-29T08:15:00',
+VALUES (61, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-29T08:15:00',
         '2024-07-29T08:15:00', '2024-07-29');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (62, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-09T06:30:00',
+VALUES (62, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-09T06:30:00',
         '2024-08-09T07:00:00', '2024-08-09');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (63, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-10T07:00:00',
+VALUES (63, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-10T07:00:00',
         '2024-08-10T08:00:00', '2024-08-10');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (64, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-31T08:15:00',
+VALUES (64, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-31T08:15:00',
         '2024-07-31T08:15:00', '2024-07-31');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (65, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-11T06:30:00',
+VALUES (65, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-11T06:30:00',
         '2024-08-11T07:00:00', '2024-08-11');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (66, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-12T07:00:00',
+VALUES (66, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-12T07:00:00',
         '2024-08-12T08:00:00', '2024-08-12');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (67, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-19T08:15:00',
+VALUES (67, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-19T08:15:00',
         '2024-07-19T08:15:00', '2024-07-19');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (68, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-13T06:30:00',
+VALUES (68, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-13T06:30:00',
         '2024-08-13T07:00:00', '2024-08-13');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (69, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-14T07:00:00',
+VALUES (69, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-14T07:00:00',
         '2024-08-14T08:00:00', '2024-08-14');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (70, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-21T08:15:00',
+VALUES (70, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-21T08:15:00',
         '2024-07-21T08:15:00', '2024-07-21');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (71, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-15T06:30:00',
+VALUES (71, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-15T06:30:00',
         '2024-08-15T07:00:00', '2024-08-15');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (72, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-16T07:00:00',
+VALUES (72, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-16T07:00:00',
         '2024-08-16T08:00:00', '2024-08-16');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (73, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-30T08:15:00',
+VALUES (73, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-30T08:15:00',
         '2024-07-30T08:15:00', '2024-07-30');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (74, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-17T06:30:00',
+VALUES (74, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-17T06:30:00',
         '2024-08-17T07:00:00', '2024-08-17');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (75, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-18T07:00:00',
+VALUES (75, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-18T07:00:00',
         '2024-08-18T08:00:00', '2024-08-18');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (76, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-28T08:15:00',
+VALUES (76, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-28T08:15:00',
         '2024-07-28T08:15:00', '2024-07-28');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (77, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-19T06:30:00',
+VALUES (77, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-19T06:30:00',
         '2024-08-19T07:00:00', '2024-08-19');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (78, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-20T07:00:00',
+VALUES (78, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-20T07:00:00',
         '2024-08-20T08:00:00', '2024-08-20');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (79, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-22T08:15:00',
+VALUES (79, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-22T08:15:00',
         '2024-07-22T08:15:00', '2024-07-22');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (80, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-21T06:30:00',
+VALUES (80, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-21T06:30:00',
         '2024-08-21T07:00:00', '2024-08-21');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (81, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-22T07:00:00',
+VALUES (81, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-22T07:00:00',
         '2024-08-22T08:00:00', '2024-08-22');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (82, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-17T08:15:00',
+VALUES (82, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-17T08:15:00',
         '2024-07-17T08:15:00', '2024-07-17');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (83, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-23T06:30:00',
+VALUES (83, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-23T06:30:00',
         '2024-08-23T07:00:00', '2024-08-23');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (84, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-24T07:00:00',
+VALUES (84, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-24T07:00:00',
         '2024-08-24T08:00:00', '2024-08-24');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (85, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-16T08:15:00',
+VALUES (85, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-16T08:15:00',
         '2024-07-16T08:15:00', '2024-07-16');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (86, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-25T06:30:00',
+VALUES (86, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-25T06:30:00',
         '2024-08-25T07:00:00', '2024-08-25');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (87, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-26T07:00:00',
+VALUES (87, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-26T07:00:00',
         '2024-08-26T08:00:00', '2024-08-26');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (88, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-18T08:15:00',
+VALUES (88, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-18T08:15:00',
         '2024-07-18T08:15:00', '2024-07-18');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (89, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-27T06:30:00',
+VALUES (89, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-27T06:30:00',
         '2024-08-27T07:00:00', '2024-08-27');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (90, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-28T07:00:00',
+VALUES (90, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-28T07:00:00',
         '2024-08-28T08:00:00', '2024-08-28');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (91, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-24T08:15:00',
+VALUES (91, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-24T08:15:00',
         '2024-07-24T08:15:00', '2024-07-24');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (92, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-29T06:30:00',
+VALUES (92, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-29T06:30:00',
         '2024-08-29T07:00:00', '2024-08-29');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (93, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-08-30T07:00:00',
+VALUES (93, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-08-30T07:00:00',
         '2024-08-30T08:00:00', '2024-08-30');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (94, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-26T08:15:00',
+VALUES (94, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-26T08:15:00',
         '2024-07-26T08:15:00', '2024-07-26');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (95, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-08-31T06:30:00',
+VALUES (95, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-08-31T06:30:00',
         '2024-08-31T07:00:00', '2024-08-31');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (96, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-09-01T07:00:00',
+VALUES (96, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-09-01T07:00:00',
         '2024-09-01T08:00:00', '2024-09-01');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (97, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-20T08:15:00',
+VALUES (97, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-20T08:15:00',
         '2024-07-20T08:15:00', '2024-07-20');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (98, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', 0, '2024-09-02T06:30:00',
+VALUES (98, 2, 4, '조깅', 'COMPLETE', '06:30:00', '07:00:00', null, '2024-09-02T06:30:00',
         '2024-09-02T07:00:00', '2024-09-02');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (99, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', 0, '2024-09-03T07:00:00',
+VALUES (99, 2, 4, '헬스장 가기', 'COMPLETE', '07:00:00', '08:00:00', null, '2024-09-03T07:00:00',
         '2024-09-03T08:00:00', '2024-09-03');
-INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, is_postponed,
+INSERT INTO ddudus(id, user_id, goal_id, name, status, begin_at, end_at, postponed_at,
                    created_at, updated_at, scheduled_on)
-VALUES (100, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, 1, '2024-07-23T08:15:00',
+VALUES (100, 2, 4, '요가 클래스', 'UNCOMPLETED', null, null, '2024-07-23T08:15:00',
         '2024-07-23T08:15:00', '2024-07-23');
 
 

--- a/bootstrap/bootstrap-gateway/src/main/resources/db/migration/V16__change_ddudu_is_postponed_to_postponed_at.sql
+++ b/bootstrap/bootstrap-gateway/src/main/resources/db/migration/V16__change_ddudu_is_postponed_to_postponed_at.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ddudus
+    ADD COLUMN postponed_at TIMESTAMP NULL AFTER end_at;
+
+ALTER TABLE ddudus
+    DROP COLUMN is_postponed;

--- a/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/doc/DduduControllerDoc.java
+++ b/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/doc/DduduControllerDoc.java
@@ -528,6 +528,10 @@ public interface DduduControllerDoc {
                       @ExampleObject(
                           name = "2012",
                           value = DduduErrorExamples.DDUDU_SHOULD_POSTPONE_UNTIL_FUTURE
+                      ),
+                      @ExampleObject(
+                          name = "2022",
+                          value = DduduErrorExamples.DDUDU_UNABLE_TO_POSTPONE_COMPLETED_DDUDU
                       )
                   }
               )

--- a/common/src/main/java/com/ddudu/common/exception/DduduErrorCode.java
+++ b/common/src/main/java/com/ddudu/common/exception/DduduErrorCode.java
@@ -27,7 +27,8 @@ public enum DduduErrorCode implements ErrorCode {
   REMINDER_NOT_AFTER_NOW(2018, "미리알림 시간은 현재 시간보다 이후여야 합니다."),
   ZERO_REMINDER(2019, "미리알림 입력값이 없습니다."),
   NEGATIVE_REMINDER_INPUT_EXISTS(2020, "미리알림을 입력값 중 음수가 포함되어 있습니다."),
-  UNABLE_TO_GET_REMINDER(2021, "미리알림 시간을 알 수 없는 상태입니다.");
+  UNABLE_TO_GET_REMINDER(2021, "미리알림 시간을 알 수 없는 상태입니다."),
+  UNABLE_TO_POSTPONE_COMPLETED_DDUDU(2022, "완료된 뚜두는 미루기 처리할 수 없습니다.");
 
   private final int code;
   private final String message;

--- a/domain/planning-domain/src/main/java/com/ddudu/domain/planning/ddudu/aggregate/Ddudu.java
+++ b/domain/planning-domain/src/main/java/com/ddudu/domain/planning/ddudu/aggregate/Ddudu.java
@@ -30,7 +30,7 @@ public class Ddudu {
   private final Long repeatDduduId;
   private final String name;
   private final DduduStatus status;
-  private final boolean isPostponed;
+  private final LocalDateTime postponedAt;
   private final LocalDate scheduledOn;
   private final LocalTime beginAt;
   private final LocalTime endAt;
@@ -44,6 +44,7 @@ public class Ddudu {
       Long repeatDduduId,
       String name,
       Boolean isPostponed,
+      LocalDateTime postponedAt,
       DduduStatus status,
       String statusValue,
       LocalDate scheduledOn,
@@ -62,7 +63,7 @@ public class Ddudu {
     this.repeatDduduId = repeatDduduId;
     this.name = name;
     this.status = Objects.requireNonNullElse(status, DduduStatus.from(statusValue));
-    this.isPostponed = Objects.requireNonNullElse(isPostponed, false);
+    this.postponedAt = resolvePostponedAt(postponedAt, isPostponed);
     this.scheduledOn = Objects.requireNonNullElse(scheduledOn, LocalDate.now());
     this.beginAt = beginAt;
     this.endAt = endAt;
@@ -82,18 +83,24 @@ public class Ddudu {
   }
 
   public Ddudu moveDate(LocalDate newDate) {
+    return moveDate(newDate, true);
+  }
+
+  public Ddudu moveDate(LocalDate newDate, boolean postpone) {
     checkArgument(Objects.nonNull(newDate), DduduErrorCode.NULL_DATE_TO_MOVE.getCodeName());
 
     DduduBuilder builder = getFullBuilder()
         .scheduledOn(newDate);
 
-    // 완료한 뚜두이거나 과거로 날짜를 변경하는 경우, 기존 미루기 상태가 적용된다.
-    if (this.status.isCompleted() || newDate.isBefore(scheduledOn)) {
+    if (!postpone) {
       return builder.build();
     }
 
+    checkArgument(!this.status.isCompleted(),
+        DduduErrorCode.UNABLE_TO_POSTPONE_COMPLETED_DDUDU.getCodeName());
+
     return builder
-        .isPostponed(true)
+        .postponedAt(LocalDateTime.now())
         .build();
   }
 
@@ -105,7 +112,7 @@ public class Ddudu {
 
     return getFullBuilder()
         .id(null)
-        .isPostponed(false)
+        .postponedAt(null)
         .status(DduduStatus.UNCOMPLETED)
         .scheduledOn(scheduledOn)
         .build();
@@ -169,6 +176,10 @@ public class Ddudu {
     return nonNull(remindAt);
   }
 
+  public boolean isPostponed() {
+    return nonNull(postponedAt);
+  }
+
   public Ddudu setReminder(int days, int hours, int minutes) {
     LocalDateTime reminder = validateReminder(days, hours, minutes);
 
@@ -208,10 +219,22 @@ public class Ddudu {
         .name(this.name)
         .status(this.status)
         .scheduledOn(this.scheduledOn)
-        .isPostponed(this.isPostponed)
+        .postponedAt(this.postponedAt)
         .beginAt(this.beginAt)
         .endAt(this.endAt)
         .remindAt(this.remindAt);
+  }
+
+  private LocalDateTime resolvePostponedAt(LocalDateTime postponedAt, Boolean isPostponed) {
+    if (nonNull(postponedAt)) {
+      return postponedAt;
+    }
+
+    if (Boolean.TRUE.equals(isPostponed)) {
+      return LocalDateTime.now();
+    }
+
+    return null;
   }
 
   private void validate(Long goalId, Long userId, String name, LocalTime beginAt, LocalTime endAt) {

--- a/domain/planning-domain/src/test/java/com/ddudu/domain/planning/ddudu/aggregate/DduduTest.java
+++ b/domain/planning-domain/src/test/java/com/ddudu/domain/planning/ddudu/aggregate/DduduTest.java
@@ -395,7 +395,7 @@ class DduduTest {
             .hasFieldOrPropertyWithValue("id", ddudu.getId())
             .hasFieldOrPropertyWithValue("userId", ddudu.getUserId())
             .hasFieldOrPropertyWithValue("name", ddudu.getName())
-            .hasFieldOrPropertyWithValue("isPostponed", ddudu.isPostponed())
+            .hasFieldOrPropertyWithValue("postponedAt", ddudu.getPostponedAt())
             .hasFieldOrPropertyWithValue("status", ddudu.getStatus())
             .hasFieldOrPropertyWithValue("goalId", ddudu.getGoalId())
             .hasFieldOrPropertyWithValue("beginAt", now)
@@ -436,7 +436,7 @@ class DduduTest {
     class 날짜_변경_테스트 {
 
       @Test
-      void 이미_완료한_뚜두면_날짜_변경_시_상태가_변하지_않는다() {
+      void 이미_완료한_뚜두에_미루기_요청하면_실패한다() {
         // given
         LocalDate newDate = LocalDate.now()
             .plusDays(1);
@@ -445,11 +445,12 @@ class DduduTest {
         assertThat(ddudu.getStatus()).isEqualTo(DduduStatus.COMPLETE);
 
         // when
-        Ddudu actual = ddudu.moveDate(newDate);
+        ThrowingCallable moveDate = () -> ddudu.moveDate(newDate, true);
 
         // then
-        assertThat(actual.getScheduledOn()).isEqualTo(newDate);
-        assertThat(actual.isPostponed()).isFalse();
+        Assertions.assertThatIllegalArgumentException()
+            .isThrownBy(moveDate)
+            .withMessage(DduduErrorCode.UNABLE_TO_POSTPONE_COMPLETED_DDUDU.getCodeName());
       }
 
       @Test
@@ -459,7 +460,7 @@ class DduduTest {
             .plusDays(1);
 
         // when
-        Ddudu actual = ddudu.moveDate(newDate);
+        Ddudu actual = ddudu.moveDate(newDate, true);
 
         // then
         assertThat(actual.getScheduledOn()).isEqualTo(newDate);
@@ -467,13 +468,12 @@ class DduduTest {
       }
 
       @Test
-      void 완료_하지_않은_뚜두의_날짜를_기존_날짜_이전으로_변경하면_상태가_변하지_않는다() {
+      void 미루기_요청이_false면_날짜만_변경된다() {
         // given
-        LocalDate newDate = LocalDate.now()
-            .minusDays(1);
+        LocalDate newDate = LocalDate.now().plusDays(1);
 
         // when
-        Ddudu actual = ddudu.moveDate(newDate);
+        Ddudu actual = ddudu.moveDate(newDate, false);
 
         // then
         assertThat(actual.getScheduledOn()).isEqualTo(newDate);
@@ -494,19 +494,25 @@ class DduduTest {
       }
 
       @Test
-      void 변경할_날짜가_예정_날짜보다_이전이어도_이미_미루기한_뚜두면_미루기_상태가_유지된다() {
+      void postponedAt이_존재하면_isPostponed는_true를_반환한다() {
         // given
         Ddudu postponedDdudu = DduduFixture.createRandomDduduWithReference(
             goalId, userId, true, null);
-        LocalDate newDate = LocalDate.now()
-            .minusDays(1);
-
-        // when
-        Ddudu actual = postponedDdudu.moveDate(newDate);
+        Ddudu actual = postponedDdudu;
 
         // then
-        assertThat(actual.getScheduledOn()).isEqualTo(newDate);
         assertThat(actual.isPostponed()).isTrue();
+      }
+
+      @Test
+      void postponedAt이_없으면_isPostponed는_false를_반환한다() {
+        // given
+
+        // when
+        Ddudu actual = ddudu;
+
+        // then
+        assertThat(actual.isPostponed()).isFalse();
       }
 
     }
@@ -770,7 +776,7 @@ class DduduTest {
           .hasFieldOrPropertyWithValue("userId", ddudu.getUserId())
           .hasFieldOrPropertyWithValue("name", ddudu.getName())
           .hasFieldOrPropertyWithValue("status", DduduStatus.UNCOMPLETED)
-          .hasFieldOrPropertyWithValue("isPostponed", false)
+          .hasFieldOrPropertyWithValue("postponedAt", null)
           .hasFieldOrPropertyWithValue("scheduledOn", tomorrow)
           .hasFieldOrPropertyWithValue("beginAt", ddudu.getBeginAt())
           .hasFieldOrPropertyWithValue("endAt", ddudu.getEndAt());

--- a/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/entity/DduduEntity.java
+++ b/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/entity/DduduEntity.java
@@ -81,10 +81,10 @@ public class DduduEntity extends BaseEntity {
   private LocalTime endAt;
 
   @Column(
-      name = "is_postponed",
-      nullable = false
+      name = "postponed_at",
+      columnDefinition = "TIMESTAMP"
   )
-  private boolean isPostponed;
+  private LocalDateTime postponedAt;
 
   @Column(
       name = "remind_at",
@@ -100,7 +100,7 @@ public class DduduEntity extends BaseEntity {
         .repeatDduduId(ddudu.getRepeatDduduId())
         .name(ddudu.getName())
         .status(ddudu.getStatus())
-        .isPostponed(ddudu.isPostponed())
+        .postponedAt(ddudu.getPostponedAt())
         .scheduledOn(ddudu.getScheduledOn())
         .beginAt(ddudu.getBeginAt())
         .endAt(ddudu.getEndAt())
@@ -116,7 +116,7 @@ public class DduduEntity extends BaseEntity {
         .repeatDduduId(repeatDduduId)
         .name(name)
         .status(status)
-        .isPostponed(isPostponed)
+        .postponedAt(postponedAt)
         .scheduledOn(scheduledOn)
         .beginAt(beginAt)
         .endAt(endAt)
@@ -127,7 +127,7 @@ public class DduduEntity extends BaseEntity {
   public void update(Ddudu ddudu) {
     this.name = ddudu.getName();
     this.status = ddudu.getStatus();
-    this.isPostponed = ddudu.isPostponed();
+    this.postponedAt = ddudu.getPostponedAt();
     this.scheduledOn = ddudu.getScheduledOn();
     this.beginAt = ddudu.getBeginAt();
     this.endAt = ddudu.getEndAt();

--- a/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/repository/DduduQueryRepositoryImpl.java
+++ b/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/repository/DduduQueryRepositoryImpl.java
@@ -82,7 +82,7 @@ public class DduduQueryRepositoryImpl implements DduduQueryRepository {
     }
 
     if (!isAchieved) {
-      condition.and(dduduEntity.isPostponed.isTrue());
+      condition.and(dduduEntity.postponedAt.isNotNull());
     }
 
     condition.and(privacyTypesIn(privacyTypes))
@@ -337,7 +337,7 @@ public class DduduQueryRepositoryImpl implements DduduQueryRepository {
         goalEntity.id,
         goalEntity.name,
         status,
-        dduduEntity.isPostponed,
+        dduduEntity.postponedAt.isNotNull(),
         dduduEntity.scheduledOn,
         dduduEntity.beginAt,
         dduduEntity.endAt

--- a/plans/뚜두-미루기-유형-변경-구현-플랜.md
+++ b/plans/뚜두-미루기-유형-변경-구현-플랜.md
@@ -1,0 +1,145 @@
+# 뚜두 미루기 유형 변경 구현 플랜
+
+## 1) 목표
+
+- `Ddudu`의 미루기 상태를 `isPostponed(Boolean)`에서 `postponedAt(LocalDateTime, nullable)`로 전환한다.
+- 날짜 변경 API(`PUT /api/ddudus/{id}/date`) 요청에 `postpone: boolean`을 추가하고, `true`일 때 현재 시각을 `postponedAt`으로 저장한다.
+- 완료된 뚜두에 대해 `postpone=true` 요청이 들어오면 400 에러를 반환한다.
+- 기존 `isPostponed` 기반 응답/조회/통계 로직을 `postponedAt` 기준으로 치환한다.
+
+## 2) 신규/변경 파일 및 패키지 경로
+
+> 아래 목록은 구현 시점에 반드시 검토가 필요한 후보 파일들이다. 실제 클래스명/위치는 코드베이스 현재 구조를 기준으로 확정한다.
+
+### 2.1 Domain (`domain/planning-domain`)
+
+- 변경: `domain/planning-domain/src/main/java/com/ddudu/domain/planning/ddudu/aggregate/Ddudu.java`
+  - 패키지: `com.ddudu.domain.planning.ddudu.aggregate`
+  - `postponedAt` 필드 반영 및 `postponedAt != null` 기반 `isPostponed()` 도메인 로직 정리
+- 변경: `domain/planning-domain/src/main/java/com/ddudu/domain/planning/ddudu/dto/ChangeDduduDateCommand.java`
+  - 패키지: `com.ddudu.domain.planning.ddudu.dto`
+  - `postpone` 입력 추가
+- 변경(있다면): `domain/planning-domain/src/main/java/com/ddudu/domain/planning/ddudu/service/DduduDomainService.java`
+  - 패키지: `com.ddudu.domain.planning.ddudu.service`
+  - 날짜 변경 시 미루기 상태 반영 오케스트레이션
+
+### 2.2 Application Common (`application/application-common`)
+
+- 변경: `application/application-common/src/main/java/com/ddudu/application/common/dto/ddudu/request/ChangeDduduDateRequest.java`
+  - 패키지: `com.ddudu.application.common.dto.ddudu.request`
+  - `postpone: boolean` 필드 추가 및 command 변환 반영
+- 변경: `application/application-common/src/main/java/com/ddudu/application/common/dto/ddudu/response/*Ddudu*Response*.java`
+  - 패키지: `com.ddudu.application.common.dto.ddudu.response`
+  - `isPostponed` 응답 필드를 `postponedAt`으로 전환
+
+### 2.3 Application Service (`application/planning-application`)
+
+- 변경: `application/planning-application/src/main/java/com/ddudu/application/planning/ddudu/service/ChangeDduduDateService.java`
+  - 패키지: `com.ddudu.application.planning.ddudu.service`
+  - `postpone=true` 처리(현재 시각 저장), 완료된 뚜두 예외 처리(400 매핑 대상)
+- 변경(쿼리 조건 사용처): `application/planning-application/src/main/java/com/ddudu/application/planning/**/service/*Service.java`
+  - 패키지: `com.ddudu.application.planning...`
+  - 기존 `isPostponed` 조건을 `postponedAt != null`로 전환
+
+### 2.4 Infra (`infra/planning-infra`)
+
+- 변경: `infra/planning-infra/src/main/java/com/ddudu/infra/planning/ddudu/persistence/entity/DduduEntity.java`
+  - 패키지: `com.ddudu.infra.planning.ddudu.persistence.entity`
+  - `isPostponed` 컬럼 → `postponedAt TIMESTAMP NULL`
+- 변경: `infra/planning-infra/src/main/java/com/ddudu/infra/planning/ddudu/persistence/repository/*Ddudu*Repository*.java`
+  - 패키지: `com.ddudu.infra.planning.ddudu.persistence.repository`
+  - where 절의 미루기 조건을 nullable timestamp 기준으로 변경
+- 신규: `infra/planning-infra/src/main/resources/db/migration/V*_change_ddudu_is_postponed_to_postponed_at.sql`
+  - Flyway DDL/데이터 이관 스크립트
+
+### 2.5 Bootstrap Gateway Data (`bootstrap/bootstrap-gateway`)
+
+- 변경: `bootstrap/bootstrap-gateway/src/main/resources/db/data/afterMigrate.sql`
+  - `ddudus` 더미데이터 DML의 `is_postponed` 컬럼 사용 구문을 `postponed_at` 기준으로 전환
+  - 기존 `is_postponed = true` 더미 케이스는 `postponed_at`에 timestamp 값이 들어가도록 수정
+  - 기존 `is_postponed = false` 더미 케이스는 `postponed_at = NULL`로 명시
+
+### 2.6 Bootstrap (`bootstrap/planning-api`)
+
+- 변경: `bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/controller/DduduController.java`
+  - 패키지: `com.ddudu.api.planning.ddudu.controller`
+  - 날짜 변경 요청 DTO의 `postpone` 수용
+- 변경: `bootstrap/planning-api/src/main/java/com/ddudu/api/planning/ddudu/doc/DduduControllerDoc.java`
+  - 패키지: `com.ddudu.api.planning.ddudu.doc`
+  - 요청/응답 스키마(`postponedAt`) 및 400 에러 예시 문서화
+- 변경(예외 코드 맵핑): `bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/**/Exception*.java`
+  - 패키지: `com.ddudu.bootstrap.common...`
+  - 완료된 뚜두 미루기 요청 예외의 HTTP 400 매핑 확인
+
+### 2.7 Test Fixture / Test
+
+- 변경: `domain/planning-domain/src/testFixtures/java/com/ddudu/fixture/DduduFixture.java`
+  - 패키지: `com.ddudu.fixture`
+  - `isPostponed` 관련 fixture 메서드를 `postponedAt` 기반 메서드로 교체
+- 변경: `domain/planning-domain/src/test/java/com/ddudu/domain/planning/ddudu/**/*Test.java`
+  - 패키지: `com.ddudu.domain.planning.ddudu...`
+  - 도메인 테스트 전환 (`isPostponed()`가 `postponedAt` null 여부를 정확히 반환하는지 검증)
+- 변경: `application/planning-application/src/test/java/com/ddudu/application/planning/ddudu/service/*Test.java`
+  - 패키지: `com.ddudu.application.planning.ddudu.service`
+  - 날짜 변경 usecase의 postpone 성공/실패(완료 뚜두 400) 테스트 추가
+
+## 3) 구현 단계
+
+1. **스키마 변경 및 엔티티 반영**
+   - Flyway로 `postponed_at TIMESTAMP NULL` 컬럼 추가/이관/구컬럼 제거 전략 수립
+   - `DduduEntity` 매핑 및 mapper 변환 코드 반영
+   - `afterMigrate.sql`의 `ddudus` 더미데이터 DML을 `postponed_at` 기준으로 함께 정합화
+
+2. **도메인 모델 전환**
+   - `Ddudu`에 `isPostponed()` 도메인 로직을 두고, 내부 구현은 `postponedAt != null`로 통일
+   - 날짜 변경 시 `postpone=true`일 때 `postponedAt=now` 처리
+   - 완료 상태에서 postpone 시 도메인 예외 발생
+
+3. **유스케이스/DTO/API 반영**
+   - `ChangeDduduDateRequest`에 `postpone` 추가
+   - Service에서 postpone 값에 따라 도메인 호출
+   - API 응답 DTO 전반의 `isPostponed` -> `postponedAt` 치환
+
+4. **조회/통계 로직 치환**
+   - `isPostponed` 사용 쿼리/조건을 전수 조사하여 목록화
+   - 조건식 치환: `isPostponed = true` → `postponedAt IS NOT NULL`
+   - 통계 조건 업데이트
+     - 미루기 통계: 기간 내 `postponedAt` 존재
+     - 재달성 통계: 기간 내 `postponedAt` 존재 + 완료
+
+5. **문서/예외 코드 정합성 점검**
+   - OpenAPI 스키마/예시 갱신
+   - 완료된 뚜두 postpone 요청의 400 응답 예시 추가
+
+## 4) 테스트 계획
+
+### 4.1 Domain 테스트
+
+- `postponedAt` 필드 전환 후 생성/수정/상태판단 테스트 정비
+- `Ddudu.isPostponed()` 도메인 로직 검증 테스트 추가
+  - `postponedAt`이 `null`이면 `false` 반환
+  - `postponedAt`이 존재하면 `true` 반환
+- 완료된 뚜두 postpone 시 예외 검증
+
+### 4.2 Application 테스트
+
+- 날짜 변경 usecase
+  - 성공: `postpone=false`면 미루기 미반영, `postpone=true`면 현재 시각 반영
+  - 실패: 완료된 뚜두에 `postpone=true` 요청 시 400 에러 매핑 예외
+
+### 4.3 Fixture/규칙 준수
+
+- Fixture는 `BaseFixtures` 상속 + Faker 랜덤 입력 사용
+- 테스트 메서드명 한국어
+- 실패 케이스는 `ThrowingCallable` + `//given //when //then` 명시
+
+### 4.4 실행 순서
+
+1. `./gradlew :bootstrap:bootstrap-gateway:flywayMigrate`
+2. 변경된 domain/application 모듈 테스트 실행
+
+## 5) 영향도 및 리스크
+
+- `isPostponed`를 사용하는 API 소비자와의 스키마 호환성 이슈(필드명/타입 변경)
+- 통계 쿼리 치환 시 인덱스/성능 영향 점검 필요(`postponed_at` 인덱싱 고려)
+- 데이터 마이그레이션 시 기존 `true/false` 값을 `timestamp/null`로 변환하는 규칙 명확화 필요


### PR DESCRIPTION
### Motivation

- Replace the coarse boolean `isPostponed` with a nullable timestamp `postponedAt` to record when a ddudu was postponed and allow more precise logic.
- Add an explicit `postpone: boolean` flag to the date-change API so callers can choose whether changing the date should set the postpone timestamp.
- Prevent postponing a completed ddudu and surface a new error code for that case.

### Description

- Added `postpone` boolean to the request DTO `MoveDateRequest` and propagated it through `MoveDateService` to the domain call `moveDate(newDate, postpone)`.
- Replaced domain field `isPostponed` with `postponedAt` (`LocalDateTime`) in `Ddudu`, added `isPostponed()` derived from `postponedAt`, overloaded `moveDate` to accept `postpone`, and added validation to forbid `postpone=true` for completed ddudus (new error `UNABLE_TO_POSTPONE_COMPLETED_DDUDU`).
- Updated persistence mapping to store `postponed_at TIMESTAMP NULL` in `DduduEntity`, updated repository query conditions to use `postponedAt IS NOT NULL`, and added a Flyway migration `V16__change_ddudu_is_postponed_to_postponed_at.sql`.
- Updated seed SQL `afterMigrate.sql`, API docs in `DduduControllerDoc`, error examples, and added the new error code in `DduduErrorCode`; also added implementation plan document and adjusted multiple tests/fixtures to the new representation.

### Testing

- Ran domain unit tests including `DduduTest`, and application service tests including `MoveDateServiceTest` and `CreateDduduServiceTest`; all updated tests passed.
- Executed module test suite via `./gradlew test` for the changed modules (domain, application, infra); tests completed successfully.
- Verified Spring-based integration tests that exercise `MoveDateService` (annotated `@SpringBootTest`) passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7602cb33c832d94020ac98dd544fb)