### PR TITLE
Use goal-centric monthly summary DTO and add optional `userId` query param

### DIFF
--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/stats/GoalMonthlyStatsSummary.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/stats/GoalMonthlyStatsSummary.java
@@ -1,0 +1,17 @@
+package com.ddudu.application.common.dto.stats;
+
+import lombok.Builder;
+
+@Builder
+public record GoalMonthlyStatsSummary(
+    Long goalId,
+    String goalName,
+    String goalColor,
+    int creationCount,
+    int achievementCount,
+    int postponedCount,
+    int sustainedCount,
+    int reattainedCount
+) {
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/stats/response/MonthlyStatsSummaryResponse.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/stats/response/MonthlyStatsSummaryResponse.java
@@ -1,20 +1,12 @@
 package com.ddudu.application.common.dto.stats.response;
 
-import com.ddudu.application.common.dto.stats.AchievementPerGoal;
-import com.ddudu.application.common.dto.stats.CreationCountPerGoal;
-import com.ddudu.application.common.dto.stats.PostponedPerGoal;
-import com.ddudu.application.common.dto.stats.ReattainmentPerGoal;
-import com.ddudu.application.common.dto.stats.SustenancePerGoal;
+import com.ddudu.application.common.dto.stats.GoalMonthlyStatsSummary;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record MonthlyStatsSummaryResponse(
-    List<CreationCountPerGoal> creationCounts,
-    List<AchievementPerGoal> achievements,
-    List<PostponedPerGoal> postponements,
-    List<SustenancePerGoal> sustenances,
-    List<ReattainmentPerGoal> reattainments
+    List<GoalMonthlyStatsSummary> summaries
 ) {
 
 }

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/stats/in/CollectMonthlyStatsSummaryUseCase.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/stats/in/CollectMonthlyStatsSummaryUseCase.java
@@ -5,6 +5,6 @@ import java.time.YearMonth;
 
 public interface CollectMonthlyStatsSummaryUseCase {
 
-  MonthlyStatsSummaryResponse collectSummary(Long loginId, YearMonth yearMonth);
+  MonthlyStatsSummaryResponse collectSummary(Long loginId, Long userId, YearMonth yearMonth);
 
 }

--- a/application/stats-application/src/main/java/com/ddudu/application/stats/service/CollectMonthlyStatsSummaryService.java
+++ b/application/stats-application/src/main/java/com/ddudu/application/stats/service/CollectMonthlyStatsSummaryService.java
@@ -1,11 +1,7 @@
 package com.ddudu.application.stats.service;
 
 import com.ddudu.aggregate.MonthlyStats;
-import com.ddudu.application.common.dto.stats.AchievementPerGoal;
-import com.ddudu.application.common.dto.stats.CreationCountPerGoal;
-import com.ddudu.application.common.dto.stats.PostponedPerGoal;
-import com.ddudu.application.common.dto.stats.ReattainmentPerGoal;
-import com.ddudu.application.common.dto.stats.SustenancePerGoal;
+import com.ddudu.application.common.dto.stats.GoalMonthlyStatsSummary;
 import com.ddudu.application.common.dto.stats.response.MonthlyStatsSummaryResponse;
 import com.ddudu.application.common.port.stats.in.CollectMonthlyStatsSummaryUseCase;
 import com.ddudu.application.common.port.stats.out.MonthlyStatsPort;
@@ -15,7 +11,6 @@ import com.ddudu.common.exception.StatsErrorCode;
 import com.ddudu.domain.user.user.aggregate.User;
 import java.time.LocalDate;
 import java.time.YearMonth;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,10 +30,13 @@ public class CollectMonthlyStatsSummaryService implements CollectMonthlyStatsSum
   @Override
   public MonthlyStatsSummaryResponse collectSummary(
       Long loginId,
+      Long userId,
       YearMonth yearMonth
   ) {
+    Long targetUserId = Objects.nonNull(userId) ? userId : loginId;
+
     User user = userLoaderPort.getUserOrElseThrow(
-        loginId,
+        targetUserId,
         StatsErrorCode.USER_NOT_EXISTING.getCodeName()
     );
 
@@ -61,64 +59,42 @@ public class CollectMonthlyStatsSummaryService implements CollectMonthlyStatsSum
     return collectSummaryByGoal(monthlyStatsByGoal);
   }
 
-  private MonthlyStatsSummaryResponse collectSummaryByGoal(Map<Long, MonthlyStats> monthlyStats) {
-    List<CreationCountPerGoal> creationStats = collectCreation(monthlyStats);
-    List<AchievementPerGoal> achievementStats = collectAchievement(monthlyStats);
-    List<SustenancePerGoal> sustenanceStats = collectSustenance(monthlyStats);
-    List<PostponedPerGoal> postponementStats = collectPostponement(monthlyStats);
-    List<ReattainmentPerGoal> reattainmentStats = collectReattainment(monthlyStats);
+  private MonthlyStatsSummaryResponse collectSummaryByGoal(Map<Long, MonthlyStats> monthlyStatsByGoal) {
+    List<GoalMonthlyStatsSummary> summaries = monthlyStatsByGoal.values()
+        .stream()
+        .map(this::toSummary)
+        .sorted(this::compareByCreationCountDescThenGoalIdAsc)
+        .toList();
 
     return MonthlyStatsSummaryResponse.builder()
-        .creationCounts(creationStats)
-        .achievements(achievementStats)
-        .sustenances(sustenanceStats)
-        .postponements(postponementStats)
-        .reattainments(reattainmentStats)
+        .summaries(summaries)
         .build();
   }
 
-  private List<CreationCountPerGoal> collectCreation(Map<Long, MonthlyStats> monthlyStats) {
-    return monthlyStats.values()
-        .stream()
-        .map(CreationCountPerGoal::from)
-        .sorted((first, second) -> second.count() - first.count())
-        .toList();
+  private int compareByCreationCountDescThenGoalIdAsc(
+      GoalMonthlyStatsSummary first,
+      GoalMonthlyStatsSummary second
+  ) {
+    int compare = Integer.compare(second.creationCount(), first.creationCount());
+
+    if (compare != 0) {
+      return compare;
+    }
+
+    return Long.compare(first.goalId(), second.goalId());
   }
 
-  private List<AchievementPerGoal> collectAchievement(Map<Long, MonthlyStats> monthlyStats) {
-    return monthlyStats.values()
-        .stream()
-        .map(AchievementPerGoal::from)
-        .sorted(Comparator.comparingInt(AchievementPerGoal::achievementRate)
-            .reversed())
-        .toList();
-  }
-
-  private List<SustenancePerGoal> collectSustenance(Map<Long, MonthlyStats> monthlyStats) {
-    return monthlyStats.values()
-        .stream()
-        .map(SustenancePerGoal::from)
-        .sorted(Comparator.comparingInt(SustenancePerGoal::sustenanceCount)
-            .reversed())
-        .toList();
-  }
-
-  private List<PostponedPerGoal> collectPostponement(Map<Long, MonthlyStats> monthlyStats) {
-    return monthlyStats.values()
-        .stream()
-        .map(PostponedPerGoal::from)
-        .sorted(Comparator.comparingInt(PostponedPerGoal::postponementCount)
-            .reversed())
-        .toList();
-  }
-
-  private List<ReattainmentPerGoal> collectReattainment(Map<Long, MonthlyStats> monthlyStats) {
-    return monthlyStats.values()
-        .stream()
-        .map(ReattainmentPerGoal::from)
-        .sorted(Comparator.comparingInt(ReattainmentPerGoal::reattainmentRate)
-            .reversed())
-        .toList();
+  private GoalMonthlyStatsSummary toSummary(MonthlyStats monthlyStats) {
+    return GoalMonthlyStatsSummary.builder()
+        .goalId(monthlyStats.getGoalId())
+        .goalName(monthlyStats.getGoalName())
+        .goalColor(monthlyStats.getGoalColor())
+        .creationCount(monthlyStats.size())
+        .achievementCount(monthlyStats.countAchievements())
+        .postponedCount(monthlyStats.calculatePostponementCount())
+        .sustainedCount(monthlyStats.calculateSustenanceCount())
+        .reattainedCount(monthlyStats.calculateReattainmentCount())
+        .build();
   }
 
 }

--- a/application/stats-application/src/test/java/com/ddudu/application/stats/service/CollectMonthlyStatsSummaryServiceTest.java
+++ b/application/stats-application/src/test/java/com/ddudu/application/stats/service/CollectMonthlyStatsSummaryServiceTest.java
@@ -2,16 +2,13 @@ package com.ddudu.application.stats.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.ddudu.application.common.dto.stats.CreationCountPerGoal;
-import com.ddudu.application.common.dto.stats.PostponedPerGoal;
-import com.ddudu.application.common.dto.stats.ReattainmentPerGoal;
-import com.ddudu.application.common.dto.stats.SustenancePerGoal;
+import com.ddudu.application.common.dto.stats.GoalMonthlyStatsSummary;
 import com.ddudu.application.common.dto.stats.response.MonthlyStatsSummaryResponse;
 import com.ddudu.application.common.port.auth.out.SignUpPort;
-import com.ddudu.application.common.port.ddudu.out.DduduLoaderPort;
 import com.ddudu.application.common.port.ddudu.out.SaveDduduPort;
 import com.ddudu.application.common.port.goal.out.SaveGoalPort;
 import com.ddudu.common.exception.StatsErrorCode;
+import com.ddudu.domain.planning.ddudu.aggregate.enums.DduduStatus;
 import com.ddudu.domain.planning.goal.aggregate.Goal;
 import com.ddudu.domain.user.user.aggregate.User;
 import com.ddudu.fixture.DduduFixture;
@@ -43,45 +40,42 @@ import org.springframework.transaction.annotation.Transactional;
 class CollectMonthlyStatsSummaryServiceTest {
 
   @Autowired
-  CollectMonthlyStatsSummaryService collectMonthlyStatsSummaryService;
+  private CollectMonthlyStatsSummaryService collectMonthlyStatsSummaryService;
 
   @Autowired
-  SignUpPort signUpPort;
+  private SignUpPort signUpPort;
 
   @Autowired
-  SaveGoalPort saveGoalPort;
+  private SaveGoalPort saveGoalPort;
 
   @Autowired
-  SaveDduduPort saveDduduPort;
+  private SaveDduduPort saveDduduPort;
 
-  User user;
-  List<Goal> goals;
-  @Autowired
-  private DduduLoaderPort dduduLoaderPort;
+  private User user;
+  private List<Goal> goals;
 
   @Nested
   class 만든_수_통계_테스트 {
 
-    List<Integer> sizes;
+    private List<Integer> creationCounts;
 
     @BeforeEach
     void setUp() {
       user = signUpPort.save(UserFixture.createRandomUserWithId());
       goals = saveGoalPort.saveAll(GoalFixture.createRandomGoalsWithUser(user.getId(), 5));
-      sizes = new ArrayList<>();
+      creationCounts = new ArrayList<>();
 
-      for (int i = 0; i < 5; i++) {
-        sizes.add(DduduFixture.getRandomInt(1, 100));
+      for (int i = 0; i < goals.size(); i++) {
+        creationCounts.add(DduduFixture.getRandomInt(1, 100));
       }
 
-      Iterator<Integer> sizeIterator = sizes.iterator();
-
+      Iterator<Integer> countIterator = creationCounts.iterator();
       goals.forEach(goal -> saveDduduPort.saveAll(DduduFixture.createMultipleDdudusWithGoal(
           goal,
-          sizeIterator.next()
+          countIterator.next()
       )));
 
-      sizes.sort(Comparator.reverseOrder());
+      creationCounts.sort(Comparator.reverseOrder());
     }
 
     @Test
@@ -92,33 +86,32 @@ class CollectMonthlyStatsSummaryServiceTest {
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           thisMonth
       );
 
       // then
-      List<CreationCountPerGoal> actual = response.creationCounts();
-      Iterator<Integer> sizeIterator = sizes.iterator();
+      List<Integer> actualCreationCounts = response.summaries().stream()
+          .map(GoalMonthlyStatsSummary::creationCount)
+          .toList();
 
-      Assertions.assertThat(actual.size())
-          .isEqualTo(goals.size());
-      Assertions.assertThat(actual)
-          .allMatch(goal -> goal.count() == sizeIterator.next());
+      assertThat(actualCreationCounts).isEqualTo(creationCounts);
     }
 
     @Test
     void 목표에_해당_달_생성_뚜두가_없으면_통계에서_제외한다() {
       // given
-      YearMonth lastMonth = YearMonth.now()
-          .minusMonths(1);
+      YearMonth lastMonth = YearMonth.now().minusMonths(1);
 
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           lastMonth
       );
 
       // then
-      assertThat(response.creationCounts()).isEmpty();
+      assertThat(response.summaries()).isEmpty();
     }
 
     @Test
@@ -128,17 +121,16 @@ class CollectMonthlyStatsSummaryServiceTest {
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           null
       );
 
       // then
-      List<CreationCountPerGoal> actual = response.creationCounts();
-      Iterator<Integer> sizeIterator = sizes.iterator();
+      List<Integer> actualCreationCounts = response.summaries().stream()
+          .map(GoalMonthlyStatsSummary::creationCount)
+          .toList();
 
-      Assertions.assertThat(actual.size())
-          .isEqualTo(goals.size());
-      Assertions.assertThat(actual)
-          .allMatch(goal -> goal.count() == sizeIterator.next());
+      assertThat(actualCreationCounts).isEqualTo(creationCounts);
     }
 
   }
@@ -146,57 +138,50 @@ class CollectMonthlyStatsSummaryServiceTest {
   @Nested
   class 달성도_통계_테스트 {
 
-    List<Integer> sizes;
-
     @BeforeEach
     void setUp() {
       user = signUpPort.save(UserFixture.createRandomUserWithId());
       goals = saveGoalPort.saveAll(GoalFixture.createRandomGoalsWithUser(user.getId(), 5));
-      sizes = new ArrayList<>();
 
-      for (int i = 0; i < 5; i++) {
-        sizes.add(DduduFixture.getRandomInt(1, 100));
-      }
-
-      Iterator<Integer> sizeIterator = sizes.iterator();
-
-      goals.forEach(goal -> saveDduduPort.saveAll(DduduFixture.createMultipleDdudusWithGoal(
+      goals.forEach(goal -> saveDduduPort.saveAll(DduduFixture.createDifferentDdudusWithGoal(
           goal,
-          sizeIterator.next()
+          DduduFixture.getRandomInt(1, 10),
+          DduduFixture.getRandomInt(1, 10)
       )));
-
-      sizes.sort(Comparator.reverseOrder());
     }
 
     @Test
-    void 이번_달_목표별_뚜두_달성률_통계를_내림차순으로_반환한다() {
+    void 이번_달_목표별_뚜두_달성_수_통계를_반환한다() {
       // given
       YearMonth thisMonth = YearMonth.now();
 
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           thisMonth
       );
 
       // then
-      assertThat(response.achievements()).hasSize(goals.size());
+      assertThat(response.summaries())
+          .hasSize(goals.size())
+          .allMatch(summary -> summary.achievementCount() >= 0);
     }
 
     @Test
     void 목표에_해당_달의_뚜두_데이터가_없으면_통계에_포함되지_않는다() {
       // given
-      YearMonth lastMonth = YearMonth.now()
-          .minusMonths(1);
+      YearMonth lastMonth = YearMonth.now().minusMonths(1);
 
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           lastMonth
       );
 
       // then
-      assertThat(response.achievements()).isEmpty();
+      assertThat(response.summaries()).isEmpty();
     }
 
     @ParameterizedTest
@@ -207,11 +192,12 @@ class CollectMonthlyStatsSummaryServiceTest {
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           yearMonth
       );
 
       // then
-      assertThat(response.achievements()).hasSize(goals.size());
+      assertThat(response.summaries()).hasSize(goals.size());
     }
 
   }
@@ -219,27 +205,25 @@ class CollectMonthlyStatsSummaryServiceTest {
   @Nested
   class 지속도_통계_테스트 {
 
-    List<Integer> expectedSustenanceCount;
+    private List<Integer> expectedSustenanceCounts;
 
     @BeforeEach
     void setUp() {
       user = signUpPort.save(UserFixture.createRandomUserWithId());
       goals = saveGoalPort.saveAll(GoalFixture.createRandomGoalsWithUser(user.getId(), 5));
-      expectedSustenanceCount = new ArrayList<>();
+      expectedSustenanceCounts = new ArrayList<>();
 
       for (int i = 0; i < goals.size(); i++) {
-        expectedSustenanceCount.add(MonthlyStatsFixture.getRandomInt(1, 10));
+        expectedSustenanceCounts.add(MonthlyStatsFixture.getRandomInt(1, 10));
       }
 
-      Iterator<Integer> iterator = expectedSustenanceCount.iterator();
-
+      Iterator<Integer> iterator = expectedSustenanceCounts.iterator();
       goals.forEach(goal -> saveDduduPort.saveAll(DduduFixture.createConsecutiveCompletedDdudus(
           goal,
           iterator.next()
       )));
 
-      expectedSustenanceCount.sort(Comparator.comparingInt(Integer::intValue)
-          .reversed());
+      expectedSustenanceCounts.sort(Comparator.reverseOrder());
     }
 
     @Test
@@ -250,44 +234,48 @@ class CollectMonthlyStatsSummaryServiceTest {
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           thisMonth
       );
 
       // then
-      List<SustenancePerGoal> actual = response.sustenances();
-      List<Integer> actualSustenanceCounts = actual.stream()
-          .map(SustenancePerGoal::sustenanceCount)
+      List<Integer> actualSustenanceCounts = response.summaries().stream()
+          .map(GoalMonthlyStatsSummary::sustainedCount)
+          .sorted(Comparator.reverseOrder())
           .toList();
 
-      assertThat(actualSustenanceCounts).isEqualTo(expectedSustenanceCount);
+      assertThat(actualSustenanceCounts).isEqualTo(expectedSustenanceCounts);
     }
 
     @Test
     void 목표에_해당_월_지속한_뚜두가_없으면_통계에서_제외한다() {
       // given
-      YearMonth lastMonth = YearMonth.now()
-          .minusMonths(1);
+      YearMonth lastMonth = YearMonth.now().minusMonths(1);
 
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           lastMonth
       );
 
       // then
-      assertThat(response.sustenances()).isEmpty();
+      assertThat(response.summaries()).isEmpty();
     }
 
     @Test
     void 날짜가_null이면_이번_달_통계를_반환한다() {
+      // given
+
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           null
       );
 
       // then
-      assertThat(response.sustenances()).hasSameSizeAs(goals);
+      assertThat(response.summaries()).hasSameSizeAs(goals);
     }
 
   }
@@ -295,27 +283,26 @@ class CollectMonthlyStatsSummaryServiceTest {
   @Nested
   class 미루기_통계_테스트 {
 
-    List<Integer> postponedCounts;
+    private List<Integer> expectedPostponedCounts;
 
     @BeforeEach
     void setUp() {
       user = signUpPort.save(UserFixture.createRandomUserWithId());
       goals = saveGoalPort.saveAll(GoalFixture.createRandomGoalsWithUser(user.getId(), 5));
-      postponedCounts = new ArrayList<>();
+      expectedPostponedCounts = new ArrayList<>();
 
       for (int i = 0; i < goals.size(); i++) {
-        postponedCounts.add(DduduFixture.getRandomInt(0, 100));
+        expectedPostponedCounts.add(DduduFixture.getRandomInt(0, 100));
       }
 
-      Iterator<Integer> iterator = postponedCounts.iterator();
-
+      Iterator<Integer> iterator = expectedPostponedCounts.iterator();
       goals.forEach(goal -> saveDduduPort.saveAll(DduduFixture.createDdudusWithPostponedFlag(
           goal,
           iterator.next(),
           DduduFixture.getRandomInt(1, 100)
       )));
 
-      postponedCounts.sort(Comparator.reverseOrder());
+      expectedPostponedCounts.sort(Comparator.reverseOrder());
     }
 
     @Test
@@ -326,143 +313,139 @@ class CollectMonthlyStatsSummaryServiceTest {
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           thisMonth
       );
 
       // then
-      List<Integer> actual = response.postponements()
-          .stream()
-          .map(PostponedPerGoal::postponementCount)
+      List<Integer> actualPostponedCounts = response.summaries().stream()
+          .map(GoalMonthlyStatsSummary::postponedCount)
+          .sorted(Comparator.reverseOrder())
           .toList();
 
-      assertThat(actual).isEqualTo(postponedCounts);
+      assertThat(actualPostponedCounts).isEqualTo(expectedPostponedCounts);
     }
 
     @Test
     void 미루기_뚜두가_없는_달이면_통계는_비어있다() {
       // given
-      YearMonth noDduduMonth = YearMonth.now()
-          .minusMonths(2);
+      YearMonth noDduduMonth = YearMonth.now().minusMonths(2);
 
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           noDduduMonth
       );
 
       // then
-      assertThat(response.postponements()).isEmpty();
-    }
-
-    @Test
-    void 날짜가_null이면_이번_달_통계를_반환한다() {
-      // given
-
-      // when
-      MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
-          user.getId(),
-          null
-      );
-
-      // then
-      assertThat(response.postponements()).isNotEmpty();
+      assertThat(response.summaries()).isEmpty();
     }
 
   }
 
   @Nested
-  class 재달성률_통계_테스트 {
+  class 재달성_통계_테스트 {
 
-    List<Integer> sizes;
+    private List<Integer> expectedReattainmentCounts;
 
     @BeforeEach
     void setUp() {
       user = signUpPort.save(UserFixture.createRandomUserWithId());
       goals = saveGoalPort.saveAll(GoalFixture.createRandomGoalsWithUser(user.getId(), 5));
-      sizes = new ArrayList<>();
-      List<Integer> reattainmentRates = new ArrayList<>();
+      expectedReattainmentCounts = new ArrayList<>();
 
       for (int i = 0; i < goals.size(); i++) {
-        sizes.add(DduduFixture.getRandomInt(1, 100));
-      }
-
-      for (int i = 0; i < goals.size(); i++) {
-        int totalPostponed = sizes.get(i);
-        int reattainment = MonthlyStatsFixture.getRandomInt(1, totalPostponed);
+        int totalPostponedCount = DduduFixture.getRandomInt(1, 100);
+        int reattainedCount = MonthlyStatsFixture.getRandomInt(1, totalPostponedCount);
 
         saveDduduPort.saveAll(DduduFixture.createReattainedDdudus(
             goals.get(i),
-            reattainment,
-            totalPostponed
+            reattainedCount,
+            totalPostponedCount
         ));
 
-        reattainmentRates.add(Math.round((float) reattainment / totalPostponed * 100));
+        expectedReattainmentCounts.add(reattainedCount);
       }
 
-      reattainmentRates.sort(Comparator.reverseOrder());
-
-      sizes = reattainmentRates;
+      expectedReattainmentCounts.sort(Comparator.reverseOrder());
     }
 
     @Test
-    void 월_목표_별_재달성률_통계를_반환한다() {
+    void 월_목표_별_재달성_수_통계를_반환한다() {
       // given
       YearMonth thisMonth = YearMonth.now();
 
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           thisMonth
       );
-      List<Integer> actual = response.reattainments()
-          .stream()
-          .map(ReattainmentPerGoal::reattainmentRate)
-          .toList();
 
       // then
-      assertThat(actual).isEqualTo(sizes);
+      List<Integer> actualReattainmentCounts = response.summaries().stream()
+          .map(GoalMonthlyStatsSummary::reattainedCount)
+          .sorted(Comparator.reverseOrder())
+          .toList();
+
+      assertThat(actualReattainmentCounts).isEqualTo(expectedReattainmentCounts);
     }
 
     @Test
-    void 목표에_해당_월_지속한_뚜두가_없으면_통계에서_제외한다() {
+    void 목표에_해당_월_뚜두가_없으면_통계에서_제외한다() {
       // given
-      YearMonth lastMonth = YearMonth.now()
-          .minusMonths(1);
+      YearMonth lastMonth = YearMonth.now().minusMonths(1);
 
       // when
       MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
           user.getId(),
+          null,
           lastMonth
       );
 
       // then
-      assertThat(response.reattainments()).isEmpty();
+      assertThat(response.summaries()).isEmpty();
     }
 
-    @Test
-    void 날짜가_null이면_이번_달_통계를_반환한다() {
-      // when
-      MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
-          user.getId(),
-          null
-      );
+  }
 
-      // then
-      assertThat(response.reattainments()).hasSameSizeAs(goals);
-    }
+  @Test
+  void 요청_사용자_아이디가_있으면_로그인_사용자_대신_해당_사용자_기준으로_월_요약을_조회한다() {
+    // given
+    User loginUser = signUpPort.save(UserFixture.createRandomUserWithId());
+    User targetUser = signUpPort.save(UserFixture.createRandomUserWithId());
+    Goal targetGoal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(targetUser.getId()));
 
+    saveDduduPort.saveAll(List.of(
+        DduduFixture.createRandomDduduWithReference(targetGoal.getId(), targetUser.getId(), true,
+            DduduStatus.COMPLETE),
+        DduduFixture.createRandomDduduWithReference(targetGoal.getId(), targetUser.getId(), false,
+            DduduStatus.UNCOMPLETED)
+    ));
+
+    // when
+    MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryService.collectSummary(
+        loginUser.getId(),
+        targetUser.getId(),
+        YearMonth.now()
+    );
+
+    // then
+    assertThat(response.summaries()).hasSize(1);
+    assertThat(response.summaries().get(0).goalColor()).isEqualTo(targetGoal.getColor());
   }
 
   @Test
   void 로그인_사용자가_없으면_월_통계_계산을_실패한다() {
     // given
     long invalidId = GoalFixture.getRandomId();
-    YearMonth thisMonth = YearMonth.now();
 
     // when
     ThrowingCallable collect = () -> collectMonthlyStatsSummaryService.collectSummary(
         invalidId,
-        thisMonth
+        null,
+        YearMonth.now()
     );
 
     // then

--- a/bootstrap/stats-api/src/main/java/com/ddudu/api/stats/controller/StatsController.java
+++ b/bootstrap/stats-api/src/main/java/com/ddudu/api/stats/controller/StatsController.java
@@ -107,11 +107,14 @@ public class StatsController implements StatsControllerDoc {
       @Login
       Long loginId,
       @RequestParam(required = false)
+      Long userId,
+      @RequestParam(required = false)
       @DateTimeFormat(pattern = "yyyy-MM")
       YearMonth yearMonth
   ) {
     MonthlyStatsSummaryResponse response = collectMonthlyStatsSummaryUseCase.collectSummary(
         loginId,
+        userId,
         yearMonth
     );
 

--- a/bootstrap/stats-api/src/main/java/com/ddudu/api/stats/doc/StatsControllerDoc.java
+++ b/bootstrap/stats-api/src/main/java/com/ddudu/api/stats/doc/StatsControllerDoc.java
@@ -244,12 +244,18 @@ public interface StatsControllerDoc {
       }
   )
   @Parameter(
+      name = "userId",
+      description = "통계 조회 대상 사용자 아이디(미입력 시 로그인 사용자)",
+      in = ParameterIn.QUERY,
+      example = "1"
+  )
+  @Parameter(
       name = "yearMonth",
       description = "통계 조회 대상 기간 월 (기본값: 이번 달)",
       in = ParameterIn.QUERY,
       example = "2024-08"
   )
-  ResponseEntity<MonthlyStatsSummaryResponse> collectSummary(Long loginId, YearMonth yearMonth);
+  ResponseEntity<MonthlyStatsSummaryResponse> collectSummary(Long loginId, Long userId, YearMonth yearMonth);
 
   @Operation(summary = "월별 뚜두 달성 중심 상세 통계")
   @ApiResponses(

--- a/domain/stats-domain/src/main/java/com/ddudu/aggregate/BaseStats.java
+++ b/domain/stats-domain/src/main/java/com/ddudu/aggregate/BaseStats.java
@@ -21,6 +21,7 @@ public class BaseStats {
   private final Long dduduId;
   private final Long goalId;
   private final String goalName;
+  private final String goalColor;
   private final DduduStatus status;
   private final boolean isPostponed;
   private final LocalDate scheduledOn;

--- a/domain/stats-domain/src/main/java/com/ddudu/aggregate/MonthlyStats.java
+++ b/domain/stats-domain/src/main/java/com/ddudu/aggregate/MonthlyStats.java
@@ -67,6 +67,13 @@ public class MonthlyStats {
         .getGoalName();
   }
 
+  public String getGoalColor() {
+    validateStatsUnderSameGoal();
+
+    return stats.get(0)
+        .getGoalColor();
+  }
+
   public int size() {
     return stats.size();
   }

--- a/domain/stats-domain/src/testFixtures/java/com/ddudu/fixtures/BaseStatsFixture.java
+++ b/domain/stats-domain/src/testFixtures/java/com/ddudu/fixtures/BaseStatsFixture.java
@@ -271,6 +271,7 @@ public final class BaseStatsFixture extends BaseFixture {
         .dduduId(dduduId)
         .goalId(goalId)
         .goalName(goalId.toString())
+        .goalColor(goalId.toString())
         .status(status)
         .scheduledOn(scheduledOn)
         .isPostponed(isPostponed)

--- a/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/repository/DduduQueryRepositoryImpl.java
+++ b/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/repository/DduduQueryRepositoryImpl.java
@@ -336,6 +336,7 @@ public class DduduQueryRepositoryImpl implements DduduQueryRepository {
         dduduEntity.id.as("dduduId"),
         goalEntity.id,
         goalEntity.name,
+        goalEntity.color.stringValue(),
         status,
         dduduEntity.postponedAt.isNotNull(),
         dduduEntity.scheduledOn,

--- a/plans/월-통계-요약-스펙-수정-구현-플랜.md
+++ b/plans/월-통계-요약-스펙-수정-구현-플랜.md
@@ -1,0 +1,113 @@
+# 월 통계 요약 스펙 수정 구현 플랜
+
+## 1) 목표
+
+- `GET /api/stats/summary` 응답을 **스탯별 목표 리스트 구조**에서 **목표별 스탯 집계 리스트 구조**로 변경한다.
+- `userId` 쿼리 파라미터(선택)를 지원하여, 값이 있으면 해당 사용자 기준으로 조회하고 없으면 로그인 사용자를 기준으로 조회한다.
+- 미루기/재달성 집계의 기준을 `isPostponed`가 아니라 `postponedAt != null` 의미로 일관되게 유지한다.
+
+## 2) 신규/변경 클래스 및 패키지
+
+### 2.1 Application Common (`application/application-common`)
+
+- **신규(권장)**: `application/application-common/src/main/java/com/ddudu/application/common/dto/stats/GoalMonthlyStatsSummary.java`
+  - 패키지: `com.ddudu.application.common.dto.stats`
+  - 역할: 목표 단위 집계 DTO
+  - 필드:
+    - `Long goalId`
+    - `String goalName`
+    - `String goalColor`
+    - `int creationCount`
+    - `int achievementCount`
+    - `int postponedCount`
+    - `int sustainedCount`
+    - `int reattainedCount`
+- **변경**: `application/application-common/src/main/java/com/ddudu/application/common/dto/stats/response/MonthlyStatsSummaryResponse.java`
+  - 패키지: `com.ddudu.application.common.dto.stats.response`
+  - 기존 `creationCounts/achievements/postponements/sustenances/reattainments` 5개 리스트를 제거하고,
+    `List<GoalMonthlyStatsSummary> summaries`(또는 record 단일 리스트 구조)로 변경
+- **변경**: `application/application-common/src/main/java/com/ddudu/application/common/port/stats/in/CollectMonthlyStatsSummaryUseCase.java`
+  - 패키지: `com.ddudu.application.common.port.stats.in`
+  - 시그니처를 `collectSummary(Long loginId, Long userId, YearMonth yearMonth)` 형태로 확장
+
+### 2.2 Application Service (`application/stats-application`)
+
+- **변경**: `application/stats-application/src/main/java/com/ddudu/application/stats/service/CollectMonthlyStatsSummaryService.java`
+  - 패키지: `com.ddudu.application.stats.service`
+  - 주요 변경:
+    1. 조회 대상 사용자 결정 로직 추가 (`userId != null ? userId : loginId`)
+    2. 사용자 존재 검증(없으면 404)
+    3. `Map<Long, MonthlyStats>`를 목표별 집계 DTO 리스트로 변환
+    4. 생성/달성/미루기/지속/재달성 count를 한 DTO에 통합
+
+### 2.3 Stats Domain (`domain/stats-domain`)
+
+- **변경(필요 시)**: `domain/stats-domain/src/main/java/com/ddudu/aggregate/BaseStats.java`
+  - 패키지: `com.ddudu.aggregate`
+  - `goalColor` 값 사용이 필요하면 필드 추가
+- **변경(필요 시)**: `domain/stats-domain/src/main/java/com/ddudu/aggregate/MonthlyStats.java`
+  - 패키지: `com.ddudu.aggregate`
+  - `getGoalColor()` 보조 메서드 추가(동일 목표 검증 후 반환)
+
+### 2.4 Infra (`infra/planning-infra-mysql`)
+
+- **변경(필요 시)**: `infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/ddudu/repository/DduduQueryRepositoryImpl.java`
+  - 패키지: `com.ddudu.infra.mysql.planning.ddudu.repository`
+  - `projectionStatsBase()`에서 목표 색상(`goalEntity.color`)을 `BaseStats`로 projection
+  - `postponedAt.isNotNull()` 기반 미루기 의미 유지 확인
+
+### 2.5 Bootstrap Stats API (`bootstrap/stats-api`)
+
+- **변경**: `bootstrap/stats-api/src/main/java/com/ddudu/api/stats/controller/StatsController.java`
+  - 패키지: `com.ddudu.api.stats.controller`
+  - `/summary`에 `@RequestParam(required = false) Long userId` 추가
+  - usecase 호출 시 `loginId, userId, yearMonth` 전달
+- **변경**: `bootstrap/stats-api/src/main/java/com/ddudu/api/stats/doc/StatsControllerDoc.java`
+  - 패키지: `com.ddudu.api.stats.doc`
+  - `userId` 쿼리 파라미터 문서화
+  - 응답 예시를 목표별 집계 리스트 스키마로 업데이트
+
+### 2.6 테스트 (`domain/*-domain`, `application/*-application`)
+
+- **변경**: `domain/stats-domain/src/test/java/com/ddudu/aggregate/MonthlyStatsTest.java`
+  - 목표 단위 집계에서 count 계산(생성/달성/미루기/지속/재달성) 정합성 검증 보강
+- **변경**: `domain/stats-domain/src/testFixtures/java/...` (실제 fixture 경로 기준)
+  - `BaseFixtures` + Faker 기반으로 goal/color/postponedAt 조합 생성 메서드 보강
+- **변경**: `application/stats-application/src/test/java/com/ddudu/application/stats/service/CollectMonthlyStatsSummaryServiceTest.java`
+  - 응답 구조 변경에 맞게 성공 케이스 검증 수정
+  - `userId` 파라미터 우선 적용 케이스 추가
+  - `postponedAt` 기준 미루기/재달성 집계 연계 검증
+
+## 3) 구현 단계
+
+1. **응답 스키마 전환**
+   - `GoalMonthlyStatsSummary`(신규) 및 `MonthlyStatsSummaryResponse`(변경) 반영
+2. **유스케이스 시그니처 확장**
+   - `CollectMonthlyStatsSummaryUseCase`와 구현체/호출부 동시 변경
+3. **대상 사용자 선택 로직 반영**
+   - `userId`가 있으면 해당 사용자, 없으면 로그인 사용자
+   - 존재하지 않는 사용자 예외 처리(404)
+4. **목표별 집계 통합 변환 로직 반영**
+   - 기존 스탯별 분리 리스트 생성 로직 제거
+   - 목표별 단일 DTO 리스트 생성
+5. **API 문서와 컨트롤러 파라미터 정합화**
+   - 컨트롤러 파라미터 및 OpenAPI 스펙 업데이트
+6. **테스트 보강 및 회귀 확인**
+   - domain/application 테스트 수정 및 검증
+
+## 4) 테스트 계획
+
+1. 선행 DB 구성(DDL 변경이 있을 때)
+   - `./gradlew :bootstrap:bootstrap-gateway:flywayMigrate`
+2. Domain 테스트
+   - `:domain:stats-domain:test`
+3. Application 테스트
+   - `:application:stats-application:test --tests "*CollectMonthlyStatsSummaryServiceTest"`
+
+> 실패 케이스는 `ThrowingCallable`을 사용하고, 모든 테스트에 `//given //when //then` 주석을 명시한다.
+
+## 5) 리스크 및 체크포인트
+
+- `goalColor`가 현재 stats projection에 없다면 Domain/Infra projection 변경이 필요하다.
+- 응답 구조가 크게 바뀌므로 클라이언트와의 계약(필드명/배열 구조) 확인이 필요하다.
+- `userId` 파라미터가 추가되므로 권한 정책(타 사용자 조회 허용 범위) 확인이 필요하다.


### PR DESCRIPTION
### Motivation
- Replace multiple per-stat lists in the monthly summary response with a single per-goal aggregated summary to simplify client consumption and align stats by goal.
- Allow requesting stats for a target user via an optional `userId` query parameter while keeping the default behavior of using the logged-in user.
- Ensure goal metadata (such as color) is available in stats DTOs and projections so the summary can include goal display info.

### Description
- Added a new record `GoalMonthlyStatsSummary` to represent aggregated monthly counts per goal (`goalId`, `goalName`, `goalColor`, `creationCount`, `achievementCount`, `postponedCount`, `sustainedCount`, `reattainedCount`).
- Replaced the previous multiple-list response with a single `MonthlyStatsSummaryResponse` that contains `List<GoalMonthlyStatsSummary> summaries`.
- Extended the use case signature to `collectSummary(Long loginId, Long userId, YearMonth yearMonth)` and updated the controller and OpenAPI doc to accept an optional `userId` query parameter.
- Updated `CollectMonthlyStatsSummaryService` to select the target user (`userId != null ? userId : loginId`), validate existence, collect `MonthlyStats` grouped by goal, convert to `GoalMonthlyStatsSummary`, and sort by creation count descending then goal id ascending.
- Added `goalColor` exposure in domain `MonthlyStats` and `BaseStats`, and updated the JPA/QueryDSL projection in `DduduQueryRepositoryImpl` to include `goalEntity.color` so color flows into the DTO.
- Updated tests in `CollectMonthlyStatsSummaryServiceTest` to match the new response shape and added a test that verifies the `userId` parameter causes the service to use the target user instead of the login user; fixtures were adjusted to provide `goalColor` where needed.
- Added `월-통계-요약-스펙-수정-구현-플랜.md` documenting the spec and implementation plan for the change.

### Testing
- Ran the service unit tests for the modified use case with `:application:stats-application:test --tests "*CollectMonthlyStatsSummaryServiceTest"` and the updated tests passed.
- Ran domain tests with `:domain:stats-domain:test` to validate `MonthlyStats`/`BaseStats` changes and they passed.
- No automated tests failed after the refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b79171c6a0832dab588d3f93aa3849)