### PR TITLE
Add reminder update API (PUT /api/reminders/{id}) with domain, service, infra and tests

### DIFF
--- a/application/application-common/src/main/java/com/ddudu/application/common/dto/reminder/request/UpdateReminderRequest.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/dto/reminder/request/UpdateReminderRequest.java
@@ -1,0 +1,11 @@
+package com.ddudu.application.common.dto.reminder.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record UpdateReminderRequest(
+    @NotNull(message = "2103 NULL_REMINDS_AT")
+    LocalDateTime remindsAt
+) {
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/reminder/in/UpdateReminderUseCase.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/reminder/in/UpdateReminderUseCase.java
@@ -1,0 +1,9 @@
+package com.ddudu.application.common.port.reminder.in;
+
+import com.ddudu.application.common.dto.reminder.request.UpdateReminderRequest;
+
+public interface UpdateReminderUseCase {
+
+  void update(Long loginId, Long id, UpdateReminderRequest request);
+
+}

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/reminder/out/ReminderCommandPort.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/reminder/out/ReminderCommandPort.java
@@ -6,4 +6,6 @@ public interface ReminderCommandPort {
 
   Reminder save(Reminder reminder);
 
+  Reminder update(Reminder reminder);
+
 }

--- a/application/application-common/src/main/java/com/ddudu/application/common/port/reminder/out/ReminderLoaderPort.java
+++ b/application/application-common/src/main/java/com/ddudu/application/common/port/reminder/out/ReminderLoaderPort.java
@@ -1,10 +1,16 @@
 package com.ddudu.application.common.port.reminder.out;
 
 import com.ddudu.domain.planning.reminder.aggregate.Reminder;
+import java.util.MissingResourceException;
 import java.util.Optional;
 
 public interface ReminderLoaderPort {
 
   Optional<Reminder> getOptionalReminder(Long id);
+
+  default Reminder getReminderOrElseThrow(Long id, String message) {
+    return getOptionalReminder(id)
+        .orElseThrow(() -> new MissingResourceException(message, "", ""));
+  }
 
 }

--- a/application/planning-application/src/main/java/com/ddudu/application/planning/reminder/service/UpdateReminderService.java
+++ b/application/planning-application/src/main/java/com/ddudu/application/planning/reminder/service/UpdateReminderService.java
@@ -1,0 +1,71 @@
+package com.ddudu.application.planning.reminder.service;
+
+import com.ddudu.application.common.dto.interim.InterimSetReminderEvent;
+import com.ddudu.application.common.dto.reminder.request.UpdateReminderRequest;
+import com.ddudu.application.common.port.reminder.in.UpdateReminderUseCase;
+import com.ddudu.application.common.port.reminder.out.ReminderCommandPort;
+import com.ddudu.application.common.port.reminder.out.ReminderLoaderPort;
+import com.ddudu.application.common.port.todo.out.TodoLoaderPort;
+import com.ddudu.application.common.port.user.out.UserLoaderPort;
+import com.ddudu.common.annotation.UseCase;
+import com.ddudu.common.exception.ReminderErrorCode;
+import com.ddudu.domain.planning.reminder.aggregate.Reminder;
+import com.ddudu.domain.planning.todo.aggregate.Todo;
+import com.ddudu.domain.user.user.aggregate.User;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class UpdateReminderService implements UpdateReminderUseCase {
+
+  private final UserLoaderPort userLoaderPort;
+  private final ReminderLoaderPort reminderLoaderPort;
+  private final TodoLoaderPort todoLoaderPort;
+  private final ReminderCommandPort reminderCommandPort;
+  private final ApplicationEventPublisher applicationEventPublisher;
+
+  @Override
+  @Transactional
+  public void update(Long loginId, Long id, UpdateReminderRequest request) {
+    User user = userLoaderPort.getUserOrElseThrow(
+        loginId,
+        ReminderErrorCode.LOGIN_USER_NOT_EXISTING.getCodeName()
+    );
+    Reminder reminder = reminderLoaderPort.getReminderOrElseThrow(
+        id,
+        ReminderErrorCode.ID_NOT_EXISTING.getCodeName()
+    );
+    Todo todo = todoLoaderPort.getTodoOrElseThrow(
+        reminder.getTodoId(),
+        ReminderErrorCode.TODO_NOT_EXISTING.getCodeName()
+    );
+
+    validateReminderCreator(reminder, user.getId());
+
+    LocalDateTime scheduledAt = resolveScheduledAt(todo);
+    Reminder updated = reminder.update(scheduledAt, request.remindsAt());
+    Reminder persisted = reminderCommandPort.update(updated);
+
+    InterimSetReminderEvent event = InterimSetReminderEvent.from(user.getId(), persisted);
+    applicationEventPublisher.publishEvent(event);
+  }
+
+  private LocalDateTime resolveScheduledAt(Todo todo) {
+    if (Objects.isNull(todo.getBeginAt())) {
+      throw new IllegalArgumentException(ReminderErrorCode.NULL_SCHEDULED_AT.getCodeName());
+    }
+
+    return todo.getScheduledOn().atTime(todo.getBeginAt());
+  }
+
+  private void validateReminderCreator(Reminder reminder, Long userId) {
+    if (!Objects.equals(reminder.getUserId(), userId)) {
+      throw new SecurityException(ReminderErrorCode.INVALID_AUTHORITY.getCodeName());
+    }
+  }
+
+}

--- a/application/planning-application/src/test/java/com/ddudu/application/planning/reminder/service/UpdateReminderServiceTest.java
+++ b/application/planning-application/src/test/java/com/ddudu/application/planning/reminder/service/UpdateReminderServiceTest.java
@@ -1,0 +1,160 @@
+package com.ddudu.application.planning.reminder.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddudu.application.common.dto.interim.InterimSetReminderEvent;
+import com.ddudu.application.common.dto.reminder.request.UpdateReminderRequest;
+import com.ddudu.application.common.port.auth.out.SignUpPort;
+import com.ddudu.application.common.port.goal.out.SaveGoalPort;
+import com.ddudu.application.common.port.reminder.out.ReminderCommandPort;
+import com.ddudu.application.common.port.reminder.out.ReminderLoaderPort;
+import com.ddudu.application.common.port.todo.out.SaveTodoPort;
+import com.ddudu.common.exception.ReminderErrorCode;
+import com.ddudu.domain.planning.goal.aggregate.Goal;
+import com.ddudu.domain.planning.reminder.aggregate.Reminder;
+import com.ddudu.domain.planning.todo.aggregate.Todo;
+import com.ddudu.domain.user.user.aggregate.User;
+import com.ddudu.fixture.GoalFixture;
+import com.ddudu.fixture.ReminderFixture;
+import com.ddudu.fixture.TodoFixture;
+import com.ddudu.fixture.UserFixture;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.MissingResourceException;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@RecordApplicationEvents
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class UpdateReminderServiceTest {
+
+  @Autowired
+  UpdateReminderService updateReminderService;
+
+  @Autowired
+  ReminderCommandPort reminderCommandPort;
+
+  @Autowired
+  ReminderLoaderPort reminderLoaderPort;
+
+  @Autowired
+  SignUpPort signUpPort;
+
+  @Autowired
+  SaveGoalPort saveGoalPort;
+
+  @Autowired
+  SaveTodoPort saveTodoPort;
+
+  User user;
+  Goal goal;
+  Todo todo;
+  Reminder reminder;
+
+  @BeforeEach
+  void setUp() {
+    user = signUpPort.save(UserFixture.createRandomUserWithId());
+    goal = saveGoalPort.save(GoalFixture.createRandomGoalWithUser(user.getId()));
+
+    Todo temp = TodoFixture.createRandomTodoWithGoalAndTime(goal, LocalTime.of(10, 0), null);
+    todo = saveTodoPort.save(temp.moveDate(LocalDate.now().plusDays(1)));
+
+    LocalDateTime remindsAt = todo.getScheduledOn().atTime(todo.getBeginAt()).minusMinutes(20);
+    Reminder createReminder = Reminder.from(user.getId(), todo.getId(), remindsAt,
+        todo.getScheduledOn().atTime(todo.getBeginAt()));
+    reminder = reminderCommandPort.save(createReminder);
+  }
+
+  @Test
+  void 미리알림_갱신_유즈케이스에_성공한다() {
+    // given
+    LocalDateTime newRemindsAt = todo.getScheduledOn().atTime(todo.getBeginAt()).minusMinutes(10);
+    UpdateReminderRequest request = new UpdateReminderRequest(newRemindsAt);
+
+    // when
+    updateReminderService.update(user.getId(), reminder.getId(), request);
+
+    // then
+    Reminder updated = reminderLoaderPort.getOptionalReminder(reminder.getId()).orElseThrow();
+    assertThat(updated.getRemindsAt()).isEqualTo(newRemindsAt);
+  }
+
+  @Test
+  void 미리알림_갱신_후_이벤트를_발행한다(ApplicationEvents events) {
+    // given
+    LocalDateTime newRemindsAt = todo.getScheduledOn().atTime(todo.getBeginAt()).minusMinutes(15);
+    UpdateReminderRequest request = new UpdateReminderRequest(newRemindsAt);
+
+    // when
+    updateReminderService.update(user.getId(), reminder.getId(), request);
+
+    // then
+    assertThat(events.stream(InterimSetReminderEvent.class))
+        .hasSize(1);
+  }
+
+  @Test
+  void 로그인_사용자가_존재하지_않으면_실패한다() {
+    // given
+    Long invalidUserId = TodoFixture.getRandomId();
+    LocalDateTime newRemindsAt = todo.getScheduledOn().atTime(todo.getBeginAt()).minusMinutes(10);
+    UpdateReminderRequest request = new UpdateReminderRequest(newRemindsAt);
+
+    // when
+    ThrowingCallable update = () -> updateReminderService.update(invalidUserId, reminder.getId(), request);
+
+    // then
+    Assertions.assertThatExceptionOfType(MissingResourceException.class)
+        .isThrownBy(update)
+        .withMessage(ReminderErrorCode.LOGIN_USER_NOT_EXISTING.getCodeName());
+  }
+
+  @Test
+  void 미리알림이_존재하지_않으면_실패한다() {
+    // given
+    Long invalidReminderId = TodoFixture.getRandomId();
+    LocalDateTime newRemindsAt = todo.getScheduledOn().atTime(todo.getBeginAt()).minusMinutes(10);
+    UpdateReminderRequest request = new UpdateReminderRequest(newRemindsAt);
+
+    // when
+    ThrowingCallable update = () -> updateReminderService.update(user.getId(), invalidReminderId, request);
+
+    // then
+    Assertions.assertThatExceptionOfType(MissingResourceException.class)
+        .isThrownBy(update)
+        .withMessage(ReminderErrorCode.ID_NOT_EXISTING.getCodeName());
+  }
+
+  @Test
+  void 투두가_존재하지_않으면_실패한다() {
+    // given
+    Reminder brokenReminder = ReminderFixture.createValidReminderWithIds(user.getId(), TodoFixture.getRandomId());
+    Reminder savedBrokenReminder = reminderCommandPort.save(brokenReminder);
+    UpdateReminderRequest request = new UpdateReminderRequest(LocalDateTime.now().plusDays(1));
+
+    // when
+    ThrowingCallable update = () -> updateReminderService.update(
+        user.getId(),
+        savedBrokenReminder.getId(),
+        request
+    );
+
+    // then
+    Assertions.assertThatExceptionOfType(MissingResourceException.class)
+        .isThrownBy(update)
+        .withMessage(ReminderErrorCode.TODO_NOT_EXISTING.getCodeName());
+  }
+
+}

--- a/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/ReminderErrorExamples.java
+++ b/bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/ReminderErrorExamples.java
@@ -51,8 +51,14 @@ public final class ReminderErrorExamples {
       }
       """;
 
+  public static final String REMINDER_ID_NOT_EXISTING = """
+      {
+        "code": 2111,
+        "message": "미리알림 아이디가 존재하지 않습니다."
+      }
+      """;
+
   private ReminderErrorExamples() {
   }
 
 }
-

--- a/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/reminder/controller/ReminderController.java
+++ b/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/reminder/controller/ReminderController.java
@@ -3,14 +3,18 @@ package com.ddudu.api.planning.reminder.controller;
 import com.ddudu.api.planning.reminder.doc.ReminderControllerDoc;
 import com.ddudu.application.common.dto.IdResponse;
 import com.ddudu.application.common.dto.reminder.request.CreateReminderRequest;
+import com.ddudu.application.common.dto.reminder.request.UpdateReminderRequest;
 import com.ddudu.application.common.dto.reminder.response.CreateReminderResponse;
 import com.ddudu.application.common.port.reminder.in.CreateReminderUseCase;
+import com.ddudu.application.common.port.reminder.in.UpdateReminderUseCase;
 import com.ddudu.bootstrap.common.annotation.Login;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReminderController implements ReminderControllerDoc {
 
   private final CreateReminderUseCase createReminderUseCase;
+  private final UpdateReminderUseCase updateReminderUseCase;
 
   @PostMapping
   public ResponseEntity<IdResponse> create(
@@ -35,6 +40,23 @@ public class ReminderController implements ReminderControllerDoc {
 
     return ResponseEntity.created(uri)
         .body(new IdResponse(response.id()));
+  }
+
+  @Override
+  @PutMapping("/{id}")
+  public ResponseEntity<Void> update(
+      @Login
+      Long loginId,
+      @PathVariable("id")
+      Long id,
+      @RequestBody
+      @Valid
+      UpdateReminderRequest request
+  ) {
+    updateReminderUseCase.update(loginId, id, request);
+
+    return ResponseEntity.noContent()
+        .build();
   }
 
 }

--- a/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/reminder/doc/ReminderControllerDoc.java
+++ b/bootstrap/planning-api/src/main/java/com/ddudu/api/planning/reminder/doc/ReminderControllerDoc.java
@@ -2,6 +2,7 @@ package com.ddudu.api.planning.reminder.doc;
 
 import com.ddudu.application.common.dto.IdResponse;
 import com.ddudu.application.common.dto.reminder.request.CreateReminderRequest;
+import com.ddudu.application.common.dto.reminder.request.UpdateReminderRequest;
 import com.ddudu.bootstrap.common.doc.examples.AuthErrorExamples;
 import com.ddudu.bootstrap.common.doc.examples.ReminderErrorExamples;
 import io.swagger.v3.oas.annotations.Operation;
@@ -89,5 +90,76 @@ public interface ReminderControllerDoc {
       }
   )
   ResponseEntity<IdResponse> create(Long loginId, CreateReminderRequest request);
+
+  @Operation(summary = "미리알림 갱신")
+  @ApiResponses(
+      value = {
+          @ApiResponse(
+              responseCode = "204",
+              description = "NO_CONTENT"
+          ),
+          @ApiResponse(
+              responseCode = "400",
+              description = "BAD_REQUEST",
+              content = @Content(
+                  examples = {
+                      @ExampleObject(
+                          name = "2103",
+                          value = ReminderErrorExamples.REMINDER_NULL_REMINDS_AT
+                      ),
+                      @ExampleObject(
+                          name = "2104",
+                          value = ReminderErrorExamples.REMINDER_NULL_SCHEDULED_AT
+                      ),
+                      @ExampleObject(
+                          name = "2105",
+                          value = ReminderErrorExamples.REMINDER_INVALID_REMINDS_AT
+                      )
+                  }
+              )
+          ),
+          @ApiResponse(
+              responseCode = "401",
+              description = "UNAUTHORIZED",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "5002",
+                      value = AuthErrorExamples.AUTH_BAD_TOKEN_CONTENT
+                  )
+              )
+          ),
+          @ApiResponse(
+              responseCode = "403",
+              description = "FORBIDDEN",
+              content = @Content(
+                  examples = @ExampleObject(
+                      name = "2108",
+                      value = ReminderErrorExamples.REMINDER_INVALID_AUTHORITY
+                  )
+              )
+          ),
+          @ApiResponse(
+              responseCode = "404",
+              description = "NOT_FOUND",
+              content = @Content(
+                  examples = {
+                      @ExampleObject(
+                          name = "2106",
+                          value = ReminderErrorExamples.REMINDER_LOGIN_USER_NOT_EXISTING
+                      ),
+                      @ExampleObject(
+                          name = "2107",
+                          value = ReminderErrorExamples.REMINDER_TODO_NOT_EXISTING
+                      ),
+                      @ExampleObject(
+                          name = "2111",
+                          value = ReminderErrorExamples.REMINDER_ID_NOT_EXISTING
+                      )
+                  }
+              )
+          )
+      }
+  )
+  ResponseEntity<Void> update(Long loginId, Long id, UpdateReminderRequest request);
 
 }

--- a/common/src/main/java/com/ddudu/common/exception/ReminderErrorCode.java
+++ b/common/src/main/java/com/ddudu/common/exception/ReminderErrorCode.java
@@ -16,7 +16,8 @@ public enum ReminderErrorCode implements ErrorCode {
   TODO_NOT_EXISTING(2107, "할 일 아이디가 존재하지 않습니다."),
   INVALID_AUTHORITY(2108, "해당 기능에 대한 사용자 권한이 없습니다."),
   UNABLE_TO_GET_REMINDER(2109, "미리알림 시간을 알 수 없는 상태입니다."),
-  REMINDER_NOT_AFTER_NOW(2110, "미리알림 시간은 현재 시간보다 이후여야 합니다.");
+  REMINDER_NOT_AFTER_NOW(2110, "미리알림 시간은 현재 시간보다 이후여야 합니다."),
+  ID_NOT_EXISTING(2111, "미리알림 아이디가 존재하지 않습니다.");
 
   private final int code;
   private final String message;
@@ -26,4 +27,3 @@ public enum ReminderErrorCode implements ErrorCode {
     return this.code + " " + this.name();
   }
 }
-

--- a/domain/planning-domain/src/main/java/com/ddudu/domain/planning/reminder/aggregate/Reminder.java
+++ b/domain/planning-domain/src/main/java/com/ddudu/domain/planning/reminder/aggregate/Reminder.java
@@ -61,6 +61,18 @@ public class Reminder {
         .build();
   }
 
+  public Reminder update(LocalDateTime todoScheduledAt, LocalDateTime newRemindsAt) {
+    Reminder updated = Reminder.from(userId, todoId, newRemindsAt, todoScheduledAt);
+
+    return Reminder.builder()
+        .id(id)
+        .userId(updated.getUserId())
+        .todoId(updated.getTodoId())
+        .remindsAt(updated.getRemindsAt())
+        .remindedAt(remindedAt)
+        .build();
+  }
+
   public boolean isReminded() {
     return Objects.nonNull(remindedAt);
   }

--- a/domain/planning-domain/src/test/java/com/ddudu/domain/planning/reminder/aggregate/ReminderTest.java
+++ b/domain/planning-domain/src/test/java/com/ddudu/domain/planning/reminder/aggregate/ReminderTest.java
@@ -213,4 +213,67 @@ class ReminderTest {
         .withMessage(ReminderErrorCode.REMINDER_NOT_AFTER_NOW.getCodeName());
   }
 
+  @Test
+  void Reminder_도메인_수정에_성공한다() {
+    // given
+    Reminder reminder = ReminderFixture.createValidReminder();
+    LocalDateTime scheduledAt = ReminderFixture.createValidTodoScheduledAt();
+    LocalDateTime newRemindsAt = ReminderFixture.createValidRemindsAtBefore(scheduledAt);
+
+    // when
+    Reminder updated = reminder.update(scheduledAt, newRemindsAt);
+
+    // then
+    assertThat(updated.getId()).isEqualTo(reminder.getId());
+    assertThat(updated.getUserId()).isEqualTo(reminder.getUserId());
+    assertThat(updated.getTodoId()).isEqualTo(reminder.getTodoId());
+    assertThat(updated.getRemindsAt()).isEqualTo(newRemindsAt);
+  }
+
+  @Test
+  void Reminder_도메인_수정_시_remindsAt이_없으면_실패한다() {
+    // given
+    Reminder reminder = ReminderFixture.createValidReminder();
+    LocalDateTime scheduledAt = ReminderFixture.createValidTodoScheduledAt();
+
+    // when
+    ThrowingCallable update = () -> reminder.update(scheduledAt, null);
+
+    // then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(update)
+        .withMessage(ReminderErrorCode.NULL_REMINDS_AT.getCodeName());
+  }
+
+  @Test
+  void Reminder_도메인_수정_시_scheduledAt이_없으면_실패한다() {
+    // given
+    Reminder reminder = ReminderFixture.createValidReminder();
+    LocalDateTime newRemindsAt = ReminderFixture.getFutureDateTime(5, TimeUnit.DAYS);
+
+    // when
+    ThrowingCallable update = () -> reminder.update(null, newRemindsAt);
+
+    // then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(update)
+        .withMessage(ReminderErrorCode.NULL_SCHEDULED_AT.getCodeName());
+  }
+
+  @Test
+  void Reminder_도메인_수정_시_remindsAt이_scheduledAt보다_늦으면_실패한다() {
+    // given
+    Reminder reminder = ReminderFixture.createValidReminder();
+    LocalDateTime scheduledAt = ReminderFixture.createValidTodoScheduledAt();
+    LocalDateTime invalidRemindsAt = scheduledAt.plusMinutes(1);
+
+    // when
+    ThrowingCallable update = () -> reminder.update(scheduledAt, invalidRemindsAt);
+
+    // then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(update)
+        .withMessage(ReminderErrorCode.INVALID_REMINDS_AT.getCodeName());
+  }
+
 }

--- a/domain/planning-domain/src/testFixtures/java/com/ddudu/fixture/ReminderFixture.java
+++ b/domain/planning-domain/src/testFixtures/java/com/ddudu/fixture/ReminderFixture.java
@@ -18,6 +18,21 @@ public class ReminderFixture extends BaseFixture {
     return Reminder.from(userId, todoId, remindsAt, scheduledAt);
   }
 
+  public static Reminder createValidReminderWithIds(Long userId, Long todoId) {
+    LocalDateTime scheduledAt = getFutureDateTime(10, TimeUnit.DAYS);
+    LocalDateTime remindsAt = getRandomDateTimeBetween(scheduledAt.minusDays(1), scheduledAt);
+
+    return Reminder.from(userId, todoId, remindsAt, scheduledAt);
+  }
+
+  public static LocalDateTime createValidTodoScheduledAt() {
+    return getFutureDateTime(10, TimeUnit.DAYS);
+  }
+
+  public static LocalDateTime createValidRemindsAtBefore(LocalDateTime scheduledAt) {
+    return getRandomDateTimeBetween(scheduledAt.minusDays(1), scheduledAt);
+  }
+
   public static Reminder createReminderWithUserId(Long userId) {
     Long todoId = getRandomId();
     LocalDateTime scheduledAt = getFutureDateTime(10, TimeUnit.DAYS);

--- a/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/reminder/adapter/ReminderPersistenceAdapter.java
+++ b/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/reminder/adapter/ReminderPersistenceAdapter.java
@@ -6,6 +6,7 @@ import com.ddudu.common.annotation.DrivenAdapter;
 import com.ddudu.domain.planning.reminder.aggregate.Reminder;
 import com.ddudu.infra.mysql.planning.reminder.entity.ReminderEntity;
 import com.ddudu.infra.mysql.planning.reminder.repository.ReminderRepository;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
@@ -19,6 +20,16 @@ public class ReminderPersistenceAdapter implements ReminderCommandPort, Reminder
   public Reminder save(Reminder reminder) {
     return reminderRepository.save(ReminderEntity.from(reminder))
         .toDomain();
+  }
+
+  @Override
+  public Reminder update(Reminder reminder) {
+    ReminderEntity reminderEntity = reminderRepository.findById(reminder.getId())
+        .orElseThrow(EntityNotFoundException::new);
+
+    reminderEntity.update(reminder);
+
+    return reminderEntity.toDomain();
   }
 
   @Override

--- a/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/reminder/entity/ReminderEntity.java
+++ b/infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/reminder/entity/ReminderEntity.java
@@ -60,4 +60,11 @@ public class ReminderEntity extends BaseEntity {
         .build();
   }
 
+  public void update(Reminder reminder) {
+    this.userId = reminder.getUserId();
+    this.todoId = reminder.getTodoId();
+    this.remindsAt = reminder.getRemindsAt();
+    this.remindedAt = reminder.getRemindedAt();
+  }
+
 }

--- a/plans/미리알림-갱신-api-구현-플랜.md
+++ b/plans/미리알림-갱신-api-구현-플랜.md
@@ -1,0 +1,110 @@
+# 미리알림 갱신 API 구현 플랜
+
+## 1) 목표 및 범위
+
+- PR 요구사항인 `PUT /api/reminders/{id}`(204 No Content)를 구현한다.
+- 유스케이스 순서(로그인 사용자 조회 → 리마인더 조회 → 투두 조회 → 갱신 → 이벤트 발행)를 그대로 반영한다.
+- 도메인 규칙은 `Reminder.from(...)`과 동일 검증을 재사용하도록 `Reminder.update(todoScheduledAt, remindsAt)`를 추가한다.
+- 인프라 갱신은 JPA 더티체킹 기반으로 처리한다(명시적 save 없이 트랜잭션 커밋 시 반영).
+
+## 2) 메서드 선택: PUT vs PATCH
+
+### 결론
+
+- **이번 스펙은 `PUT`보다 `PATCH`가 더 의미적으로 적합**하다.
+
+### 근거
+
+- HTTP Semantics(RFC 9110)에서 `PUT`은 대상 리소스의 **전체 표현(complete replacement)**을 저장하는 의미가 강하다.
+- HTTP PATCH(RFC 5789)는 리소스의 **부분 변경(partial modification)**을 위해 정의되었다.
+- 이번 요청 본문은 `remindsAt` 단일 필드 변경이므로 부분 갱신 성격이다.
+
+### 적용 제안
+
+- 단기: 요구 스펙을 존중하여 `PUT /api/reminders/{id}` 구현.
+- 중기: API 일관성 개선을 위해 `PATCH /api/reminders/{id}` 병행 제공(또는 차기 버전 전환) 검토.
+
+## 3) 상세 구현 단계
+
+1. 요청/유스케이스 계약 추가
+   - `UpdateReminderRequest(remindsAt)` DTO 추가.
+   - `UpdateReminderUseCase` 입력 계약 추가.
+2. 애플리케이션 서비스 구현
+   - `UpdateReminderService`에서 아래 순서 보장:
+     1) 사용자 조회(없으면 404)
+     2) 리마인더 조회(없으면 404)
+     3) 투두 조회(없으면 404)
+     4) 권한 검증(리마인더 생성자=로그인 사용자)
+     5) `Reminder.update(...)` 호출
+     6) 포트로 갱신 반영(더티체킹)
+     7) `InterimSetReminderEvent` 발행
+3. 도메인 로직 보강
+   - `Reminder.update(todoScheduledAt, remindsAt)` 추가.
+   - 내부에서 `Reminder.from(...)`과 동일 제약(`NULL_SCHEDULED_AT`, `NULL_REMINDS_AT`, `INVALID_REMINDS_AT`)을 강제.
+4. 인프라 업데이트 경로 추가
+   - `ReminderEntity.update(Reminder reminder)` 메서드 추가.
+   - 어댑터에서 엔티티 조회 후 필드 변경(더티체킹 반영).
+5. 부트스트랩 API/문서 반영
+   - 컨트롤러에 `@PutMapping("/{id}")` 추가.
+   - Swagger Doc에 204/에러 코드 예시를 확장.
+6. 테스트 작성
+   - Domain: `ReminderTest`에 update 성공/실패 케이스.
+   - Application: `UpdateReminderServiceTest`에 성공/실패/이벤트 발행 검증.
+   - 테스트 메서드명은 한국어, 실패 케이스는 `ThrowingCallable` + `//given //when //then` 규칙 준수.
+
+## 4) 신규/변경 패키지 및 클래스
+
+## 신규 예정
+
+- `application/application-common/src/main/java/com/ddudu/application/common/dto/reminder/request/UpdateReminderRequest.java`
+- `application/application-common/src/main/java/com/ddudu/application/common/port/reminder/in/UpdateReminderUseCase.java`
+- `application/planning-application/src/main/java/com/ddudu/application/planning/reminder/service/UpdateReminderService.java`
+- `application/planning-application/src/test/java/com/ddudu/application/planning/reminder/service/UpdateReminderServiceTest.java`
+
+## 변경 예정
+
+- `domain/planning-domain/src/main/java/com/ddudu/domain/planning/reminder/aggregate/Reminder.java`
+  - `update(todoScheduledAt, remindsAt)` 추가
+- `domain/planning-domain/src/test/java/com/ddudu/domain/planning/reminder/aggregate/ReminderTest.java`
+  - update 성공/실패 검증 추가
+- `application/application-common/src/main/java/com/ddudu/application/common/port/reminder/out/ReminderCommandPort.java`
+  - update 시그니처 추가
+- `infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/reminder/adapter/ReminderPersistenceAdapter.java`
+  - 조회 후 엔티티 변경 기반 업데이트 구현
+- `infra/planning-infra-mysql/src/main/java/com/ddudu/infra/mysql/planning/reminder/entity/ReminderEntity.java`
+  - `update(Reminder)` 메서드 추가
+- `bootstrap/planning-api/src/main/java/com/ddudu/api/planning/reminder/controller/ReminderController.java`
+  - `PUT /api/reminders/{id}` 엔드포인트 추가
+- `bootstrap/planning-api/src/main/java/com/ddudu/api/planning/reminder/doc/ReminderControllerDoc.java`
+  - 204/404/400 응답 스펙 및 예시 추가
+- `bootstrap/bootstrap-common/src/main/java/com/ddudu/bootstrap/common/doc/examples/ReminderErrorExamples.java`
+  - 신규/재사용 에러 예시 정합화
+
+## 5) 예외/에러코드 매핑 계획
+
+- 로그인 사용자 없음: `ReminderErrorCode.LOGIN_USER_NOT_EXISTING`(404)
+- 리마인더 없음: `ReminderErrorCode.ID_NOT_EXISTING` 또는 동등 코드(404)
+- 투두 없음: `ReminderErrorCode.TODO_NOT_EXISTING`(404)
+- 유효하지 않은 remindsAt/scheduledAt: `ReminderErrorCode.NULL_SCHEDULED_AT`, `NULL_REMINDS_AT`, `INVALID_REMINDS_AT`(400)
+- 권한 없음: `ReminderErrorCode.INVALID_AUTHORITY`(403)
+
+> 주의: `ID_NOT_EXISTING` 코드 존재 여부에 따라, Reminder 전용 not found 코드가 없으면 이번 작업에서 추가 여부를 결정한다.
+
+## 6) 테스트/검증 실행 계획
+
+1. (DDL 변경이 있을 때만) `./gradlew :bootstrap:bootstrap-gateway:flywayMigrate`
+2. 도메인 테스트
+   - `./gradlew :domain:planning-domain:test --tests "*ReminderTest"`
+3. 애플리케이션 테스트
+   - `./gradlew :application:planning-application:test --tests "*UpdateReminderServiceTest"`
+4. API 모듈 컴파일/테스트
+   - `./gradlew :bootstrap:planning-api:test`
+
+## 7) 구현 순서(권장 커밋 단위)
+
+1. Domain(`Reminder.update`) + Domain Test
+2. Application Common(port/dto) + Planning Application Service/Test
+3. Infra(Dirty Checking update 경로)
+4. Bootstrap API/Doc
+5. 통합 테스트 및 예외/문서 예시 정리
+


### PR DESCRIPTION
### Motivation

- Implement the `PUT /api/reminders/{id}` endpoint to allow updating a reminder's `remindsAt` while preserving domain validations and emitting the interim event.
- Reuse existing domain validation logic for `remindsAt` vs `scheduledAt` by adding a domain `update` operation to avoid duplicating checks.
- Ensure persistence is applied via the infra layer using JPA dirty-checking and provide clear error codes/examples for not-found cases.

### Description

- Added request contract `UpdateReminderRequest` and input port `UpdateReminderUseCase` and implemented the use case in `UpdateReminderService` which performs user, reminder and todo lookups, authority validation, domain update, persistence and publishes `InterimSetReminderEvent`.
- Extended the `Reminder` domain with `update(LocalDateTime todoScheduledAt, LocalDateTime newRemindsAt)` to reuse `Reminder.from(...)` validations and return an updated instance, and added domain tests for success and failure cases in `ReminderTest`.
- Extended ports and infra: added `ReminderCommandPort.update(...)`, `ReminderLoaderPort.getReminderOrElseThrow(...)`, implemented `update` in `ReminderPersistenceAdapter` using `findById` plus `ReminderEntity.update(...)` for dirty-checking persistence, and added corresponding entity update method.
- Added controller endpoint `@PutMapping("/{id}")` in `ReminderController` and OpenAPI docs updates in `ReminderControllerDoc`, plus new error code `ID_NOT_EXISTING` and example `REMINDER_ID_NOT_EXISTING` in docs and updated bootstrap examples; also included the implementation plan file `미리알림-갱신-api-구현-플랜.md`.

### Testing

- Ran domain unit tests for `Reminder` with `./gradlew :domain:planning-domain:test --tests "*ReminderTest"` and all new/updated tests passed.
- Ran application tests for the service with `./gradlew :application:planning-application:test --tests "*UpdateReminderServiceTest"` and they passed, including event publication assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc4b2a3134832d8cbc5970de2ba418)