### PR TITLE
Migrate refresh tokens to single-record model with CAS rotation and update refresh flow

### DIFF
--- a/application/application-common/src/main/java/com/modoo/application/common/dto/repeattodo/RepeatTodoDto.java
+++ b/application/application-common/src/main/java/com/modoo/application/common/dto/repeattodo/RepeatTodoDto.java
@@ -1,9 +1,9 @@
 package com.modoo.application.common.dto.repeattodo;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.modoo.domain.planning.repeattodo.aggregate.RepeatTodo;
 import com.modoo.domain.planning.repeattodo.aggregate.enums.RepeatType;
 import com.modoo.domain.planning.repeattodo.aggregate.vo.RepeatPattern;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/application/application-common/src/main/java/com/modoo/application/common/dto/todo/TodoForTimetable.java
+++ b/application/application-common/src/main/java/com/modoo/application/common/dto/todo/TodoForTimetable.java
@@ -1,8 +1,8 @@
 package com.modoo.application.common.dto.todo;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.modoo.domain.planning.todo.aggregate.Todo;
 import com.modoo.domain.planning.todo.aggregate.enums.TodoStatus;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.time.LocalTime;

--- a/application/application-common/src/main/java/com/modoo/application/common/dto/todo/response/TodoDetailResponse.java
+++ b/application/application-common/src/main/java/com/modoo/application/common/dto/todo/response/TodoDetailResponse.java
@@ -1,9 +1,9 @@
 package com.modoo.application.common.dto.todo.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.modoo.application.common.dto.reminder.response.RetrieveReminderResponse;
 import com.modoo.domain.planning.todo.aggregate.Todo;
 import com.modoo.domain.planning.todo.aggregate.enums.TodoStatus;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/application/application-common/src/main/java/com/modoo/application/common/port/auth/out/TokenLoaderPort.java
+++ b/application/application-common/src/main/java/com/modoo/application/common/port/auth/out/TokenLoaderPort.java
@@ -2,9 +2,12 @@ package com.modoo.application.common.port.auth.out;
 
 import com.modoo.domain.user.auth.aggregate.RefreshToken;
 import java.util.List;
+import java.util.Optional;
 
 public interface TokenLoaderPort {
 
   List<RefreshToken> loadByUserFamily(Long userId, int family);
+
+  Optional<RefreshToken> loadOneByUserFamily(Long userId, int family);
 
 }

--- a/application/application-common/src/main/java/com/modoo/application/common/port/auth/out/TokenManipulationPort.java
+++ b/application/application-common/src/main/java/com/modoo/application/common/port/auth/out/TokenManipulationPort.java
@@ -1,6 +1,7 @@
 package com.modoo.application.common.port.auth.out;
 
 import com.modoo.domain.user.auth.aggregate.RefreshToken;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface TokenManipulationPort {
@@ -12,5 +13,13 @@ public interface TokenManipulationPort {
   void deleteAllFamily(List<RefreshToken> tokenFamily);
 
   void deleteByUserFamily(Long userId, int family);
+
+  long rotateIfCurrentMatches(
+      Long userId,
+      int family,
+      String currentToken,
+      String newCurrentToken,
+      LocalDateTime refreshedAt
+  );
 
 }

--- a/application/user-application/src/main/java/com/modoo/application/user/auth/jwt/TokenManager.java
+++ b/application/user-application/src/main/java/com/modoo/application/user/auth/jwt/TokenManager.java
@@ -32,8 +32,12 @@ public class TokenManager {
   }
 
   public RefreshToken createRefreshToken(User user, Integer family) {
+    return createRefreshToken(user.getId(), family);
+  }
+
+  public RefreshToken createRefreshToken(Long userId, Integer family) {
     UserFamily userFamily = UserFamily.builder()
-        .userId(user.getId())
+        .userId(userId)
         .family(family)
         .build();
     Map<String, Object> claim = Collections.singletonMap(

--- a/application/user-application/src/main/java/com/modoo/application/user/auth/jwt/TokenManager.java
+++ b/application/user-application/src/main/java/com/modoo/application/user/auth/jwt/TokenManager.java
@@ -6,7 +6,6 @@ import com.modoo.domain.user.auth.aggregate.vo.UserFamily;
 import com.modoo.domain.user.user.aggregate.User;
 import com.google.common.collect.Maps;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -18,6 +17,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TokenManager {
 
+  private static final String USER_CLAIM = "user";
+  private static final String AUTH_CLAIM = "auth";
   private final JwtProperties jwtProperties;
   private final JwtIssuer jwtIssuer;
   private final JwtDecoder jwtDecoder;
@@ -25,25 +26,34 @@ public class TokenManager {
   public String createAccessToken(User user) {
     Map<String, Object> claims = Maps.newHashMap();
 
-    claims.put("user", user.getId());
-    claims.put("auth", user.getAuthority());
+    claims.put(USER_CLAIM, user.getId());
+    claims.put(AUTH_CLAIM, user.getAuthority());
+
+    return jwtIssuer.issue(claims, Duration.ofSeconds(jwtProperties.getExpiredAfter()));
+  }
+
+  public String createAccessToken(Long userId, String authority) {
+    Map<String, Object> claims = Maps.newHashMap();
+
+    claims.put(USER_CLAIM, userId);
+    claims.put(AUTH_CLAIM, authority);
 
     return jwtIssuer.issue(claims, Duration.ofSeconds(jwtProperties.getExpiredAfter()));
   }
 
   public RefreshToken createRefreshToken(User user, Integer family) {
-    return createRefreshToken(user.getId(), family);
+    return createRefreshToken(user.getId(), family, user.getAuthority()
+        .name());
   }
 
-  public RefreshToken createRefreshToken(Long userId, Integer family) {
+  public RefreshToken createRefreshToken(Long userId, Integer family, String authority) {
     UserFamily userFamily = UserFamily.builder()
         .userId(userId)
         .family(family)
         .build();
-    Map<String, Object> claim = Collections.singletonMap(
-        JwtClaimNames.SUB,
-        userFamily.getUserFamilyValue()
-    );
+    Map<String, Object> claim = Maps.newHashMap();
+    claim.put(JwtClaimNames.SUB, userFamily.getUserFamilyValue());
+    claim.put(AUTH_CLAIM, authority);
     String tokenValue = jwtIssuer.issue(claim, Duration.ZERO);
 
     return RefreshToken.builder()
@@ -58,6 +68,12 @@ public class TokenManager {
     return UserFamily.builderWithString()
         .userFamilyValue(jwt.getSubject())
         .buildWithString();
+  }
+
+  public String decodeRefreshTokenAuthority(String refreshToken) {
+    Jwt jwt = jwtDecoder.decode(refreshToken);
+
+    return jwt.getClaimAsString(AUTH_CLAIM);
   }
 
 }

--- a/application/user-application/src/main/java/com/modoo/application/user/auth/jwt/TokenManager.java
+++ b/application/user-application/src/main/java/com/modoo/application/user/auth/jwt/TokenManager.java
@@ -1,12 +1,14 @@
 package com.modoo.application.user.auth.jwt;
 
+import com.google.common.collect.Maps;
 import com.modoo.application.user.auth.config.JwtProperties;
+import com.modoo.common.exception.AuthErrorCode;
 import com.modoo.domain.user.auth.aggregate.RefreshToken;
 import com.modoo.domain.user.auth.aggregate.vo.UserFamily;
 import com.modoo.domain.user.user.aggregate.User;
-import com.google.common.collect.Maps;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtClaimNames;
@@ -24,12 +26,10 @@ public class TokenManager {
   private final JwtDecoder jwtDecoder;
 
   public String createAccessToken(User user) {
-    Map<String, Object> claims = Maps.newHashMap();
+    String authority = user.getAuthority()
+        .getAuthority();
 
-    claims.put(USER_CLAIM, user.getId());
-    claims.put(AUTH_CLAIM, user.getAuthority());
-
-    return jwtIssuer.issue(claims, Duration.ofSeconds(jwtProperties.getExpiredAfter()));
+    return createAccessToken(user.getId(), authority);
   }
 
   public String createAccessToken(Long userId, String authority) {
@@ -42,11 +42,18 @@ public class TokenManager {
   }
 
   public RefreshToken createRefreshToken(User user, Integer family) {
-    return createRefreshToken(user.getId(), family, user.getAuthority()
-        .name());
+    return createRefreshToken(
+        user.getId(),
+        family,
+        user.getAuthority().getAuthority()
+    );
   }
 
   public RefreshToken createRefreshToken(Long userId, Integer family, String authority) {
+    if (Objects.isNull(authority) || authority.isBlank()) {
+      throw new IllegalArgumentException(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
+    }
+
     UserFamily userFamily = UserFamily.builder()
         .userId(userId)
         .family(family)
@@ -54,6 +61,7 @@ public class TokenManager {
     Map<String, Object> claim = Maps.newHashMap();
     claim.put(JwtClaimNames.SUB, userFamily.getUserFamilyValue());
     claim.put(AUTH_CLAIM, authority);
+
     String tokenValue = jwtIssuer.issue(claim, Duration.ZERO);
 
     return RefreshToken.builder()
@@ -63,17 +71,25 @@ public class TokenManager {
   }
 
   public UserFamily decodeRefreshToken(String refreshToken) {
-    Jwt jwt = jwtDecoder.decode(refreshToken);
+    Jwt jwt = decode(refreshToken);
+    String authority = jwt.getClaimAsString(AUTH_CLAIM);
+
+    if (Objects.isNull(authority) || authority.isBlank()) {
+      throw new UnsupportedOperationException(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
+    }
 
     return UserFamily.builderWithString()
         .userFamilyValue(jwt.getSubject())
+        .authority(authority)
         .buildWithString();
   }
 
-  public String decodeRefreshTokenAuthority(String refreshToken) {
-    Jwt jwt = jwtDecoder.decode(refreshToken);
-
-    return jwt.getClaimAsString(AUTH_CLAIM);
+  private Jwt decode(String jwt) {
+    try {
+      return jwtDecoder.decode(jwt);
+    } catch (RuntimeException e) {
+      throw new UnsupportedOperationException(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
+    }
   }
 
 }

--- a/application/user-application/src/main/java/com/modoo/application/user/auth/jwt/TokenManager.java
+++ b/application/user-application/src/main/java/com/modoo/application/user/auth/jwt/TokenManager.java
@@ -43,7 +43,7 @@ public class TokenManager {
     String tokenValue = jwtIssuer.issue(claim, Duration.ZERO);
 
     return RefreshToken.builder()
-        .tokenValue(tokenValue)
+        .currentToken(tokenValue)
         .userFamily(userFamily)
         .build();
   }

--- a/application/user-application/src/main/java/com/modoo/application/user/auth/service/TokenRefreshService.java
+++ b/application/user-application/src/main/java/com/modoo/application/user/auth/service/TokenRefreshService.java
@@ -14,8 +14,6 @@ import com.modoo.domain.user.auth.aggregate.vo.UserFamily;
 import com.modoo.domain.user.user.aggregate.User;
 import java.time.LocalDateTime;
 import java.util.MissingResourceException;
-import java.util.Objects;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,21 +29,22 @@ public class TokenRefreshService implements TokenRefreshUseCase {
 
   @Override
   public TokenResponse refresh(TokenRefreshRequest request) {
-    String requestRefreshToken = request.refreshToken();
-    UserFamily decoded = decodeOrThrowUnauthorized(requestRefreshToken);
-    String authority = decodeAuthorityOrThrowUnauthorized(requestRefreshToken);
-    String accessToken = tokenManager.createAccessToken(decoded.getUserId(), authority);
+    UserFamily decoded = tokenManager.decodeRefreshToken(request.refreshToken());
+    String accessToken = tokenManager.createAccessToken(
+        decoded.getUserId(),
+        decoded.getAuthority()
+    );
     RefreshToken newRefreshToken = tokenManager.createRefreshToken(
         decoded.getUserId(),
         decoded.getFamily(),
-        authority
+        decoded.getAuthority()
     );
     LocalDateTime now = LocalDateTime.now();
 
     long updated = tokenManipulationPort.rotateIfCurrentMatches(
         decoded.getUserId(),
         decoded.getFamily(),
-        requestRefreshToken,
+        request.refreshToken(),
         newRefreshToken.getTokenValue(),
         now
     );
@@ -54,27 +53,27 @@ public class TokenRefreshService implements TokenRefreshUseCase {
       return new TokenResponse(accessToken, newRefreshToken.getTokenValue());
     }
 
-    userLoaderPort.loadFullUser(decoded.getUserId())
+    User user = userLoaderPort.loadFullUser(decoded.getUserId())
         .orElseThrow(() -> new MissingResourceException(
             AuthErrorCode.USER_NOT_FOUND.getCodeName(),
             User.class.getCanonicalName(),
             String.valueOf(decoded.getUserId())
         ));
 
-    Optional<RefreshToken> found = tokenLoaderPort.loadOneByUserFamily(
-        decoded.getUserId(),
-        decoded.getFamily()
-    );
+    RefreshToken saved = tokenLoaderPort.loadOneByUserFamily(
+            user.getId(),
+            decoded.getFamily()
+        )
+        .orElseThrow(() -> new MissingResourceException(
+            AuthErrorCode.REFRESH_TOKEN_NOT_FOUND.getCodeName(),
+            RefreshToken.class.getCanonicalName(),
+            decoded.getUserFamilyValue()
+        ));
 
-    RefreshToken saved = found.orElseThrow(() -> new MissingResourceException(
-        AuthErrorCode.REFRESH_TOKEN_NOT_FOUND.getCodeName(),
-        RefreshToken.class.getCanonicalName(),
-        decoded.getUserFamilyValue()
-    ));
-
-    if (!saved.hasSamePreviousToken(requestRefreshToken)) {
+    if (!saved.hasSamePreviousToken(request.refreshToken())) {
       tokenManipulationPort.deleteByUserFamily(decoded.getUserId(), decoded.getFamily());
-      throw new SecurityException(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
+
+      throw new SecurityException(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
     }
 
     if (saved.isWithinGracePeriod(now)) {
@@ -82,29 +81,7 @@ public class TokenRefreshService implements TokenRefreshUseCase {
     }
 
     tokenManipulationPort.deleteByUserFamily(decoded.getUserId(), decoded.getFamily());
-    throw new SecurityException(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
-  }
-
-  private UserFamily decodeOrThrowUnauthorized(String refreshToken) {
-    try {
-      return tokenManager.decodeRefreshToken(refreshToken);
-    } catch (RuntimeException e) {
-      throw new UnsupportedOperationException(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
-    }
-  }
-
-  private String decodeAuthorityOrThrowUnauthorized(String refreshToken) {
-    try {
-      String authority = tokenManager.decodeRefreshTokenAuthority(refreshToken);
-
-      if (Objects.isNull(authority)) {
-        throw new UnsupportedOperationException(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
-      }
-
-      return authority;
-    } catch (RuntimeException e) {
-      throw new UnsupportedOperationException(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
-    }
+    throw new SecurityException(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
   }
 
 }

--- a/application/user-application/src/main/java/com/modoo/application/user/auth/service/TokenRefreshService.java
+++ b/application/user-application/src/main/java/com/modoo/application/user/auth/service/TokenRefreshService.java
@@ -14,6 +14,7 @@ import com.modoo.domain.user.auth.aggregate.vo.UserFamily;
 import com.modoo.domain.user.user.aggregate.User;
 import java.time.LocalDateTime;
 import java.util.MissingResourceException;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,32 +31,35 @@ public class TokenRefreshService implements TokenRefreshUseCase {
 
   @Override
   public TokenResponse refresh(TokenRefreshRequest request) {
-    UserFamily decoded = decodeOrThrowUnauthorized(request.refreshToken());
+    String refreshToken = request.refreshToken();
+    UserFamily decoded = decodeOrThrowUnauthorized(refreshToken);
+    String authority = decodeAuthorityOrThrowUnauthorized(refreshToken);
+    String accessToken = tokenManager.createAccessToken(decoded.getUserId(), authority);
     RefreshToken newRefreshToken = tokenManager.createRefreshToken(
         decoded.getUserId(),
-        decoded.getFamily()
+        decoded.getFamily(),
+        authority
     );
     LocalDateTime now = LocalDateTime.now();
 
     long updated = tokenManipulationPort.rotateIfCurrentMatches(
         decoded.getUserId(),
         decoded.getFamily(),
-        request.refreshToken(),
+        refreshToken,
         newRefreshToken.getTokenValue(),
         now
     );
 
-    User user = userLoaderPort.loadFullUser(decoded.getUserId())
+    if (updated == 1L) {
+      return new TokenResponse(accessToken, newRefreshToken.getTokenValue());
+    }
+
+    userLoaderPort.loadFullUser(decoded.getUserId())
         .orElseThrow(() -> new MissingResourceException(
             AuthErrorCode.USER_NOT_FOUND.getCodeName(),
             User.class.getCanonicalName(),
             String.valueOf(decoded.getUserId())
         ));
-    String accessToken = tokenManager.createAccessToken(user);
-
-    if (updated == 1L) {
-      return new TokenResponse(accessToken, newRefreshToken.getTokenValue());
-    }
 
     Optional<RefreshToken> found = tokenLoaderPort.loadOneByUserFamily(
         decoded.getUserId(),
@@ -68,7 +72,7 @@ public class TokenRefreshService implements TokenRefreshUseCase {
         decoded.getUserFamilyValue()
     ));
 
-    if (!saved.hasSamePreviousToken(request.refreshToken())) {
+    if (!saved.hasSamePreviousToken(refreshToken)) {
       tokenManipulationPort.deleteByUserFamily(decoded.getUserId(), decoded.getFamily());
       throw new SecurityException(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
     }
@@ -84,6 +88,20 @@ public class TokenRefreshService implements TokenRefreshUseCase {
   private UserFamily decodeOrThrowUnauthorized(String refreshToken) {
     try {
       return tokenManager.decodeRefreshToken(refreshToken);
+    } catch (RuntimeException e) {
+      throw new UnsupportedOperationException(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
+    }
+  }
+
+  private String decodeAuthorityOrThrowUnauthorized(String refreshToken) {
+    try {
+      String authority = tokenManager.decodeRefreshTokenAuthority(refreshToken);
+
+      if (Objects.isNull(authority)) {
+        throw new UnsupportedOperationException(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
+      }
+
+      return authority;
     } catch (RuntimeException e) {
       throw new UnsupportedOperationException(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
     }

--- a/application/user-application/src/main/java/com/modoo/application/user/auth/service/TokenRefreshService.java
+++ b/application/user-application/src/main/java/com/modoo/application/user/auth/service/TokenRefreshService.java
@@ -27,19 +27,14 @@ public class TokenRefreshService implements TokenRefreshUseCase {
   private final TokenManipulationPort tokenManipulationPort;
   private final TokenManager tokenManager;
   private final UserLoaderPort userLoaderPort;
-  private static final long DUPLICATED_REQUEST_GRACE_MINUTES = 3L;
 
   @Override
   public TokenResponse refresh(TokenRefreshRequest request) {
     UserFamily decoded = decodeOrThrowUnauthorized(request.refreshToken());
-    User user = userLoaderPort.loadFullUser(decoded.getUserId())
-        .orElseThrow(() -> new MissingResourceException(
-            AuthErrorCode.USER_NOT_FOUND.getCodeName(),
-            User.class.getCanonicalName(),
-            String.valueOf(decoded.getUserId())
-        ));
-    String accessToken = tokenManager.createAccessToken(user);
-    RefreshToken newRefreshToken = tokenManager.createRefreshToken(user, decoded.getFamily());
+    RefreshToken newRefreshToken = tokenManager.createRefreshToken(
+        decoded.getUserId(),
+        decoded.getFamily()
+    );
     LocalDateTime now = LocalDateTime.now();
 
     long updated = tokenManipulationPort.rotateIfCurrentMatches(
@@ -49,6 +44,14 @@ public class TokenRefreshService implements TokenRefreshUseCase {
         newRefreshToken.getTokenValue(),
         now
     );
+
+    User user = userLoaderPort.loadFullUser(decoded.getUserId())
+        .orElseThrow(() -> new MissingResourceException(
+            AuthErrorCode.USER_NOT_FOUND.getCodeName(),
+            User.class.getCanonicalName(),
+            String.valueOf(decoded.getUserId())
+        ));
+    String accessToken = tokenManager.createAccessToken(user);
 
     if (updated == 1L) {
       return new TokenResponse(accessToken, newRefreshToken.getTokenValue());
@@ -70,7 +73,7 @@ public class TokenRefreshService implements TokenRefreshUseCase {
       throw new SecurityException(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
     }
 
-    if (saved.isRefreshedWithin(now, DUPLICATED_REQUEST_GRACE_MINUTES)) {
+    if (saved.isWithinGracePeriod(now)) {
       return new TokenResponse(accessToken, saved.getCurrentToken());
     }
 

--- a/application/user-application/src/main/java/com/modoo/application/user/auth/service/TokenRefreshService.java
+++ b/application/user-application/src/main/java/com/modoo/application/user/auth/service/TokenRefreshService.java
@@ -31,9 +31,9 @@ public class TokenRefreshService implements TokenRefreshUseCase {
 
   @Override
   public TokenResponse refresh(TokenRefreshRequest request) {
-    String refreshToken = request.refreshToken();
-    UserFamily decoded = decodeOrThrowUnauthorized(refreshToken);
-    String authority = decodeAuthorityOrThrowUnauthorized(refreshToken);
+    String requestRefreshToken = request.refreshToken();
+    UserFamily decoded = decodeOrThrowUnauthorized(requestRefreshToken);
+    String authority = decodeAuthorityOrThrowUnauthorized(requestRefreshToken);
     String accessToken = tokenManager.createAccessToken(decoded.getUserId(), authority);
     RefreshToken newRefreshToken = tokenManager.createRefreshToken(
         decoded.getUserId(),
@@ -45,7 +45,7 @@ public class TokenRefreshService implements TokenRefreshUseCase {
     long updated = tokenManipulationPort.rotateIfCurrentMatches(
         decoded.getUserId(),
         decoded.getFamily(),
-        refreshToken,
+        requestRefreshToken,
         newRefreshToken.getTokenValue(),
         now
     );
@@ -72,7 +72,7 @@ public class TokenRefreshService implements TokenRefreshUseCase {
         decoded.getUserFamilyValue()
     ));
 
-    if (!saved.hasSamePreviousToken(refreshToken)) {
+    if (!saved.hasSamePreviousToken(requestRefreshToken)) {
       tokenManipulationPort.deleteByUserFamily(decoded.getUserId(), decoded.getFamily());
       throw new SecurityException(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
     }

--- a/application/user-application/src/main/java/com/modoo/application/user/auth/service/TokenRefreshService.java
+++ b/application/user-application/src/main/java/com/modoo/application/user/auth/service/TokenRefreshService.java
@@ -12,70 +12,76 @@ import com.modoo.common.exception.AuthErrorCode;
 import com.modoo.domain.user.auth.aggregate.RefreshToken;
 import com.modoo.domain.user.auth.aggregate.vo.UserFamily;
 import com.modoo.domain.user.user.aggregate.User;
-import java.util.List;
+import java.time.LocalDateTime;
 import java.util.MissingResourceException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
-@Transactional(noRollbackFor = UnsupportedOperationException.class)
+@Transactional(noRollbackFor = {UnsupportedOperationException.class, SecurityException.class})
 public class TokenRefreshService implements TokenRefreshUseCase {
 
   private final TokenLoaderPort tokenLoaderPort;
   private final TokenManipulationPort tokenManipulationPort;
   private final TokenManager tokenManager;
   private final UserLoaderPort userLoaderPort;
+  private static final long DUPLICATED_REQUEST_GRACE_MINUTES = 3L;
 
   @Override
   public TokenResponse refresh(TokenRefreshRequest request) {
-    List<RefreshToken> tokenFamily = getTokenFamilyOf(request.refreshToken());
-    RefreshToken currentRefreshToken = tokenFamily.stream()
-        .filter(token -> token.hasSameTokenValue(request.refreshToken()))
-        .findFirst()
-        .orElseThrow(() -> new UnsupportedOperationException(
-            AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName()
-        ));
-
-    validateNotUsed(tokenFamily, currentRefreshToken);
-
-    User user = userLoaderPort.loadFullUser(currentRefreshToken.getUserId())
+    UserFamily decoded = decodeOrThrowUnauthorized(request.refreshToken());
+    User user = userLoaderPort.loadFullUser(decoded.getUserId())
         .orElseThrow(() -> new MissingResourceException(
             AuthErrorCode.USER_NOT_FOUND.getCodeName(),
             User.class.getCanonicalName(),
-            String.valueOf(currentRefreshToken.getUserId())
+            String.valueOf(decoded.getUserId())
         ));
-
     String accessToken = tokenManager.createAccessToken(user);
-    RefreshToken newRefreshToken = tokenManager.createRefreshToken(
-        user,
-        currentRefreshToken.getFamily()
+    RefreshToken newRefreshToken = tokenManager.createRefreshToken(user, decoded.getFamily());
+    LocalDateTime now = LocalDateTime.now();
+
+    long updated = tokenManipulationPort.rotateIfCurrentMatches(
+        decoded.getUserId(),
+        decoded.getFamily(),
+        request.refreshToken(),
+        newRefreshToken.getTokenValue(),
+        now
     );
 
-    tokenManipulationPort.save(newRefreshToken);
-
-    return new TokenResponse(accessToken, newRefreshToken.getTokenValue());
-  }
-
-  private List<RefreshToken> getTokenFamilyOf(String refreshToken) {
-    UserFamily decoded = tokenManager.decodeRefreshToken(refreshToken);
-
-    return tokenLoaderPort.loadByUserFamily(decoded.getUserId(), decoded.getFamily());
-  }
-
-  private void validateNotUsed(List<RefreshToken> tokenFamily, RefreshToken refreshToken) {
-    if (tokenFamily.size() == 1) {
-      return;
+    if (updated == 1L) {
+      return new TokenResponse(accessToken, newRefreshToken.getTokenValue());
     }
 
-    Long mostRecent = tokenFamily.stream()
-        .map(RefreshToken::getId)
-        .findFirst()
-        .get();
+    Optional<RefreshToken> found = tokenLoaderPort.loadOneByUserFamily(
+        decoded.getUserId(),
+        decoded.getFamily()
+    );
 
-    if (!refreshToken.hasSameId(mostRecent)) {
-      tokenManipulationPort.deleteAllFamily(tokenFamily);
+    RefreshToken saved = found.orElseThrow(() -> new MissingResourceException(
+        AuthErrorCode.REFRESH_TOKEN_NOT_FOUND.getCodeName(),
+        RefreshToken.class.getCanonicalName(),
+        decoded.getUserFamilyValue()
+    ));
 
+    if (!saved.hasSamePreviousToken(request.refreshToken())) {
+      tokenManipulationPort.deleteByUserFamily(decoded.getUserId(), decoded.getFamily());
+      throw new SecurityException(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
+    }
+
+    if (saved.isRefreshedWithin(now, DUPLICATED_REQUEST_GRACE_MINUTES)) {
+      return new TokenResponse(accessToken, saved.getCurrentToken());
+    }
+
+    tokenManipulationPort.deleteByUserFamily(decoded.getUserId(), decoded.getFamily());
+    throw new SecurityException(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
+  }
+
+  private UserFamily decodeOrThrowUnauthorized(String refreshToken) {
+    try {
+      return tokenManager.decodeRefreshToken(refreshToken);
+    } catch (RuntimeException e) {
       throw new UnsupportedOperationException(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
     }
   }

--- a/application/user-application/src/test/java/com/modoo/application/user/auth/jwt/JwtIssuerTest.java
+++ b/application/user-application/src/test/java/com/modoo/application/user/auth/jwt/JwtIssuerTest.java
@@ -1,10 +1,10 @@
 package com.modoo.application.user.auth.jwt;
 
+import com.google.common.collect.Maps;
 import com.modoo.application.user.auth.config.JwtConfig;
 import com.modoo.application.user.auth.config.TestJwtConfig;
 import com.modoo.common.dto.Authority;
 import com.modoo.fixture.UserFixture;
-import com.google.common.collect.Maps;
 import java.time.Duration;
 import java.util.Map;
 import org.assertj.core.api.Assertions;

--- a/application/user-application/src/test/java/com/modoo/application/user/auth/jwt/TokenManagerTest.java
+++ b/application/user-application/src/test/java/com/modoo/application/user/auth/jwt/TokenManagerTest.java
@@ -1,14 +1,19 @@
 package com.modoo.application.user.auth.jwt;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import com.modoo.application.user.auth.config.JwtConfig;
 import com.modoo.application.user.auth.config.TestJwtConfig;
+import com.modoo.common.exception.AuthErrorCode;
 import com.modoo.domain.user.auth.aggregate.RefreshToken;
 import com.modoo.domain.user.auth.aggregate.vo.UserFamily;
 import com.modoo.domain.user.user.aggregate.User;
 import com.modoo.fixture.UserFixture;
+import java.time.Duration;
+import java.util.Collections;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -31,15 +36,16 @@ class TokenManagerTest {
   @Autowired
   JwtDecoder jwtDecoder;
 
+  @Autowired
+  JwtIssuer jwtIssuer;
+
   User user;
   int family;
-  String expectedToken;
 
   @BeforeEach
   void setUp() {
     user = UserFixture.createRandomUserWithId();
     family = UserFixture.getRandomPositive();
-    expectedToken = UserFixture.getRandomSentenceWithMax(30);
   }
 
   @Test
@@ -52,8 +58,13 @@ class TokenManagerTest {
     // then
     Long userClaim = jwtDecoder.decode(accessToken)
         .getClaim("user");
+    String authClaim = jwtDecoder.decode(accessToken)
+        .getClaimAsString("auth");
+
     Assertions.assertThat(userClaim)
         .isEqualTo(user.getId());
+    Assertions.assertThat(authClaim)
+        .isEqualTo(user.getAuthority().getAuthority());
   }
 
   @Test
@@ -79,6 +90,40 @@ class TokenManagerTest {
     // then
     assertThat(actual.getUserId()).isEqualTo(user.getId());
     assertThat(actual.getFamily()).isEqualTo(family);
+    assertThat(actual.getAuthority()).isEqualTo(user.getAuthority().getAuthority());
+  }
+
+  @Test
+  void 리프레시_토큰이_유효하지_않으면_해독을_실패한다() {
+    // given
+    String invalidRefreshToken = UserFixture.getRandomSentenceWithMax(20);
+
+    // when
+    ThrowingCallable decode = () ->
+        tokenManager.decodeRefreshToken(invalidRefreshToken);
+
+    // then
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+        .isThrownBy(decode)
+        .withMessage(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
+  }
+
+  @Test
+  void 권한_claim이_없는_리프레시_토큰이면_해독을_실패한다() {
+    // given
+    String refreshTokenWithoutAuthority = jwtIssuer.issue(
+        Collections.singletonMap("sub", user.getId() + "-" + family),
+        Duration.ZERO
+    );
+
+    // when
+    ThrowingCallable decode = () ->
+        tokenManager.decodeRefreshToken(refreshTokenWithoutAuthority);
+
+    // then
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+        .isThrownBy(decode)
+        .withMessage(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
   }
 
 }

--- a/application/user-application/src/test/java/com/modoo/application/user/auth/service/LogoutServiceTest.java
+++ b/application/user-application/src/test/java/com/modoo/application/user/auth/service/LogoutServiceTest.java
@@ -53,10 +53,8 @@ class LogoutServiceTest {
   void 로그아웃을_성공하면_리프레시_토큰_패밀리를_삭제한다() {
     // given
     RefreshToken refreshToken = tokenManager.createRefreshToken(loginUser, family);
-    RefreshToken anotherRefreshToken = tokenManager.createRefreshToken(loginUser, family);
 
     tokenManipulationPort.save(refreshToken);
-    tokenManipulationPort.save(anotherRefreshToken);
 
     // when
     logoutService.logout(loginUser.getId(), refreshToken.getTokenValue());

--- a/application/user-application/src/test/java/com/modoo/application/user/auth/service/TokenRefreshServiceTest.java
+++ b/application/user-application/src/test/java/com/modoo/application/user/auth/service/TokenRefreshServiceTest.java
@@ -163,12 +163,14 @@ class TokenRefreshServiceTest {
   }
 
   @Test
-  void 이전_토큰이지만_삼분이_지났으면_토큰을_삭제하고_토큰_갱신을_실패한다() {
+  void 이전_토큰이지만_삼분이_지났으면_토큰을_삭제하고_토큰_갱신을_실패한다() throws InterruptedException {
     // given
     RefreshToken oldRefreshToken = tokenManager.createRefreshToken(user, family);
     tokenManipulationPort.save(oldRefreshToken);
 
+    sleep(1000);
     RefreshToken newRefreshToken = tokenManager.createRefreshToken(user, family);
+    Assertions.assertThat(newRefreshToken.getTokenValue()).isNotEqualTo(oldRefreshToken.getTokenValue());
     tokenManipulationPort.rotateIfCurrentMatches(
         user.getId(),
         family,

--- a/application/user-application/src/test/java/com/modoo/application/user/auth/service/TokenRefreshServiceTest.java
+++ b/application/user-application/src/test/java/com/modoo/application/user/auth/service/TokenRefreshServiceTest.java
@@ -13,6 +13,7 @@ import com.modoo.domain.user.auth.aggregate.RefreshToken;
 import com.modoo.domain.user.auth.aggregate.vo.UserFamily;
 import com.modoo.domain.user.user.aggregate.User;
 import com.modoo.fixture.UserFixture;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.MissingResourceException;
 import org.assertj.core.api.Assertions;
@@ -55,12 +56,10 @@ class TokenRefreshServiceTest {
   }
 
   @Test
-  void 토큰_갱신을_성공한다() {
+  void 업데이트_성공으로_토큰_갱신을_조기_응답한다() {
     // given
     RefreshToken refreshToken = tokenManager.createRefreshToken(user, family);
-
     tokenManipulationPort.save(refreshToken);
-
     TokenRefreshRequest request = new TokenRefreshRequest(refreshToken.getTokenValue());
 
     // when
@@ -68,68 +67,51 @@ class TokenRefreshServiceTest {
 
     // then
     UserFamily decoded = tokenManager.decodeRefreshToken(actual.refreshToken());
-    List<RefreshToken> refreshTokens = tokenLoaderPort.loadByUserFamily(
-        decoded.getUserId(),
-        decoded.getFamily()
-    );
+    RefreshToken saved = tokenLoaderPort.loadOneByUserFamily(decoded.getUserId(), decoded.getFamily())
+        .orElseThrow();
 
-    Assertions.assertThat(refreshTokens)
-        .anyMatch(token -> token.hasSameTokenValue(actual.refreshToken()));
+    Assertions.assertThat(saved.getCurrentToken()).isEqualTo(actual.refreshToken());
+    Assertions.assertThat(saved.getPreviousToken()).isEqualTo(refreshToken.getTokenValue());
   }
 
   @Test
-  void 저장된_토큰이_없으면_토큰_갱신을_실패한다() {
-    // given
-    RefreshToken refreshToken = tokenManager.createRefreshToken(user, family);
-    TokenRefreshRequest request = new TokenRefreshRequest(refreshToken.getTokenValue());
-
-    // when
-    ThrowingCallable refresh = () -> tokenRefreshService.refresh(request);
-
-    // then
-    Assertions.assertThatExceptionOfType(UnsupportedOperationException.class)
-        .isThrownBy(refresh)
-        .withMessage(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
-  }
-
-  @Test
-  void 이미_사용한_적이_있는_토큰이라면_갱신을_실패하고_같은_사용자와_패밀리의_토큰을_모두_삭제한다() throws InterruptedException {
+  void 업데이트가_실패해도_삼분_이내면_현재_토큰을_응답한다() {
     // given
     RefreshToken oldRefreshToken = tokenManager.createRefreshToken(user, family);
-
     tokenManipulationPort.save(oldRefreshToken);
 
-    sleep(1000);
-
-    RefreshToken newRefreshToken = tokenManager.createRefreshToken(user, family);
-
-    tokenManipulationPort.save(newRefreshToken);
+    TokenResponse refreshed = tokenRefreshService.refresh(
+        new TokenRefreshRequest(oldRefreshToken.getTokenValue())
+    );
 
     TokenRefreshRequest request = new TokenRefreshRequest(oldRefreshToken.getTokenValue());
 
     // when
+    TokenResponse actual = tokenRefreshService.refresh(request);
+
+    // then
+    Assertions.assertThat(actual.refreshToken()).isEqualTo(refreshed.refreshToken());
+  }
+
+  @Test
+  void 리프레시_토큰_디코드에_실패하면_예외를_던진다() {
+    // given
+    TokenRefreshRequest request = new TokenRefreshRequest("invalid-refresh-token");
+
+    // when
     ThrowingCallable refresh = () -> tokenRefreshService.refresh(request);
 
     // then
     Assertions.assertThatExceptionOfType(UnsupportedOperationException.class)
         .isThrownBy(refresh)
         .withMessage(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
-
-    List<RefreshToken> refreshTokens = tokenLoaderPort.loadByUserFamily(
-        oldRefreshToken.getUserId(), oldRefreshToken.getFamily());
-
-    Assertions.assertThat(refreshTokens)
-        .isEmpty();
   }
 
   @Test
-  void 토큰의_사용자를_찾을_수_없으면_토큰_갱신을_실패한다() {
+  void 사용자_정보가_없으면_토큰_갱신을_실패한다() {
     // given
-    User wrongUser = UserFixture.createRandomUserWithId();
-    RefreshToken refreshToken = tokenManager.createRefreshToken(wrongUser, family);
-
-    tokenManipulationPort.save(refreshToken);
-
+    User deletedUser = UserFixture.createRandomUserWithId();
+    RefreshToken refreshToken = tokenManager.createRefreshToken(deletedUser, family);
     TokenRefreshRequest request = new TokenRefreshRequest(refreshToken.getTokenValue());
 
     // when
@@ -139,6 +121,74 @@ class TokenRefreshServiceTest {
     Assertions.assertThatExceptionOfType(MissingResourceException.class)
         .isThrownBy(refresh)
         .withMessage(AuthErrorCode.USER_NOT_FOUND.getCodeName());
+  }
+
+  @Test
+  void 사용자와_패밀리로_토큰을_찾지_못하면_토큰_갱신을_실패한다() {
+    // given
+    RefreshToken refreshToken = tokenManager.createRefreshToken(user, family);
+    TokenRefreshRequest request = new TokenRefreshRequest(refreshToken.getTokenValue());
+
+    // when
+    ThrowingCallable refresh = () -> tokenRefreshService.refresh(request);
+
+    // then
+    Assertions.assertThatExceptionOfType(MissingResourceException.class)
+        .isThrownBy(refresh)
+        .withMessage(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND.getCodeName());
+  }
+
+  @Test
+  void 이전_토큰과_다르면_토큰을_삭제하고_토큰_갱신을_실패한다() throws InterruptedException {
+    // given
+    RefreshToken oldRefreshToken = tokenManager.createRefreshToken(user, family);
+    tokenManipulationPort.save(oldRefreshToken);
+
+    tokenRefreshService.refresh(new TokenRefreshRequest(oldRefreshToken.getTokenValue()));
+
+    sleep(1000);
+    RefreshToken wrongRefreshToken = tokenManager.createRefreshToken(user, family);
+    TokenRefreshRequest request = new TokenRefreshRequest(wrongRefreshToken.getTokenValue());
+
+    // when
+    ThrowingCallable refresh = () -> tokenRefreshService.refresh(request);
+
+    // then
+    Assertions.assertThatExceptionOfType(SecurityException.class)
+        .isThrownBy(refresh)
+        .withMessage(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
+
+    List<RefreshToken> refreshTokens = tokenLoaderPort.loadByUserFamily(user.getId(), family);
+    Assertions.assertThat(refreshTokens).isEmpty();
+  }
+
+  @Test
+  void 이전_토큰이지만_삼분이_지났으면_토큰을_삭제하고_토큰_갱신을_실패한다() {
+    // given
+    RefreshToken oldRefreshToken = tokenManager.createRefreshToken(user, family);
+    tokenManipulationPort.save(oldRefreshToken);
+
+    RefreshToken newRefreshToken = tokenManager.createRefreshToken(user, family);
+    tokenManipulationPort.rotateIfCurrentMatches(
+        user.getId(),
+        family,
+        oldRefreshToken.getTokenValue(),
+        newRefreshToken.getTokenValue(),
+        LocalDateTime.now().minusMinutes(4)
+    );
+
+    TokenRefreshRequest request = new TokenRefreshRequest(oldRefreshToken.getTokenValue());
+
+    // when
+    ThrowingCallable refresh = () -> tokenRefreshService.refresh(request);
+
+    // then
+    Assertions.assertThatExceptionOfType(SecurityException.class)
+        .isThrownBy(refresh)
+        .withMessage(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
+
+    List<RefreshToken> refreshTokens = tokenLoaderPort.loadByUserFamily(user.getId(), family);
+    Assertions.assertThat(refreshTokens).isEmpty();
   }
 
 }

--- a/application/user-application/src/test/java/com/modoo/application/user/auth/service/TokenRefreshServiceTest.java
+++ b/application/user-application/src/test/java/com/modoo/application/user/auth/service/TokenRefreshServiceTest.java
@@ -67,11 +67,16 @@ class TokenRefreshServiceTest {
 
     // then
     UserFamily decoded = tokenManager.decodeRefreshToken(actual.refreshToken());
-    RefreshToken saved = tokenLoaderPort.loadOneByUserFamily(decoded.getUserId(), decoded.getFamily())
+    RefreshToken saved = tokenLoaderPort.loadOneByUserFamily(
+            decoded.getUserId(),
+            decoded.getFamily()
+        )
         .orElseThrow();
 
-    Assertions.assertThat(saved.getCurrentToken()).isEqualTo(actual.refreshToken());
-    Assertions.assertThat(saved.getPreviousToken()).isEqualTo(refreshToken.getTokenValue());
+    Assertions.assertThat(actual.accessToken())
+        .isNotBlank();
+    Assertions.assertThat(saved.getCurrentToken())
+        .isEqualTo(actual.refreshToken());
   }
 
   @Test
@@ -90,7 +95,8 @@ class TokenRefreshServiceTest {
     TokenResponse actual = tokenRefreshService.refresh(request);
 
     // then
-    Assertions.assertThat(actual.refreshToken()).isEqualTo(refreshed.refreshToken());
+    Assertions.assertThat(actual.refreshToken())
+        .isEqualTo(refreshed.refreshToken());
   }
 
   @Test
@@ -104,7 +110,7 @@ class TokenRefreshServiceTest {
     // then
     Assertions.assertThatExceptionOfType(UnsupportedOperationException.class)
         .isThrownBy(refresh)
-        .withMessage(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
+        .withMessage(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
   }
 
   @Test
@@ -156,10 +162,11 @@ class TokenRefreshServiceTest {
     // then
     Assertions.assertThatExceptionOfType(SecurityException.class)
         .isThrownBy(refresh)
-        .withMessage(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
+        .withMessage(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
 
     List<RefreshToken> refreshTokens = tokenLoaderPort.loadByUserFamily(user.getId(), family);
-    Assertions.assertThat(refreshTokens).isEmpty();
+    Assertions.assertThat(refreshTokens)
+        .isEmpty();
   }
 
   @Test
@@ -170,13 +177,15 @@ class TokenRefreshServiceTest {
 
     sleep(1000);
     RefreshToken newRefreshToken = tokenManager.createRefreshToken(user, family);
-    Assertions.assertThat(newRefreshToken.getTokenValue()).isNotEqualTo(oldRefreshToken.getTokenValue());
+    Assertions.assertThat(newRefreshToken.getTokenValue())
+        .isNotEqualTo(oldRefreshToken.getTokenValue());
     tokenManipulationPort.rotateIfCurrentMatches(
         user.getId(),
         family,
         oldRefreshToken.getTokenValue(),
         newRefreshToken.getTokenValue(),
-        LocalDateTime.now().minusMinutes(4)
+        LocalDateTime.now()
+            .minusMinutes(4)
     );
 
     TokenRefreshRequest request = new TokenRefreshRequest(oldRefreshToken.getTokenValue());
@@ -187,10 +196,11 @@ class TokenRefreshServiceTest {
     // then
     Assertions.assertThatExceptionOfType(SecurityException.class)
         .isThrownBy(refresh)
-        .withMessage(AuthErrorCode.INVALID_AUTHORITY.getCodeName());
+        .withMessage(AuthErrorCode.REFRESH_NOT_ALLOWED.getCodeName());
 
     List<RefreshToken> refreshTokens = tokenLoaderPort.loadByUserFamily(user.getId(), family);
-    Assertions.assertThat(refreshTokens).isEmpty();
+    Assertions.assertThat(refreshTokens)
+        .isEmpty();
   }
 
 }

--- a/bootstrap/bootstrap-gateway/src/main/resources/db/data/afterMigrate.sql
+++ b/bootstrap/bootstrap-gateway/src/main/resources/db/data/afterMigrate.sql
@@ -34,9 +34,12 @@ VALUES (2, '짜증난 강아지', 'irritatedpuppy30b6f3ed', null, null, 'ADMIN',
 # 투두 구글 계정
 
 -- REFRESH TOKEN
-INSERT INTO refresh_tokens(id, user_id, family, token_value, created_at, updated_at)
+INSERT INTO refresh_tokens(id, user_id, family, current_token, previous_token, refreshed_at,
+                           created_at, updated_at)
 VALUES (1, 1, 1,
         'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJtYXJjby1kZHVkdSIsInN1YiI6IjEtMSIsImlhdCI6MTcxNTkzMDAyOH0.ig76OI9bD2Da0-NsIgWoaM3rzewvm_Y0HUbjOjJUOG-gBZHk_k5CCrCSynRSZXwcttqdiwLSKhHYzj5zUUf8ZQ',
+        null,
+        '2024-05-17T16:13:48',
         '2024-05-17T16:13:48', '2024-05-17T16:13:48');
 
 -- AUTH PROVIDERS

--- a/bootstrap/bootstrap-gateway/src/main/resources/db/migration/V21__change_refresh_token_to_single_record.sql
+++ b/bootstrap/bootstrap-gateway/src/main/resources/db/migration/V21__change_refresh_token_to_single_record.sql
@@ -1,0 +1,8 @@
+DELETE FROM refresh_tokens;
+
+ALTER TABLE refresh_tokens
+    DROP COLUMN token_value,
+    ADD COLUMN current_token VARCHAR(255) NOT NULL,
+    ADD COLUMN previous_token VARCHAR(255) NULL,
+    ADD COLUMN refreshed_at TIMESTAMP NULL,
+    ADD CONSTRAINT uk_refresh_tokens_user_family UNIQUE (user_id, family);

--- a/common/src/main/java/com/modoo/common/exception/AuthErrorCode.java
+++ b/common/src/main/java/com/modoo/common/exception/AuthErrorCode.java
@@ -13,7 +13,8 @@ public enum AuthErrorCode implements ErrorCode {
   INVALID_USER_ID_FOR_REFRESH_TOKEN(5005, "리프레시 토큰의 사용자 아이디가 올바르지 않습니다."),
   INVALID_REFRESH_TOKEN_FAMILY(5006, "리프레시 토큰 패밀리가 올바르지 않습니다."),
   REFRESH_NOT_ALLOWED(5007, "잘못된 리프레시 토큰입니다. 갱신할 수 없습니다."),
-  USER_NOT_FOUND(5008, "토큰을 생성할 사용자를 찾을 수 없습니다.");
+  USER_NOT_FOUND(5008, "토큰을 생성할 사용자를 찾을 수 없습니다."),
+  REFRESH_TOKEN_NOT_FOUND(5009, "사용자와 패밀리에 해당하는 리프레시 토큰을 찾을 수 없습니다.");
 
   private final int code;
   private final String message;

--- a/docs/plans/refresh-token-single-record-implementation-plan.md
+++ b/docs/plans/refresh-token-single-record-implementation-plan.md
@@ -1,0 +1,148 @@
+# 리프레시 토큰 단일 레코드 전환 구현 플랜 (Fix: 리프레시 토큰 처리 방식 수정)
+
+## 1) 목표 및 요구사항 요약
+
+- `user_id + family` 조합당 refresh token 상태를 **1개 레코드**로 관리한다.
+- 스키마를 아래 필드 구조로 전환한다.
+  - `id`
+  - `user_id`
+  - `family`
+  - `current_token`
+  - `previous_token`
+  - `refreshed_at`
+- refresh 처리 로직을 CAS(Update-where-current-token) 방식으로 변경한다.
+- 실패 시 재검증 분기에서 404/403/200(3분 내 재응답) 규칙을 정확히 반영한다.
+- Flyway migration에서 구조 변경 + 기존 `refresh_tokens` 데이터 전체 삭제를 수행한다.
+
+## 2) 구현 전략
+
+### 2-1. 핵심 처리 흐름 (Token Refresh)
+
+1. 요청 RT decode 시도 (`TokenManager.decodeRefreshToken`)
+   - decode 실패 시 `401`.
+2. CAS update 1차 시도
+   - 조건: `user_id`, `family`, `current_token` 일치
+   - 성공(영향 row=1): 새 RT를 즉시 반환 (`200`).
+3. CAS update 실패(영향 row=0) 시 확인 로직
+   - user 미존재: `404`
+   - `user_id + family` 레코드 미존재: `404`
+   - 요청 RT != `previous_token`: 레코드 삭제 후 `403`
+   - 요청 RT == `previous_token` && `refreshed_at`이 현재 기준 3분 이내: 저장된 `current_token` 반환(`200`)
+   - 요청 RT == `previous_token` && 3분 초과: 레코드 삭제 후 `403`
+
+### 2-2. 도메인 모델링 방향
+
+- 기존 `RefreshToken`의 “다중 이력 리스트 기반” 비교를 제거하고, 단일 레코드 상태 전이 관점으로 단순화한다.
+- 객체지향 ask-and-tell을 위해 아래 성격의 도메인 행위를 도입한다.
+  - `canReissueWith(previousToken, now, gracePeriod)`
+  - `rotateTo(newToken, now)`
+  - `isPreviousToken(token)` / `isCurrentToken(token)`
+- 서비스는 “분기 orchestration”에 집중하고, 시간/토큰 비교 규칙은 가능한 한 도메인에 위임한다.
+
+### 2-3. 영속 계층 전략
+
+- CAS update는 Querydsl/JPA custom query로 구현하고 `updatedCount`를 반환한다.
+- `loadByUserFamily`의 반환 타입을 단일건 중심(`Optional<RefreshToken>`)으로 정리한다.
+- 삭제는 `deleteByUserFamily(userId, family)`를 재사용한다.
+
+## 3) 신규/변경 영향 클래스 및 패키지
+
+### 3-1. Domain (user-domain)
+
+- 패키지: `com.modoo.domain.user.auth.aggregate`
+  - **변경** `RefreshToken`
+    - 필드 변경: `tokenValue` 중심 구조 → `currentToken`, `previousToken`, `refreshedAt`
+    - 단일 레코드 정책에 맞는 상태 전이/검증 메서드 추가
+- 패키지: `domain/user-domain/src/test/java/com/modoo/domain/user/auth/aggregate`
+  - **변경** `RefreshTokenTest`
+    - 단일 레코드 회전/재사용 허용시간(3분) 관련 테스트로 재구성
+
+### 3-2. Application Common
+
+- 패키지: `com.modoo.application.common.port.auth.out`
+  - **변경** `TokenLoaderPort`
+    - `List<RefreshToken> loadByUserFamily(...)` → `Optional<RefreshToken> loadByUserFamily(...)` (또는 단건 조회 메서드 추가)
+  - **변경** `TokenManipulationPort`
+    - CAS update 전용 메서드 추가
+      - 예: `int rotateIfCurrentMatches(Long userId, int family, String expectedCurrent, String newToken, Instant now)`
+
+### 3-3. User Application
+
+- 패키지: `com.modoo.application.user.auth.service`
+  - **변경** `TokenRefreshService`
+    - 다중 토큰 목록 기반 로직 제거
+    - CAS 선시도 + 실패 시 확인 분기(404/403/200) 구현
+- 패키지: `com.modoo.application.user.auth.jwt`
+  - **변경 가능** `TokenManager`
+    - decode 실패를 `401`로 매핑하기 쉬운 예외 표준화 여부 검토
+- 패키지: `application/user-application/src/test/java/com/modoo/application/user/auth/service`
+  - **변경** `TokenRefreshServiceTest`
+    - 요구된 7개 케이스 모두 반영
+    - 테스트 메서드명 한국어, `//given //when //then`, 실패 케이스 `ThrowingCallable` 준수
+
+### 3-4. Infra (user-infra-mysql)
+
+- 패키지: `com.modoo.infra.mysql.user.auth.entiy`
+  - **변경** `RefreshTokenEntity`
+    - 컬럼 매핑 변경: `token_value` 제거, `current_token`, `previous_token`, `refreshed_at` 추가
+- 패키지: `com.modoo.infra.mysql.user.auth.repository`
+  - **변경** `RefreshTokenQueryRepository`
+    - CAS update 메서드 및 단건 조회 메서드 시그니처 반영
+  - **변경** `RefreshTokenQueryRepositoryImpl`
+    - CAS update 쿼리 구현
+    - 단건 조회/삭제 쿼리 정합성 점검
+- 패키지: `com.modoo.infra.mysql.user.auth.adapter`
+  - **변경** `AuthPersistenceAdpater`
+    - 신규 port 메서드 구현 및 단건 조회로직 반영
+
+### 3-5. Bootstrap / DB Migration
+
+- 패키지: `bootstrap/bootstrap-gateway/src/main/resources/db/migration`
+  - **신규** migration SQL
+    - `refresh_tokens` 컬럼 구조 변경
+    - `DELETE FROM refresh_tokens` 포함
+- 패키지: `bootstrap/bootstrap-gateway/src/main/resources/db/data`
+  - **변경 가능** `afterMigrate.sql`
+    - 샘플 데이터가 신규 스키마와 호환되도록 수정
+
+## 4) 상세 작업 순서
+
+1. Flyway migration 추가 (스키마 변경 + 기존 데이터 삭제)
+2. Domain `RefreshToken` 구조 및 행위 변경
+3. Port 인터페이스 변경 (`TokenLoaderPort`, `TokenManipulationPort`)
+4. Infra repository/adapter에 CAS update 및 단건 조회 반영
+5. `TokenRefreshService` 로직 교체 (CAS 선시도 + fallback 분기)
+6. 테스트 리팩터링/추가
+   - domain 테스트
+   - application 서비스 통합 테스트
+7. 회귀 확인
+   - 로그인/로그아웃/토큰발급 주요 시나리오 영향 점검
+
+## 5) 테스트 플랜
+
+- 사전: 신규 DDL이 있다면 `./gradlew :bootstrap:bootstrap-gateway:flywayMigrate` 실행
+- 애플리케이션 테스트 타겟
+  - `application/user-application`의 `TokenRefreshServiceTest`
+- 도메인 테스트 타겟
+  - `domain/user-domain`의 `RefreshTokenTest`
+- 필수 케이스
+  1. update 성공으로 early 응답 성공
+  2. update 실패 + 3분 이내 current_token 응답 성공
+  3. jwt decode 실패(401)
+  4. user 없음(404)
+  5. user+family 레코드 없음(404)
+  6. previous_token 불일치로 삭제 후 403
+  7. previous_token 일치이나 3분 경과로 삭제 후 403
+
+## 6) 리스크 및 확인 포인트
+
+- **동시성**: 동일 `user+family` 동시 refresh 요청에서 CAS로 원자성 보장 여부 확인
+- **인덱스/유니크 제약**: `user_id + family` 유니크 인덱스 추가 필요성 검토
+- **시간 기준**: `refreshed_at` 비교 시 DB 시간 vs 애플리케이션 시간 일관성 확보
+- **호환성**: 기존 `token_value` 참조 코드 누락 여부 전역 점검
+
+## 7) 완료 기준 (Definition of Done)
+
+- 단일 레코드 정책 및 상태 전이가 코드/DB/테스트에 일관되게 반영된다.
+- 명세된 7개 테스트 케이스가 모두 통과한다.
+- migration 적용 후 refresh token 관련 테이블/샘플 데이터가 정상 동작한다.

--- a/domain/user-domain/src/main/java/com/modoo/domain/user/auth/aggregate/RefreshToken.java
+++ b/domain/user-domain/src/main/java/com/modoo/domain/user/auth/aggregate/RefreshToken.java
@@ -1,6 +1,7 @@
 package com.modoo.domain.user.auth.aggregate;
 
 import com.modoo.domain.user.auth.aggregate.vo.UserFamily;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,10 +14,21 @@ public class RefreshToken {
 
   @Getter(AccessLevel.NONE)
   private final UserFamily userFamily;
-  private final String tokenValue;
+  private final String currentToken;
+  private final String previousToken;
+  private final LocalDateTime refreshedAt;
 
   @Builder
-  private RefreshToken(Long id, String tokenValue, UserFamily userFamily, Long userId, int family) {
+  private RefreshToken(
+      Long id,
+      String tokenValue,
+      String currentToken,
+      String previousToken,
+      LocalDateTime refreshedAt,
+      UserFamily userFamily,
+      Long userId,
+      int family
+  ) {
     this.id = id;
     this.userFamily = Objects.requireNonNullElseGet(
         userFamily,
@@ -25,7 +37,9 @@ public class RefreshToken {
             .family(family)
             .build()
     );
-    this.tokenValue = tokenValue;
+    this.currentToken = Objects.requireNonNullElse(currentToken, tokenValue);
+    this.previousToken = previousToken;
+    this.refreshedAt = refreshedAt;
   }
 
   public Long getUserId() {
@@ -41,7 +55,28 @@ public class RefreshToken {
   }
 
   public boolean hasSameTokenValue(String tokenValue) {
-    return this.tokenValue.equals(tokenValue);
+    return this.currentToken.equals(tokenValue);
+  }
+
+  public boolean hasSameCurrentToken(String tokenValue) {
+    return this.currentToken.equals(tokenValue);
+  }
+
+  public boolean hasSamePreviousToken(String tokenValue) {
+    return Objects.equals(this.previousToken, tokenValue);
+  }
+
+  public boolean isRefreshedWithin(LocalDateTime comparedAt, long minutes) {
+    if (Objects.isNull(refreshedAt)) {
+      return false;
+    }
+
+    return !refreshedAt.plusMinutes(minutes)
+        .isBefore(comparedAt);
+  }
+
+  public String getTokenValue() {
+    return currentToken;
   }
 
 }

--- a/domain/user-domain/src/main/java/com/modoo/domain/user/auth/aggregate/RefreshToken.java
+++ b/domain/user-domain/src/main/java/com/modoo/domain/user/auth/aggregate/RefreshToken.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 @Getter
 public class RefreshToken {
 
+  private static final long GRACE_PERIOD_MINUTES = 3L;
   private final Long id;
 
   @Getter(AccessLevel.NONE)
@@ -73,6 +74,10 @@ public class RefreshToken {
 
     return !refreshedAt.plusMinutes(minutes)
         .isBefore(comparedAt);
+  }
+
+  public boolean isWithinGracePeriod(LocalDateTime comparedAt) {
+    return isRefreshedWithin(comparedAt, GRACE_PERIOD_MINUTES);
   }
 
   public String getTokenValue() {

--- a/domain/user-domain/src/main/java/com/modoo/domain/user/auth/aggregate/vo/UserFamily.java
+++ b/domain/user-domain/src/main/java/com/modoo/domain/user/auth/aggregate/vo/UserFamily.java
@@ -12,9 +12,10 @@ public class UserFamily {
 
   private final Long userId;
   private final int family;
+  private final String authority;
 
   @Builder
-  private UserFamily(Long userId, int family) {
+  private UserFamily(Long userId, int family, String authority) {
     checkArgument(
         Objects.nonNull(userId),
         AuthErrorCode.INVALID_USER_ID_FOR_REFRESH_TOKEN.getCodeName()
@@ -22,13 +23,14 @@ public class UserFamily {
 
     this.userId = userId;
     this.family = family;
+    this.authority = authority;
   }
 
   @Builder(
       builderMethodName = "builderWithString",
       buildMethodName = "buildWithString"
   )
-  private UserFamily(String userFamilyValue) {
+  private UserFamily(String userFamilyValue, String authority) {
     String[] userFamily = userFamilyValue.split("-");
 
     checkArgument(
@@ -38,6 +40,7 @@ public class UserFamily {
 
     this.userId = getUserId(userFamily[0]);
     this.family = getFamily(userFamily[1]);
+    this.authority = authority;
   }
 
   public String getUserFamilyValue() {

--- a/domain/user-domain/src/test/java/com/modoo/domain/user/auth/aggregate/RefreshTokenTest.java
+++ b/domain/user-domain/src/test/java/com/modoo/domain/user/auth/aggregate/RefreshTokenTest.java
@@ -47,6 +47,23 @@ class RefreshTokenTest {
     }
 
     @Test
+    void 현재_토큰이_null이면_tokenValue를_현재_토큰으로_사용한다() {
+      // given
+
+      // when
+      RefreshToken refreshToken = RefreshToken.builder()
+          .userId(userId)
+          .family(family)
+          .tokenValue(tokenValue)
+          .currentToken(null)
+          .build();
+
+      // then
+      assertThat(refreshToken.getCurrentToken()).isEqualTo(tokenValue);
+      assertThat(refreshToken.getTokenValue()).isEqualTo(tokenValue);
+    }
+
+    @Test
     void 유저_패밀리_객체로_생성한다() {
       // given
       UserFamily userFamily = UserFamily.builder()
@@ -119,11 +136,58 @@ class RefreshTokenTest {
     }
 
     @Test
+    void 아이디가_같으면_true를_반환한다() {
+      // given
+      Long refreshTokenId = UserFixture.getRandomId();
+      RefreshToken tokenWithId = RefreshToken.builder()
+          .id(refreshTokenId)
+          .userId(UserFixture.getRandomId())
+          .family(UserFixture.getRandomPositive())
+          .currentToken("current-token")
+          .build();
+
+      // when
+      boolean actual = tokenWithId.hasSameId(refreshTokenId);
+
+      // then
+      assertThat(actual).isTrue();
+    }
+
+    @Test
+    void tokenValue_비교는_현재_토큰과_비교한다() {
+      // given
+
+      // when
+      boolean actual = refreshToken.hasSameTokenValue("current-token");
+
+      // then
+      assertThat(actual).isTrue();
+    }
+
+    @Test
     void 이전_토큰이_같으면_true를_반환한다() {
       // given
 
       // when
       boolean actual = refreshToken.hasSamePreviousToken("previous-token");
+
+      // then
+      assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 이전_토큰이_null이고_비교값도_null이면_true를_반환한다() {
+      // given
+      RefreshToken tokenWithoutPrevious = RefreshToken.builder()
+          .userId(UserFixture.getRandomId())
+          .family(UserFixture.getRandomPositive())
+          .currentToken("current-token")
+          .previousToken(null)
+          .refreshedAt(LocalDateTime.now())
+          .build();
+
+      // when
+      boolean actual = tokenWithoutPrevious.hasSamePreviousToken(null);
 
       // then
       assertThat(actual).isTrue();
@@ -138,6 +202,59 @@ class RefreshTokenTest {
 
       // then
       assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 갱신_시각이_삼분_경계면_true를_반환한다() {
+      // given
+      LocalDateTime now = LocalDateTime.now();
+      RefreshToken refreshedAtBoundary = RefreshToken.builder()
+          .userId(UserFixture.getRandomId())
+          .family(UserFixture.getRandomPositive())
+          .currentToken("current-token")
+          .refreshedAt(now.minusMinutes(3))
+          .build();
+
+      // when
+      boolean actual = refreshedAtBoundary.isWithinGracePeriod(now);
+
+      // then
+      assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 갱신_시각이_삼분을_초과하면_false를_반환한다() {
+      // given
+      LocalDateTime now = LocalDateTime.now();
+      RefreshToken refreshedBeforeGracePeriod = RefreshToken.builder()
+          .userId(UserFixture.getRandomId())
+          .family(UserFixture.getRandomPositive())
+          .currentToken("current-token")
+          .refreshedAt(now.minusMinutes(3).minusNanos(1))
+          .build();
+
+      // when
+      boolean actual = refreshedBeforeGracePeriod.isWithinGracePeriod(now);
+
+      // then
+      assertThat(actual).isFalse();
+    }
+
+    @Test
+    void 갱신_시각이_null이면_false를_반환한다() {
+      // given
+      RefreshToken tokenWithoutRefreshedAt = RefreshToken.builder()
+          .userId(UserFixture.getRandomId())
+          .family(UserFixture.getRandomPositive())
+          .currentToken("current-token")
+          .refreshedAt(null)
+          .build();
+
+      // when
+      boolean actual = tokenWithoutRefreshedAt.isWithinGracePeriod(LocalDateTime.now());
+
+      // then
+      assertThat(actual).isFalse();
     }
   }
 

--- a/domain/user-domain/src/test/java/com/modoo/domain/user/auth/aggregate/RefreshTokenTest.java
+++ b/domain/user-domain/src/test/java/com/modoo/domain/user/auth/aggregate/RefreshTokenTest.java
@@ -134,7 +134,7 @@ class RefreshTokenTest {
       // given
 
       // when
-      boolean actual = refreshToken.isRefreshedWithin(LocalDateTime.now(), 3L);
+      boolean actual = refreshToken.isWithinGracePeriod(LocalDateTime.now());
 
       // then
       assertThat(actual).isTrue();

--- a/domain/user-domain/src/test/java/com/modoo/domain/user/auth/aggregate/RefreshTokenTest.java
+++ b/domain/user-domain/src/test/java/com/modoo/domain/user/auth/aggregate/RefreshTokenTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.modoo.domain.user.auth.aggregate.vo.UserFamily;
 import com.modoo.fixture.UserFixture;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -25,8 +26,7 @@ class RefreshTokenTest {
     void setUp() {
       userId = UserFixture.getRandomId();
       family = UserFixture.getRandomPositive();
-      tokenValue = UUID.randomUUID()
-          .toString();
+      tokenValue = UUID.randomUUID().toString();
     }
 
     @Test
@@ -43,6 +43,7 @@ class RefreshTokenTest {
       // then
       assertThat(refreshToken.getUserId()).isEqualTo(userId);
       assertThat(refreshToken.getFamily()).isEqualTo(family);
+      assertThat(refreshToken.getCurrentToken()).isEqualTo(tokenValue);
     }
 
     @Test
@@ -83,7 +84,61 @@ class RefreshTokenTest {
       // then
       assertThat(refreshToken.getUserId()).isEqualTo(userFamily.getUserId());
     }
+  }
 
+  @Nested
+  class 상태_비교_테스트 {
+
+    RefreshToken refreshToken;
+
+    @BeforeEach
+    void setUp() {
+      // given
+      refreshToken = RefreshToken.builder()
+          .userId(UserFixture.getRandomId())
+          .family(UserFixture.getRandomPositive())
+          .currentToken("current-token")
+          .previousToken("previous-token")
+          .refreshedAt(LocalDateTime.now())
+          .build();
+
+      // when
+
+      // then
+    }
+
+    @Test
+    void 현재_토큰이_같으면_true를_반환한다() {
+      // given
+
+      // when
+      boolean actual = refreshToken.hasSameCurrentToken("current-token");
+
+      // then
+      assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 이전_토큰이_같으면_true를_반환한다() {
+      // given
+
+      // when
+      boolean actual = refreshToken.hasSamePreviousToken("previous-token");
+
+      // then
+      assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 갱신_시각이_삼분_이내면_true를_반환한다() {
+      // given
+
+      // when
+      boolean actual = refreshToken.isRefreshedWithin(LocalDateTime.now(), 3L);
+
+      // then
+      assertThat(actual).isTrue();
+    }
   }
 
 }

--- a/domain/user-domain/src/test/java/com/modoo/domain/user/auth/aggregate/vo/UserFamilyTest.java
+++ b/domain/user-domain/src/test/java/com/modoo/domain/user/auth/aggregate/vo/UserFamilyTest.java
@@ -44,6 +44,21 @@ class UserFamilyTest {
     }
 
     @Test
+    void 유저_패밀리_문자열_포맷을_반환한다() {
+      // given
+      UserFamily userFamily = UserFamily.builder()
+          .userId(userId)
+          .family(family)
+          .build();
+
+      // when
+      String actual = userFamily.getUserFamilyValue();
+
+      // then
+      assertThat(actual).isEqualTo(userId + "-" + family);
+    }
+
+    @Test
     void 아이디가_null이면_유저_패밀리_생성을_실패한다() {
       // given
       UserFamilyBuilder builder = UserFamily.builder()
@@ -61,15 +76,18 @@ class UserFamilyTest {
     void 문자열_형식으로_유저_패밀리_생성을_성공한다() {
       // given
       String userFamilyValue = userId + "-" + family;
+      String authority = "NORMAL";
 
       // when
       UserFamily actual = UserFamily.builderWithString()
           .userFamilyValue(userFamilyValue)
+          .authority(authority)
           .buildWithString();
 
       // then
       assertThat(actual.getUserId()).isEqualTo(userId);
       assertThat(actual.getFamily()).isEqualTo(family);
+      assertThat(actual.getAuthority()).isEqualTo(authority);
     }
 
     @Test

--- a/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/adapter/AuthPersistenceAdpater.java
+++ b/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/adapter/AuthPersistenceAdpater.java
@@ -6,7 +6,9 @@ import com.modoo.common.annotation.DrivenAdapter;
 import com.modoo.domain.user.auth.aggregate.RefreshToken;
 import com.modoo.infra.mysql.user.auth.entiy.RefreshTokenEntity;
 import com.modoo.infra.mysql.user.auth.repository.RefreshTokenRepository;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @DrivenAdapter
@@ -47,6 +49,29 @@ public class AuthPersistenceAdpater implements TokenManipulationPort, TokenLoade
         .stream()
         .map(RefreshTokenEntity::toDomain)
         .toList();
+  }
+
+  @Override
+  public Optional<RefreshToken> loadOneByUserFamily(Long userId, int family) {
+    return refreshTokenRepository.findByUserFamily(userId, family)
+        .map(RefreshTokenEntity::toDomain);
+  }
+
+  @Override
+  public long rotateIfCurrentMatches(
+      Long userId,
+      int family,
+      String currentToken,
+      String newCurrentToken,
+      LocalDateTime refreshedAt
+  ) {
+    return refreshTokenRepository.rotateIfCurrentMatches(
+        userId,
+        family,
+        currentToken,
+        newCurrentToken,
+        refreshedAt
+    );
   }
 
 }

--- a/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/entiy/RefreshTokenEntity.java
+++ b/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/entiy/RefreshTokenEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,15 +40,23 @@ public class RefreshTokenEntity extends BaseEntity {
   private int family;
 
   @Column(
-      name = "token_value",
+      name = "current_token",
       nullable = false
   )
-  private String tokenValue;
+  private String currentToken;
+
+  @Column(name = "previous_token")
+  private String previousToken;
+
+  @Column(name = "refreshed_at")
+  private LocalDateTime refreshedAt;
 
   public static RefreshTokenEntity from(RefreshToken refreshToken) {
     return RefreshTokenEntity.builder()
         .id(refreshToken.getId())
-        .tokenValue(refreshToken.getTokenValue())
+        .currentToken(refreshToken.getCurrentToken())
+        .previousToken(refreshToken.getPreviousToken())
+        .refreshedAt(refreshToken.getRefreshedAt())
         .family(refreshToken.getFamily())
         .userId(refreshToken.getUserId())
         .build();
@@ -56,7 +65,9 @@ public class RefreshTokenEntity extends BaseEntity {
   public RefreshToken toDomain() {
     return RefreshToken.builder()
         .id(id)
-        .tokenValue(tokenValue)
+        .currentToken(currentToken)
+        .previousToken(previousToken)
+        .refreshedAt(refreshedAt)
         .family(family)
         .userId(userId)
         .build();

--- a/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/repository/RefreshTokenQueryRepository.java
+++ b/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/repository/RefreshTokenQueryRepository.java
@@ -1,6 +1,7 @@
 package com.modoo.infra.mysql.user.auth.repository;
 
 import com.modoo.infra.mysql.user.auth.entiy.RefreshTokenEntity;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,6 +11,16 @@ public interface RefreshTokenQueryRepository {
 
   List<RefreshTokenEntity> findAllByUserFamily(Long userId, int family);
 
+  Optional<RefreshTokenEntity> findByUserFamily(Long userId, int family);
+
   void deleteByUserFamily(Long userId, int family);
+
+  long rotateIfCurrentMatches(
+      Long userId,
+      int family,
+      String currentToken,
+      String newCurrentToken,
+      LocalDateTime refreshedAt
+  );
 
 }

--- a/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/repository/RefreshTokenQueryRepositoryImpl.java
+++ b/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/repository/RefreshTokenQueryRepositoryImpl.java
@@ -68,13 +68,12 @@ public class RefreshTokenQueryRepositoryImpl implements RefreshTokenQueryReposit
       String newCurrentToken,
       LocalDateTime refreshedAt
   ) {
-    String previousToken = currentToken;
     BooleanBuilder whereCondition = new BooleanBuilder(refreshTokenEntity.userId.eq(userId))
         .and(refreshTokenEntity.family.eq(family))
         .and(refreshTokenEntity.currentToken.eq(currentToken));
 
     return jpaQueryFactory.update(refreshTokenEntity)
-        .set(refreshTokenEntity.previousToken, previousToken)
+        .set(refreshTokenEntity.previousToken, currentToken)
         .set(refreshTokenEntity.currentToken, newCurrentToken)
         .set(refreshTokenEntity.refreshedAt, refreshedAt)
         .where(whereCondition)

--- a/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/repository/RefreshTokenQueryRepositoryImpl.java
+++ b/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/repository/RefreshTokenQueryRepositoryImpl.java
@@ -73,7 +73,7 @@ public class RefreshTokenQueryRepositoryImpl implements RefreshTokenQueryReposit
         .and(refreshTokenEntity.currentToken.eq(currentToken));
 
     return jpaQueryFactory.update(refreshTokenEntity)
-        .set(refreshTokenEntity.previousToken, refreshTokenEntity.currentToken)
+        .set(refreshTokenEntity.previousToken, currentToken)
         .set(refreshTokenEntity.currentToken, newCurrentToken)
         .set(refreshTokenEntity.refreshedAt, refreshedAt)
         .where(whereCondition)

--- a/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/repository/RefreshTokenQueryRepositoryImpl.java
+++ b/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/repository/RefreshTokenQueryRepositoryImpl.java
@@ -5,6 +5,7 @@ import static com.modoo.infra.mysql.user.auth.entiy.QRefreshTokenEntity.refreshT
 import com.modoo.infra.mysql.user.auth.entiy.RefreshTokenEntity;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -38,11 +39,43 @@ public class RefreshTokenQueryRepositoryImpl implements RefreshTokenQueryReposit
   }
 
   @Override
+  public Optional<RefreshTokenEntity> findByUserFamily(Long userId, int family) {
+    BooleanBuilder whereCondition = new BooleanBuilder(refreshTokenEntity.userId.eq(userId))
+        .and(refreshTokenEntity.family.eq(family));
+
+    return Optional.ofNullable(
+        jpaQueryFactory.selectFrom(refreshTokenEntity)
+            .where(whereCondition)
+            .fetchOne()
+    );
+  }
+
+  @Override
   public void deleteByUserFamily(Long userId, int family) {
     BooleanBuilder whereCondition = new BooleanBuilder(refreshTokenEntity.userId.eq(userId))
         .and(refreshTokenEntity.family.eq(family));
 
     jpaQueryFactory.delete(refreshTokenEntity)
+        .where(whereCondition)
+        .execute();
+  }
+
+  @Override
+  public long rotateIfCurrentMatches(
+      Long userId,
+      int family,
+      String currentToken,
+      String newCurrentToken,
+      LocalDateTime refreshedAt
+  ) {
+    BooleanBuilder whereCondition = new BooleanBuilder(refreshTokenEntity.userId.eq(userId))
+        .and(refreshTokenEntity.family.eq(family))
+        .and(refreshTokenEntity.currentToken.eq(currentToken));
+
+    return jpaQueryFactory.update(refreshTokenEntity)
+        .set(refreshTokenEntity.previousToken, refreshTokenEntity.currentToken)
+        .set(refreshTokenEntity.currentToken, newCurrentToken)
+        .set(refreshTokenEntity.refreshedAt, refreshedAt)
         .where(whereCondition)
         .execute();
   }

--- a/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/repository/RefreshTokenQueryRepositoryImpl.java
+++ b/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/repository/RefreshTokenQueryRepositoryImpl.java
@@ -68,12 +68,13 @@ public class RefreshTokenQueryRepositoryImpl implements RefreshTokenQueryReposit
       String newCurrentToken,
       LocalDateTime refreshedAt
   ) {
+    String previousToken = currentToken;
     BooleanBuilder whereCondition = new BooleanBuilder(refreshTokenEntity.userId.eq(userId))
         .and(refreshTokenEntity.family.eq(family))
         .and(refreshTokenEntity.currentToken.eq(currentToken));
 
     return jpaQueryFactory.update(refreshTokenEntity)
-        .set(refreshTokenEntity.previousToken, currentToken)
+        .set(refreshTokenEntity.previousToken, previousToken)
         .set(refreshTokenEntity.currentToken, newCurrentToken)
         .set(refreshTokenEntity.refreshedAt, refreshedAt)
         .where(whereCondition)

--- a/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/repository/RefreshTokenRepository.java
+++ b/infra/user-infra-mysql/src/main/java/com/modoo/infra/mysql/user/auth/repository/RefreshTokenRepository.java
@@ -3,7 +3,7 @@ package com.modoo.infra.mysql.user.auth.repository;
 import com.modoo.infra.mysql.user.auth.entiy.RefreshTokenEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, String>,
+public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, Long>,
     RefreshTokenQueryRepository {
 
 }


### PR DESCRIPTION
### Motivation

- Replace multi-row refresh token history with a single record per `user_id + family` to simplify rotation semantics and support CAS-style atomic updates.
- Ensure safe handling of concurrent/duplicated refresh requests with a grace window and clear 404/403/200 outcomes according to state.

### Description

- Introduced schema migration `V21__change_refresh_token_to_single_record.sql` and updated sample data in `afterMigrate.sql` to remove `token_value` and add `current_token`, `previous_token`, `refreshed_at`, and a unique constraint on `(user_id, family)`. 
- Changed domain model `RefreshToken` to use `currentToken`, `previousToken`, and `refreshedAt` and added helpers `hasSameCurrentToken`, `hasSamePreviousToken`, `isRefreshedWithin`, and `getTokenValue`.
- Updated application ports: added `Optional<RefreshToken> loadOneByUserFamily(...)` to `TokenLoaderPort` and a CAS method `rotateIfCurrentMatches(...)` to `TokenManipulationPort`.
- Reworked `TokenRefreshService` to perform a CAS update via `rotateIfCurrentMatches` and implement fallback verification logic (user not found => 404, missing record => 404, previous token mismatch => delete & 403, previous token match within 3 minutes => return existing current token with 200, otherwise delete & 403). Added `DUPLICATED_REQUEST_GRACE_MINUTES` constant and improved exception mapping/transaction attributes. 
- Adjusted `TokenManager` to populate `currentToken` when creating refresh tokens.
- Updated persistence layer: `RefreshTokenEntity` mapping, `RefreshTokenRepository` signature, `RefreshTokenQueryRepository` and `RefreshTokenQueryRepositoryImpl` with `findByUserFamily(...)` and `rotateIfCurrentMatches(...)`, and `AuthPersistenceAdpater` implementations for the new ports and rotation method.
- Added design/implementation plan document `docs/plans/refresh-token-single-record-implementation-plan.md` describing the migration and behavior.
- Updated and expanded tests in `RefreshTokenTest` and `TokenRefreshServiceTest` to cover the new single-record semantics, CAS rotation, duplicated-request grace behavior, and the new error cases.

### Testing

- Ran unit tests `domain.user-domain RefreshTokenTest` and `application.user-application TokenRefreshServiceTest`, and they passed locally. 
- Verified repository/query changes via updated service tests that exercise `rotateIfCurrentMatches` behavior and the various refresh outcome branches (early-success, duplicated within 3 minutes, decode failure, user missing, record missing, previous-token mismatch, and previous-token expired).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05e96e418832da0b54282cce8b449)