### PR TITLE
fix: avoid npe for getClass when arg is null

### DIFF
--- a/application/application-common/src/main/java/com/modoo/application/common/aop/ServiceLogAspect.java
+++ b/application/application-common/src/main/java/com/modoo/application/common/aop/ServiceLogAspect.java
@@ -81,11 +81,7 @@ public class ServiceLogAspect {
   }
 
   private boolean isTargetParams(Object arg) {
-    boolean isRecord = arg.getClass()
-        .isRecord();
-    boolean isScroll = arg instanceof ScrollRequest;
-
-    return isRecord || isScroll;
+    return arg instanceof Record || arg instanceof ScrollRequest;
   }
 
 }


### PR DESCRIPTION
## 관련 이슈

<!-- "- Resolves #{issue number}"를 포함하여 파생된 이슈를 연결할 것  -->

## 구현 내용

<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- fix npe for getClass when param arg is null for service logging