### PR TITLE
Allow optional goalId for Todo create/update (nullable goal handling, DB migration, and tests)

### DIFF
--- a/application/application-common/src/main/java/com/modoo/application/common/dto/todo/request/CreateTodoRequest.java
+++ b/application/application-common/src/main/java/com/modoo/application/common/dto/todo/request/CreateTodoRequest.java
@@ -10,7 +10,6 @@ import java.time.LocalTime;
 import java.util.List;
 
 public record CreateTodoRequest(
-    @NotNull(message = "2001 NULL_GOAL_VALUE")
     @Positive(message = "2014 NEGATIVE_OR_ZERO_GOAL_ID")
     Long goalId,
     @NotBlank(message = "2002 BLANK_NAME")

--- a/application/application-common/src/main/java/com/modoo/application/common/dto/todo/request/UpdateTodoRequest.java
+++ b/application/application-common/src/main/java/com/modoo/application/common/dto/todo/request/UpdateTodoRequest.java
@@ -10,7 +10,6 @@ import java.time.LocalTime;
 import java.util.List;
 
 public record UpdateTodoRequest(
-    @NotNull(message = "2001 NULL_GOAL_VALUE")
     @Positive(message = "2014 NEGATIVE_OR_ZERO_GOAL_ID")
     Long goalId,
     @NotBlank(message = "2002 BLANK_NAME")

--- a/application/planning-application/src/main/java/com/modoo/application/planning/todo/service/CreateTodoService.java
+++ b/application/planning-application/src/main/java/com/modoo/application/planning/todo/service/CreateTodoService.java
@@ -36,19 +36,14 @@ public class CreateTodoService implements CreateTodoUseCase {
 
   @Override
   public BasicTodoResponse create(Long loginId, CreateTodoRequest request) {
-    // 1. 요청 유저, 목표 조회
+    // 1. 요청 유저 조회
     User user = userLoaderPort.getUserOrElseThrow(
         loginId, TodoErrorCode.LOGIN_USER_NOT_EXISTING.getCodeName());
-    Goal goal = goalLoaderPort.getGoalOrElseThrow(
-        request.goalId(), TodoErrorCode.GOAL_NOT_EXISTING.getCodeName());
 
-    // 2. 목표 소유자의 요청인지 확인
-    goal.validateGoalCreator(loginId);
+    // 2. 목표가 있는 요청이면 목표 검증
+    validateGoalIfExists(loginId, request.goalId());
 
-    // 3. 종료되지 않은 목표인지 확인
-    validateGoalNotDone(goal);
-
-    // 4. 투두 생성 후 저장
+    // 3. 투두 생성 후 저장
     Todo todo = todoDomainService.create(user.getId(), request.toCommand());
     Todo saved = saveTodoPort.save(todo);
 
@@ -75,6 +70,17 @@ public class CreateTodoService implements CreateTodoUseCase {
                 InterimSetReminderEvent.from(userId, savedReminder)
             )
         );
+  }
+
+  private void validateGoalIfExists(Long loginId, Long goalId) {
+    if (Objects.isNull(goalId)) {
+      return;
+    }
+
+    Goal goal = goalLoaderPort.getGoalOrElseThrow(
+        goalId, TodoErrorCode.GOAL_NOT_EXISTING.getCodeName());
+    goal.validateGoalCreator(loginId);
+    validateGoalNotDone(goal);
   }
 
   private void validateGoalNotDone(Goal goal) {

--- a/application/planning-application/src/main/java/com/modoo/application/planning/todo/service/UpdateTodoService.java
+++ b/application/planning-application/src/main/java/com/modoo/application/planning/todo/service/UpdateTodoService.java
@@ -55,13 +55,8 @@ public class UpdateTodoService implements UpdateTodoUseCase {
         todoId,
         TodoErrorCode.ID_NOT_EXISTING.getCodeName()
     );
-    Goal goal = goalLoaderPort.getGoalOrElseThrow(
-        request.goalId(),
-        TodoErrorCode.GOAL_NOT_EXISTING.getCodeName()
-    );
-
     todo.validateTodoCreator(user.getId());
-    goal.validateGoalCreator(user.getId());
+    validateGoalIfExists(user.getId(), request.goalId());
 
     Todo updatedTodo = todoDomainService.update(todo, request.toCommand());
     Todo saved = todoUpdatePort.update(updatedTodo);
@@ -69,6 +64,18 @@ public class UpdateTodoService implements UpdateTodoUseCase {
     replaceReminders(user.getId(), saved, request.reminders());
 
     return BasicTodoResponse.from(saved);
+  }
+
+  private void validateGoalIfExists(Long userId, Long goalId) {
+    if (Objects.isNull(goalId)) {
+      return;
+    }
+
+    Goal goal = goalLoaderPort.getGoalOrElseThrow(
+        goalId,
+        TodoErrorCode.GOAL_NOT_EXISTING.getCodeName()
+    );
+    goal.validateGoalCreator(userId);
   }
 
   private void replaceReminders(Long userId, Todo todo, List<UpdateTodoReminderRequest> requests) {

--- a/application/planning-application/src/test/java/com/modoo/application/planning/goal/service/RetrieveGoalServiceTest.java
+++ b/application/planning-application/src/test/java/com/modoo/application/planning/goal/service/RetrieveGoalServiceTest.java
@@ -71,7 +71,7 @@ class RetrieveGoalServiceTest {
             "color",
             "privacyType",
             "priority"
-        )
+    )
         .containsExactly(
             goal.getId(),
             goal.getName(),
@@ -79,7 +79,7 @@ class RetrieveGoalServiceTest {
             goal.getColor(),
             goal.getPrivacyType(),
             goal.getPriority()
-        );
+    );
   }
 
   @Test
@@ -112,13 +112,13 @@ class RetrieveGoalServiceTest {
             "repeatType",
             "startDate",
             "endDate"
-        )
+    )
         .containsExactly(
             repeatTodo.getName(),
             repeatTodo.getRepeatType(),
             repeatTodo.getStartDate(),
             repeatTodo.getEndDate()
-        );
+    );
 
     RepeatPattern actualPattern = actual.getRepeatPattern();
     RepeatPattern expectedPattern = repeatTodo.getRepeatPattern();

--- a/application/planning-application/src/test/java/com/modoo/application/planning/todo/service/CreateTodoServiceTest.java
+++ b/application/planning-application/src/test/java/com/modoo/application/planning/todo/service/CreateTodoServiceTest.java
@@ -60,7 +60,6 @@ class CreateTodoServiceTest {
     memo = TodoFixture.createValidMemo();
   }
 
-
   @Test
   void 할_일_생성에_성공한다() {
     // given
@@ -103,6 +102,47 @@ class CreateTodoServiceTest {
   }
 
   @Test
+  void 목표가_없어도_할_일_생성에_성공한다() {
+    // given
+    CreateTodoRequest request = new CreateTodoRequest(
+        null,
+        name,
+        memo,
+        scheduledOn,
+        null,
+        null,
+        null
+    );
+
+    // when
+    BasicTodoResponse response = createTodoService.create(user.getId(), request);
+
+    // then
+    Todo actual = todoLoaderPort.getTodoOrElseThrow(
+        response.id(),
+        "할 일이 생성되지 않았습니다."
+    );
+    assertThat(actual).extracting(
+            "name",
+            "memo",
+            "scheduledOn",
+            "goalId",
+            "userId",
+            "status",
+            "postponedAt"
+        )
+        .containsExactly(
+            name,
+            memo,
+            scheduledOn,
+            null,
+            user.getId(),
+            TodoStatus.UNCOMPLETED,
+            null
+        );
+  }
+
+  @Test
   void 날짜를_설정하지_않은_경우_기본값이_적용된다() {
     // given
     CreateTodoRequest request = new CreateTodoRequest(
@@ -128,7 +168,7 @@ class CreateTodoServiceTest {
 
   @Test
   void 사용자_아이디가_유효하지_않으면_예외가_발생한다() {
-    // give
+    // given
     Long invalidUserId = UserFixture.getRandomId();
     CreateTodoRequest request = new CreateTodoRequest(
         goal.getId(),

--- a/application/planning-application/src/test/java/com/modoo/application/planning/todo/service/CreateTodoServiceTest.java
+++ b/application/planning-application/src/test/java/com/modoo/application/planning/todo/service/CreateTodoServiceTest.java
@@ -89,7 +89,7 @@ class CreateTodoServiceTest {
             "userId",
             "status",
             "postponedAt"
-        )
+    )
         .containsExactly(
             name,
             memo,
@@ -98,7 +98,7 @@ class CreateTodoServiceTest {
             user.getId(),
             TodoStatus.UNCOMPLETED,
             null
-        );
+    );
   }
 
   @Test
@@ -130,7 +130,7 @@ class CreateTodoServiceTest {
             "userId",
             "status",
             "postponedAt"
-        )
+    )
         .containsExactly(
             name,
             memo,
@@ -139,7 +139,7 @@ class CreateTodoServiceTest {
             user.getId(),
             TodoStatus.UNCOMPLETED,
             null
-        );
+    );
   }
 
   @Test

--- a/application/planning-application/src/test/java/com/modoo/application/planning/todo/service/UpdateTodoServiceTest.java
+++ b/application/planning-application/src/test/java/com/modoo/application/planning/todo/service/UpdateTodoServiceTest.java
@@ -10,6 +10,7 @@ import com.modoo.application.common.port.goal.out.SaveGoalPort;
 import com.modoo.application.common.port.reminder.out.ReminderCommandPort;
 import com.modoo.application.common.port.reminder.out.ReminderLoaderPort;
 import com.modoo.application.common.port.todo.out.SaveTodoPort;
+import com.modoo.application.common.port.todo.out.TodoLoaderPort;
 import com.modoo.common.exception.GoalErrorCode;
 import com.modoo.common.exception.TodoErrorCode;
 import com.modoo.domain.planning.goal.aggregate.Goal;
@@ -50,6 +51,9 @@ class UpdateTodoServiceTest {
 
   @Autowired
   SaveTodoPort saveTodoPort;
+
+  @Autowired
+  TodoLoaderPort todoLoaderPort;
 
   @Autowired
   ReminderCommandPort reminderCommandPort;
@@ -102,6 +106,35 @@ class UpdateTodoServiceTest {
     // then
     assertThat(actual.id()).isEqualTo(todo.getId());
     assertThat(actual.name()).isEqualTo(request.name());
+  }
+
+  @Test
+  void 목표가_없도록_투두를_수정한다() {
+    // given
+    UpdateTodoRequest requestWithoutGoal = new UpdateTodoRequest(
+        null,
+        request.name(),
+        request.memo(),
+        request.scheduledOn(),
+        request.beginAt(),
+        request.endAt(),
+        request.reminders()
+    );
+
+    // when
+    BasicTodoResponse actual = updateTodoService.update(
+        user.getId(),
+        todo.getId(),
+        requestWithoutGoal
+    );
+
+    // then
+    Todo updatedTodo = todoLoaderPort.getTodoOrElseThrow(
+        actual.id(),
+        TodoErrorCode.ID_NOT_EXISTING.getCodeName()
+    );
+    assertThat(updatedTodo.getGoalId()).isNull();
+    assertThat(updatedTodo.getName()).isEqualTo(request.name());
   }
 
   @Test

--- a/bootstrap/bootstrap-gateway/src/main/resources/db/migration/V22__allow_null_todo_goal_id.sql
+++ b/bootstrap/bootstrap-gateway/src/main/resources/db/migration/V22__allow_null_todo_goal_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE todos
+    MODIFY goal_id BIGINT NULL;

--- a/bootstrap/planning-api/src/main/java/com/modoo/api/planning/todo/doc/TodoControllerDoc.java
+++ b/bootstrap/planning-api/src/main/java/com/modoo/api/planning/todo/doc/TodoControllerDoc.java
@@ -50,10 +50,6 @@ public interface TodoControllerDoc {
               content = @Content(
                   examples = {
                       @ExampleObject(
-                          name = "2001",
-                          value = TodoErrorExamples.TODO_NULL_GOAL_VALUE
-                      ),
-                      @ExampleObject(
                           name = "2014",
                           value = TodoErrorExamples.TODO_NEGATIVE_OR_ZERO_GOAL_ID
                       ),

--- a/domain/planning-domain/src/main/java/com/modoo/domain/planning/todo/aggregate/Todo.java
+++ b/domain/planning-domain/src/main/java/com/modoo/domain/planning/todo/aggregate/Todo.java
@@ -51,7 +51,7 @@ public class Todo {
       LocalTime beginAt,
       LocalTime endAt
   ) {
-    validate(goalId, userId, name, memo, beginAt, endAt);
+    validate(userId, name, memo, beginAt, endAt);
 
     this.id = id;
     this.goalId = goalId;
@@ -204,14 +204,12 @@ public class Todo {
   }
 
   private void validate(
-      Long goalId,
       Long userId,
       String name,
       String memo,
       LocalTime beginAt,
       LocalTime endAt
   ) {
-    checkArgument(Objects.nonNull(goalId), TodoErrorCode.NULL_GOAL_VALUE.getCodeName());
     checkArgument(Objects.nonNull(userId), TodoErrorCode.NULL_USER.getCodeName());
     validateName(name);
     validateMemo(memo);

--- a/domain/planning-domain/src/test/java/com/modoo/domain/planning/todo/aggregate/TodoTest.java
+++ b/domain/planning-domain/src/test/java/com/modoo/domain/planning/todo/aggregate/TodoTest.java
@@ -150,19 +150,17 @@ class TodoTest {
     }
 
     @Test
-    void 목표가_없으면_생성을_실패한다() {
+    void 목표가_없어도_생성을_성공한다() {
       // given
-      TodoBuilder builder = Todo.builder()
-          .userId(userId)
-          .name(name);
 
       // when
-      ThrowingCallable create = builder::build;
+      Todo todo = Todo.builder()
+          .userId(userId)
+          .name(name)
+          .build();
 
       // then
-      Assertions.assertThatIllegalArgumentException()
-          .isThrownBy(create)
-          .withMessage(TodoErrorCode.NULL_GOAL_VALUE.getCodeName());
+      assertThat(todo.getGoalId()).isNull();
     }
 
     @Test

--- a/domain/planning-domain/src/test/java/com/modoo/domain/planning/todo/service/TodoDomainServiceTest.java
+++ b/domain/planning-domain/src/test/java/com/modoo/domain/planning/todo/service/TodoDomainServiceTest.java
@@ -60,6 +60,26 @@ class TodoDomainServiceTest {
     }
 
     @Test
+    void 목표가_없어도_투두를_생성한다() {
+      // given
+      CreateTodoCommand request = new CreateTodoCommand(
+          null,
+          name,
+          memo,
+          scheduledOn,
+          null,
+          null
+      );
+
+      // when
+      Todo actual = todoDomainService.create(userId, request);
+
+      // then
+      assertThat(actual).extracting("userId", "goalId", "name", "memo", "scheduledOn")
+          .containsExactly(userId, null, name, memo, scheduledOn);
+    }
+
+    @Test
     void 날짜가_설정되지_않으면_투두의_날짜가_생성_날짜가_된다() {
       // given
       CreateTodoCommand request = new CreateTodoCommand(
@@ -105,6 +125,38 @@ class TodoDomainServiceTest {
     assertThat(actual).extracting("goalId", "name", "memo", "scheduledOn", "beginAt", "endAt")
         .containsExactly(
             command.goalId(),
+            command.name(),
+            command.memo(),
+            command.scheduledOn(),
+            command.beginAt(),
+            command.endAt()
+        );
+  }
+
+  @Test
+  void 목표가_없도록_투두를_수정한다() {
+    // given
+    Todo todo = TodoFixture.getTodoBuilder()
+        .userId(GoalFixture.getRandomId())
+        .goalId(GoalFixture.getRandomId())
+        .build();
+    UpdateTodoCommand command = UpdateTodoCommand.builder()
+        .goalId(null)
+        .name(TodoFixture.getRandomSentenceWithMax(50))
+        .memo(TodoFixture.createValidMemo())
+        .scheduledOn(LocalDate.now()
+            .plusDays(1))
+        .beginAt(LocalTime.of(10, 0))
+        .endAt(LocalTime.of(11, 0))
+        .build();
+
+    // when
+    Todo actual = todoDomainService.update(todo, command);
+
+    // then
+    assertThat(actual).extracting("goalId", "name", "memo", "scheduledOn", "beginAt", "endAt")
+        .containsExactly(
+            null,
             command.name(),
             command.memo(),
             command.scheduledOn(),

--- a/domain/planning-domain/src/test/java/com/modoo/domain/planning/todo/service/TodoDomainServiceTest.java
+++ b/domain/planning-domain/src/test/java/com/modoo/domain/planning/todo/service/TodoDomainServiceTest.java
@@ -130,7 +130,7 @@ class TodoDomainServiceTest {
             command.scheduledOn(),
             command.beginAt(),
             command.endAt()
-        );
+    );
   }
 
   @Test
@@ -162,7 +162,7 @@ class TodoDomainServiceTest {
             command.scheduledOn(),
             command.beginAt(),
             command.endAt()
-        );
+    );
   }
 
 }

--- a/infra/planning-infra-mysql/src/main/java/com/modoo/infra/mysql/planning/todo/entity/TodoEntity.java
+++ b/infra/planning-infra-mysql/src/main/java/com/modoo/infra/mysql/planning/todo/entity/TodoEntity.java
@@ -33,10 +33,7 @@ public class TodoEntity extends BaseEntity {
   @Column(name = "id")
   private Long id;
 
-  @Column(
-      name = "goal_id",
-      nullable = false
-  )
+  @Column(name = "goal_id")
   private Long goalId;
 
   @Column(name = "user_id")
@@ -125,6 +122,7 @@ public class TodoEntity extends BaseEntity {
   }
 
   public void update(Todo todo) {
+    this.goalId = todo.getGoalId();
     this.name = todo.getName();
     this.memo = todo.getMemo();
     this.status = todo.getStatus();

--- a/plans/투두-목표-optional-구현-플랜.md
+++ b/plans/투두-목표-optional-구현-플랜.md
@@ -1,0 +1,140 @@
+# 투두 생성/수정 목표 Optional 구현 플랜
+
+## 배경
+
+- 투두 생성/수정 요청에서 `goalId`가 없어도 투두를 생성하거나 수정할 수 있어야 한다.
+- 목표가 전달된 경우에는 기존과 동일하게 목표 존재 여부, 목표 소유자 여부, 종료 목표 여부를 검증한다.
+- 목표가 전달되지 않은 경우에는 목표 조회 및 목표 기반 검증을 생략한다.
+- 현재 통계 및 타임테이블은 목표 전용 서비스로 유지하므로, `goalId`가 `null`인 투두는 별도 그룹/응답으로 포함하지 않고 기존 목표 기반 조회 흐름에서 자연스럽게 생략한다.
+
+## 구현 원칙
+
+1. `goalId` Optional 처리는 생성/수정 입력, 도메인 생성/수정, 영속화 저장/수정, DB 스키마까지 일관되게 반영한다.
+2. 목표가 있는 요청의 기존 검증 강도는 낮추지 않는다.
+3. 목표가 없는 투두는 생성/수정 API의 정상 케이스로 허용한다.
+4. 통계 및 타임테이블은 목표 전용 서비스이므로 `goalId == null` 투두를 포함하기 위한 별도 조회/응답 처리는 하지 않는다.
+5. 도메인 수정 로직과 영속화 수정 로직 모두 `goalId` 변경을 반영하도록 확인한다.
+
+## 상세 구현 단계
+
+### 1. 요청 DTO의 `goalId` 필수 검증 제거
+
+- `CreateTodoRequest.goalId`에서 `@NotNull(message = "2001 NULL_GOAL_VALUE")`를 제거한다.
+- `UpdateTodoRequest.goalId`에서 `@NotNull(message = "2001 NULL_GOAL_VALUE")`를 제거한다.
+- `@Positive(message = "2014 NEGATIVE_OR_ZERO_GOAL_ID")`는 유지해, 값이 전달된 경우 양수만 허용한다.
+- `toCommand()`는 기존처럼 `goalId`를 command로 전달하되, `null` 전달을 정상 케이스로 허용한다.
+
+#### 영향 패키지 및 클래스
+
+| 유형 | 패키지 | 클래스 |
+| --- | --- | --- |
+| 변경 | `com.modoo.application.common.dto.todo.request` | `CreateTodoRequest` |
+| 변경 | `com.modoo.application.common.dto.todo.request` | `UpdateTodoRequest` |
+
+### 2. 애플리케이션 서비스의 목표 조회/검증 조건부 처리
+
+- `CreateTodoService#create()`에서 `request.goalId()`가 `null`이면 목표 조회를 수행하지 않는다.
+- `CreateTodoService#create()`에서 목표가 있는 경우에만 목표 소유자 검증과 종료 목표 검증을 수행한다.
+- `UpdateTodoService#update()`에서 `request.goalId()`가 `null`이면 목표 조회와 목표 소유자 검증을 수행하지 않는다.
+- `UpdateTodoService#update()`에서 기존 투두 작성자 검증은 목표 여부와 무관하게 유지한다.
+- 목표가 있는 수정 요청은 기존처럼 목표 존재 여부와 목표 소유자 검증을 수행한다.
+
+#### 영향 패키지 및 클래스
+
+| 유형 | 패키지 | 클래스 |
+| --- | --- | --- |
+| 변경 | `com.modoo.application.planning.todo.service` | `CreateTodoService` |
+| 변경 | `com.modoo.application.planning.todo.service` | `UpdateTodoService` |
+
+### 3. Todo 도메인 생성/수정 로직의 `goalId` Optional 반영
+
+- `Todo.validate(...)`에서 `goalId` non-null 검증을 제거한다.
+- `userId`, `name`, `memo`, 기간 검증은 기존과 동일하게 유지한다.
+- `Todo.update(...)`는 수정 요청의 `goalId`를 새 도메인 상태에 반영해야 한다.
+- 현재처럼 `Todo.update(...)`가 builder에 `.goalId(goalId)`를 세팅하는 구조를 유지하거나, 누락되어 있다면 반드시 추가한다.
+- 테스트에서는 `goalId == null` 생성뿐 아니라, 기존 목표가 있던 투두를 `goalId == null`로 수정하는 도메인 시나리오를 검증한다.
+
+#### 영향 패키지 및 클래스
+
+| 유형 | 패키지 | 클래스 |
+| --- | --- | --- |
+| 변경 | `com.modoo.domain.planning.todo.aggregate` | `Todo` |
+| 확인 | `com.modoo.domain.planning.todo.dto` | `CreateTodoCommand` |
+| 확인 | `com.modoo.domain.planning.todo.dto` | `UpdateTodoCommand` |
+| 확인 | `com.modoo.domain.planning.todo.service` | `TodoDomainService` |
+
+### 4. 영속화 엔티티와 DB 스키마의 `goal_id` nullable 반영
+
+- `TodoEntity.goalId`의 `@Column(nullable = false)` 설정을 제거하거나 nullable 허용으로 변경한다.
+- `TodoEntity.from(Todo todo)`는 기존처럼 `todo.getGoalId()`를 저장하되, `null` 값을 허용한다.
+- `TodoEntity.toDomain()`은 기존처럼 `goalId`를 도메인으로 복원하되, `null` 값을 허용한다.
+- `TodoEntity.update(Todo todo)`에 `this.goalId = todo.getGoalId();`를 반영한다.
+  - 이 작업이 없으면 도메인 `Todo.update(...)`가 `goalId` 변경을 반영하더라도 DB 수정에는 반영되지 않는다.
+- 신규 Flyway migration을 추가해 `todos.goal_id` 컬럼을 `NULL` 허용으로 변경한다.
+- nullable FK는 유지해, `goal_id`가 있는 경우에는 기존처럼 유효한 목표만 참조하도록 한다.
+
+#### 영향 패키지 및 클래스
+
+| 유형 | 패키지/경로 | 클래스/파일 |
+| --- | --- | --- |
+| 변경 | `com.modoo.infra.mysql.planning.todo.entity` | `TodoEntity` |
+| 신규 | `bootstrap/bootstrap-gateway/src/main/resources/db/migration` | `V{next}__allow_null_todo_goal_id.sql` |
+
+### 5. 통계 및 타임테이블의 `goalId == null` 처리 정책
+
+- 현재 통계 및 타임테이블은 목표 전용 서비스로 유지한다.
+- `goalId == null`인 투두를 통계/타임테이블 응답에 포함하기 위한 별도 그룹, 기본 목표, 기본 색상, left join 보완은 구현하지 않는다.
+- 기존 목표 기반 inner join 또는 목표 기반 조건으로 인해 `goalId == null` 투두가 조회 결과에서 제외되는 것은 의도한 동작으로 본다.
+- 단, 생성/수정 API의 저장 결과 조회처럼 목표 전용이 아닌 단건 응답에서는 `goalId == null`을 그대로 허용한다.
+- 향후 목표 없는 투두를 통계/타임테이블에 포함해야 하는 요구사항이 생기면 별도 이슈에서 응답 스펙과 노출 정책을 먼저 정의한다.
+
+#### 영향 패키지 및 클래스
+
+| 유형 | 패키지 | 클래스 |
+| --- | --- | --- |
+| 변경 없음 | `com.modoo.infra.mysql.planning.todo.repository` | `TodoQueryRepositoryImpl`의 목표 전용 통계/타임테이블 조회 |
+| 변경 없음 | `com.modoo.application.planning.todo.model` | `Timetable` |
+| 변경 없음 | `com.modoo.application.planning.todo.model` | `TodoList`의 목표 그룹 응답 흐름 |
+
+### 6. 테스트 계획
+
+#### 도메인 테스트
+
+- `goalId`가 `null`이어도 투두를 생성할 수 있는지 검증한다.
+- 기존 목표가 있는 투두를 `goalId == null`로 수정할 수 있는지 검증한다.
+- `goalId == null`이어도 이름, 메모, 기간, 사용자 검증은 기존처럼 동작하는지 확인한다.
+- 실패 케이스는 `ThrowingCallable`을 사용하고 `// given`, `// when`, `// then` 주석을 명시한다.
+- 테스트 메서드명은 한국어로 작성한다.
+
+#### 애플리케이션 테스트
+
+- 투두 생성 시 `goalId == null`이면 목표 조회 없이 저장되는지 검증한다.
+- 투두 수정 시 `goalId == null`이면 목표 조회 없이 수정되는지 검증한다.
+- 투두 수정 시 `goalId == null`로 변경된 값이 영속화 계층까지 반영되는지 검증한다.
+- 목표가 있는 생성/수정 요청은 기존 목표 검증이 유지되는지 검증한다.
+- 애플리케이션 서비스 테스트는 `@SpringBootTest`, `@Transactional`, `@BeforeEach` 기반 데이터 준비 규칙을 따른다.
+
+#### 마이그레이션 및 회귀 테스트
+
+- 신규 DDL이 추가되므로 `./gradlew :bootstrap:bootstrap-gateway:flywayMigrate`를 먼저 실행한다.
+- 이후 관련 도메인/애플리케이션 테스트를 실행한다.
+- 통계 및 타임테이블은 목표 전용 서비스 정책에 따라 `goalId == null` 투두가 포함되지 않는 기존 흐름을 회귀 확인한다.
+
+## 권장 구현 순서
+
+1. 요청 DTO의 `goalId @NotNull` 제거.
+2. `Todo.validate(...)`의 `goalId` non-null 검증 제거.
+3. `Todo.update(...)`가 수정 요청의 `goalId`를 도메인 상태에 반영하는지 확인 및 보완.
+4. 생성/수정 애플리케이션 서비스에서 목표 조회/검증을 `goalId != null`일 때만 수행하도록 변경.
+5. `TodoEntity.goalId` nullable 반영 및 `TodoEntity.update(...)`의 `goalId` 갱신 추가.
+6. `todos.goal_id` nullable 변경 Flyway migration 추가.
+7. 도메인 및 애플리케이션 테스트 추가/수정.
+8. `flywayMigrate`와 관련 테스트 실행.
+9. 통계 및 타임테이블은 목표 전용 서비스로 유지되며, `goalId == null` 투두를 포함하기 위한 추가 처리는 하지 않았음을 리뷰 노트에 명시.
+
+## 구현 시 주의사항
+
+- `goalId == null`은 생성/수정 API에서만 정상 입력으로 본다.
+- 목표가 있는 요청에 대한 검증 누락이 발생하지 않도록 목표 검증 로직을 별도 private method로 분리하는 방안을 고려한다.
+- `TodoEntity.update(...)`에 `goalId` 갱신이 빠지면 수정 API에서 목표 제거가 DB에 반영되지 않으므로 반드시 테스트로 보호한다.
+- 통계 및 타임테이블은 목표 전용 서비스라는 정책을 코드 주석 또는 테스트명으로 명확히 드러내면 후속 변경 시 혼선을 줄일 수 있다.


### PR DESCRIPTION
### Motivation

- Support creating and updating Todo items without a `goalId` so that todos can exist independently of goals while preserving existing goal validations when a `goalId` is provided. 
- Ensure domain, persistence, API contract and DB schema consistently accept `null` `goalId` and properly persist changes when a todo's `goalId` is removed.

### Description

- Request DTOs `CreateTodoRequest` and `UpdateTodoRequest` removed the `@NotNull` constraint on `goalId` while keeping `@Positive` so a missing `goalId` is allowed but non-positive values remain invalid. 
- Application services `CreateTodoService` and `UpdateTodoService` now conditionally validate and load `Goal` only when `goalId` is present via new `validateGoalIfExists(...)` helpers. 
- Domain `Todo` validation no longer requires `goalId` to be non-null so todos can be created without an associated goal, and domain update flows reflect optional `goalId`. 
- Persistence `TodoEntity` allows a nullable `goal_id` column and `update(...)` was changed to assign `this.goalId = todo.getGoalId()` so goal removal is persisted, and a Flyway migration `V22__allow_null_todo_goal_id.sql` was added to alter the DB column. 
- API documentation examples were adjusted to remove the example for the old `NULL_GOAL_VALUE` validation, and comprehensive implementation plan `투두-목표-optional-구현-플랜.md` was added. 
- Added and updated tests to cover nullable `goalId` scenarios and ensure the change is reflected through domain and persistence layers. 

### Testing

- Ran application integration tests: `CreateTodoServiceTest` and `UpdateTodoServiceTest` were updated/extended to include `goalId == null` cases and executed successfully. 
- Ran domain tests: `TodoTest` and `TodoDomainServiceTest` additions for creation/update with `goalId == null` executed successfully. 
- Verified persistence behavior with updated `TodoEntity.update(...)` and applied the Flyway migration to allow `todos.goal_id` to be nullable during testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa681d7210832dab00e58803df4e61)